### PR TITLE
Bug 3809 Fix compression not to interfere with SSE

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/DeflateEncoder.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/DeflateEncoder.java
@@ -84,6 +84,18 @@ public class DeflateEncoder extends ContentEncoder {
     @Override
     public OutputStream encode(String contentEncoding, OutputStream entityStream)
             throws IOException {
+        return encode(entityStream, false);
+    }
+
+    @Override
+    public OutputStream timeCriticalEncode(String contentEncoding, OutputStream entityStream)
+            throws IOException {
+        return encode(entityStream, true);
+    }
+
+
+    private OutputStream encode(OutputStream entityStream, boolean isTimeCritical)
+            throws IOException {
         // some implementations don't support the correct deflate
         // so we have a property to configure the incorrect deflate (no zlib wrapper) should be used
         // let's check that
@@ -98,7 +110,7 @@ public class DeflateEncoder extends ContentEncoder {
         }
 
         return deflateWithoutZLib
-                ? new DeflaterOutputStream(entityStream, new Deflater(Deflater.DEFAULT_COMPRESSION, true))
-                : new DeflaterOutputStream(entityStream);
+                ? new DeflaterOutputStream(entityStream, new Deflater(Deflater.DEFAULT_COMPRESSION, true), isTimeCritical)
+                : new DeflaterOutputStream(entityStream, isTimeCritical);
     }
 }

--- a/core-common/src/main/java/org/glassfish/jersey/message/GZipEncoder.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/GZipEncoder.java
@@ -54,4 +54,10 @@ public class GZipEncoder extends ContentEncoder {
             throws IOException {
         return new GZIPOutputStream(entityStream);
     }
+
+    @Override
+    public OutputStream timeCriticalEncode(String contentEncoding, OutputStream entityStream)
+            throws IOException {
+        return new GZIPOutputStream(entityStream, true);
+    }
 }


### PR DESCRIPTION
Motivation:

The gzip and deflate compression implementation, if enabled and
requested by the client, accepts some 8 kiB of data before sending any
compressed data to the client.  It may take considerable time (with the
server sending many SSE events) before sufficient data is collected and
any compressed data is sent to the client.

Modification:

Add support for detecting time-critical responses, based on the declared
MIME type of the response.

Add the possibility for a ContentEncoder to provide a different encode
wrapping for time-critical responses.

Update GZip and Deflate ContentEncoders to enable syncFlush flag for
time-critical responses.  With this flag, a flush results in any pending
data being compressed and sent.  This will likely result in poorer
compression ratio.

Result:

Compressed SSE data is delivered without unnecessary delays.

Issue: https://github.com/eclipse-ee4j/jersey/issues/3809
Signed-off-by: Paul Millar <paul.millar@desy.de>