### PR TITLE
issue 3804 fix (SelectableEntityFiltering when the fields specified is . character)

### DIFF
--- a/examples/entity-filtering-selectable/src/test/java/org/glassfish/jersey/examples/entityfiltering/selectable/PersonResourceTest.java
+++ b/examples/entity-filtering-selectable/src/test/java/org/glassfish/jersey/examples/entityfiltering/selectable/PersonResourceTest.java
@@ -137,6 +137,28 @@ public class PersonResourceTest extends JerseyTest {
     }
 
     /**
+     * Test empty (but valid) filters.
+     * Valid empty filters are:
+     *  . ,. , .. .,
+     *
+     *
+     * result is empty object (nothing is returned) but Jersey will not throw any exception
+     */
+    @Test
+    public void testEmptyFilters() throws Exception {
+        final Person entity = target("people").path("1234")
+                .queryParam("select", ".").request()
+                .get(Person.class);
+
+        // Null values (all elements).
+        assertThat(entity.getFamilyName(), nullValue());
+        assertThat(entity.getGivenName(), nullValue());
+        assertThat(entity.getAddresses(), nullValue());
+        assertThat(entity.getPhoneNumbers(), nullValue());
+        assertThat(entity.getRegion(), nullValue());
+    }
+
+    /**
      * Test 2nd and 3rd level filters.
      */
     @Test

--- a/ext/entity-filtering/src/main/java/org/glassfish/jersey/message/filtering/SelectableScopeResolver.java
+++ b/ext/entity-filtering/src/main/java/org/glassfish/jersey/message/filtering/SelectableScopeResolver.java
@@ -83,6 +83,9 @@ public class SelectableScopeResolver implements ScopeResolver {
         final String[] fields = Tokenizer.tokenize(fieldName, ",");
         for (final String field : fields) {
             final String[] subfields = Tokenizer.tokenize(field, ".");
+            if (subfields.length == 0) {
+                continue;
+            }
             // in case of nested path, add first level as stand-alone to ensure subgraph is added
             scopes.add(SelectableScopeResolver.PREFIX + subfields[0]);
             if (subfields.length > 1) {


### PR DESCRIPTION
Tokenizer is fixed to allow valid empty filters. The fix will prevent Jersey to fail after empty filter request. The empty object is returned instead. 

Issue #3804 
Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>