### PR TITLE
Use non-strict mode for comparing JSON in LinkingTest

### DIFF
--- a/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/integration/LinkingTest.java
+++ b/incubator/declarative-linking/src/test/java/org/glassfish/jersey/linking/integration/LinkingTest.java
@@ -87,7 +87,7 @@ public class LinkingTest extends JerseyTest {
                     + "{id:'2',price:'0.0',links:["
                     + "{uri:'/orders/2',params:{rel:'self'},uriBuilder:{absolute:false},rels:['self'],rel:'self'}]}"
                     + "],firstPage:true,previousPageAvailable:false,nextPageAvailable:true,lastPage:false}",
-                order, true);
+                order, false);
     }
 
     @Test
@@ -107,7 +107,7 @@ public class LinkingTest extends JerseyTest {
                     + "{id:'4',price:'0.0',links:["
                     + "{uri:'/orders/4',params:{rel:'self'},uriBuilder:{absolute:false},rels:['self'],rel:'self'}]}"
                     + "],firstPage:false,previousPageAvailable:true,nextPageAvailable:true,lastPage:false}",
-                order, true);
+                order, false);
     }
 
     @Test
@@ -126,7 +126,7 @@ public class LinkingTest extends JerseyTest {
                     + "{id:'6',price:'0.0',links:["
                     + "{uri:'/orders/6',params:{rel:'self'},uriBuilder:{absolute:false},rels:['self'],rel:'self'}]}"
                     + "],firstPage:false,previousPageAvailable:true,nextPageAvailable:false,lastPage:true}",
-                order, true);
+                order, false);
     }
 
 


### PR DESCRIPTION
The Jersey build is currently failing for me with OpenJDK 1.8.0_171, because the test `LinkingTest` fails.

The reasons is that the `links` array returned from the resources contains the links in a different order than expected. The test verifies the JSON response using JSONAssert in strict mode and therefore fails.

Disabling the JSONAssert strict mode fixes this problem. I think that this fix is fine, because the order of links doesn't really matter and it is not that easy to define a consistent ordering of links on the server side.
