### PR TITLE
Removed reference to JavaFX class javax.util.Pair

### DIFF
--- a/tests/e2e-entity/src/test/java/org/glassfish/jersey/tests/e2e/sse/GenericEntityTest.java
+++ b/tests/e2e-entity/src/test/java/org/glassfish/jersey/tests/e2e/sse/GenericEntityTest.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.jersey.tests.e2e.sse;
 
-import javafx.util.Pair;
+import java.util.Objects;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
@@ -255,4 +255,47 @@ public class GenericEntityTest extends JerseyTest {
             return data;
         }
     }
+
+    private static class Pair<K, V> {
+
+        private final K key;
+        private final V value;
+
+        public Pair(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Pair<?, ?> pair = (Pair<?, ?>) o;
+            return Objects.equals(key, pair.key) && Objects.equals(value, pair.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
+
+        @Override
+        public String toString() {
+            return "Pair{key=" + key + ", value=" + value + '}';
+        }
+
+        public K getKey() {
+            return key;
+        }
+
+        public V getValue() {
+            return value;
+        }
+
+    }
+
 }


### PR DESCRIPTION
There is currently a single class in the Jersey code which depends on a JavaFX class: The test `GenericEntityTest` uses `javax.util.Pair`. Unfortunately this prevents the Jersey build to work with OpenJDK, because OpenJDK doesn't ship with JavaFX (yet?).

This pull requests replaces `javax.util.Pair` with a simple implementation which was added as a static inner class to `GenericEntityTest`. The test runs find with OpenJDK after applying this patch.