### PR TITLE
osgi tests fix

### DIFF
--- a/examples/osgi-helloworld-webapp/functional-test/src/test/resources/felix.policy
+++ b/examples/osgi-helloworld-webapp/functional-test/src/test/resources/felix.policy
@@ -1,13 +1,12 @@
-/*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Distribution License v. 1.0, which is available at
- * http://www.eclipse.org/org/documents/edl-v10.php.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- */
- 
+//
+// Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Distribution License v. 1.0, which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
 allow { [org.osgi.service.condpermadmin.BundleLocationCondition "*System*"] (java.security.AllPermission) } "allToSystem";
 allow { [org.osgi.service.condpermadmin.BundleLocationCondition "*System*"] (org.osgi.framework.AdminPermission) } "adminToSystem";
 allow { [org.osgi.service.condpermadmin.BundleLocationCondition "*System*"] (org.osgi.framework.PackagePermission) } "packageToSystem";


### PR DESCRIPTION
Copyright header fixed (only in felix.policy file) to allow OSGI tests pass successfully 

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>