### PR TITLE
Travis CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+
+jdk:
+  - oraclejdk8
+
+cache:
+  directories:
+    - .autoconf
+
+install: true
+
+script:
+  - bash travis.sh

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [//]: # "  "
 [//]: # " SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 "
 
+[![Build Status](https://travis-ci.org/eclipse-ee4j/jersey.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jersey)
+
 ### About Jersey
 
 Jersey is a REST framework that provides JAX-RS Reference Implementation and more.

--- a/connectors/jdk-connector/src/main/java/org/glassfish/jersey/jdk/connector/internal/HttpConnection.java
+++ b/connectors/jdk-connector/src/main/java/org/glassfish/jersey/jdk/connector/internal/HttpConnection.java
@@ -127,7 +127,7 @@ class HttpConnection {
         });
     }
 
-    synchronized void close() {
+    void close() {
         if (state == State.CLOSED) {
             return;
         }
@@ -218,6 +218,9 @@ class HttpConnection {
     }
 
     private void changeState(State newState) {
+        if (state == State.CLOSED) {
+            return;
+        }
         State old = state;
         state = newState;
 
@@ -414,9 +417,11 @@ class HttpConnection {
 
         @Override
         void processConnectionClosed() {
-            cancelAllTimeouts();
-            changeState(State.CLOSED_BY_SERVER);
-            HttpConnection.this.close();
+            synchronized (HttpConnection.this) {
+                cancelAllTimeouts();
+                changeState(State.CLOSED_BY_SERVER);
+                HttpConnection.this.close();
+            }
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -764,6 +764,7 @@
             <properties>
                 <release.tests.args>-Dskip.tests=true</release.tests.args>
                 <skip.tests>true</skip.tests>
+                <skip.e2e>true</skip.e2e>
             </properties>
         </profile>
         <profile>
@@ -1171,6 +1172,37 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <!--
+            Profile is aimed to run the build on travis
+            due to travis limitations for output (max 4MB) this profile is used along with grep which reduces
+            the output.
+            However some e2e tests produce output which is not grepped (thus is not visible) and run longer than
+            10 minutes which results in the whole build is being murdered by Travis because of death suspection
+
+            the whole build is run as clean install but excludes several e2e tests because of the not grepped output
+            -->
+            <id>travis_e2e_skip</id>
+            <properties>
+                <skip.e2e>true</skip.e2e>
+            </properties>
+        </profile>
+        <profile>
+            <!--
+             Profile is aimed to run the build on travis
+            due to travis limitations for output (max 4MB) this profile is used to run e2e tests only.
+
+            the only thing which is happen using throfile is run of e2e tests (without additional build or so)
+            everything is already build using travis_e2e_skip profile
+
+            the whole build is run as test -Ptravis_e2e
+            -->
+            <id>travis_e2e</id>
+            <properties>
+                <skip.e2e>false</skip.e2e>
+                <skip.tests>true</skip.tests>
+            </properties>
         </profile>
     </profiles>
 
@@ -1963,5 +1995,6 @@
         <xerces.version>2.11.0</xerces.version>
         <xmlunit.version>1.6</xmlunit.version>
         <yasson.version>1.0.1</yasson.version>
+        <skip.e2e>false</skip.e2e>
     </properties>
 </project>

--- a/tests/e2e-client/pom.xml
+++ b/tests/e2e-client/pom.xml
@@ -41,6 +41,7 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
+                    <skipTests>${skip.e2e}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e-entity/pom.xml
+++ b/tests/e2e-entity/pom.xml
@@ -41,6 +41,7 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
+                    <skipTests>${skip.e2e}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e-entity/src/test/java/org/glassfish/jersey/tests/e2e/entity/filtering/EntityFilteringClientTest.java
+++ b/tests/e2e-entity/src/test/java/org/glassfish/jersey/tests/e2e/entity/filtering/EntityFilteringClientTest.java
@@ -77,7 +77,12 @@ public class EntityFilteringClientTest extends EntityFilteringTest {
 
     @Test
     public void testEntityAnnotationsPrimaryView() throws Exception {
-        final String fields = target()
+        final ClientConfig config = new ClientConfig()
+                .property(EntityFilteringFeature.ENTITY_FILTERING_SCOPE, PrimaryDetailedView.Factory.get());
+        configureClient(config);
+
+        final String fields = ClientBuilder.newClient(config)
+                .target(getBaseUri())
                 .request()
                 .post(Entity.entity(
                                 new OneFilteringOnClassEntity(),

--- a/tests/e2e-server/pom.xml
+++ b/tests/e2e-server/pom.xml
@@ -41,6 +41,7 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
+                    <skipTests>${skip.e2e}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e-testng/pom.xml
+++ b/tests/e2e-testng/pom.xml
@@ -45,6 +45,7 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
+                    <skipTests>${skip.e2e}</skipTests>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/tests/e2e/pom.xml
+++ b/tests/e2e/pom.xml
@@ -41,6 +41,7 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
+                    <skipTests>${skip.e2e}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mvn -e -U -B clean install -Ptravis_e2e_skip 2>&1 | tee jersey-build.log | grep -E '(---)|(Building)|(Tests run)|(T E S T S)'
+echo '------------------------------------------------------------------------'
+tail -100 jersey-build.log
+cd tests
+mvn -e -B test -Ptravis_e2e


### PR DESCRIPTION
Configuration for Travis CI build. Including changes in pom files (additional profiles for sequential output are added), configuration files (separate bash script and travis.yml config files are added).

For now the build is fully sequential, but it's supposed to modify it to be parallel (multiple build threads in Travis CI).

The whole build time for now is 45 minutes. The whole output (log) is 2.5 MB

Build is run as clean install targets for main Jersey sources (with main travis profile) and when this part is finished the only several tests (e2e and integration) are run as test targed (e2e travis profile) 

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>