### PR TITLE
Travis CI parallel script and code style fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
+sudo: required
+
 language: java
+
+services:
+  - docker
 
 jdk:
   - oraclejdk8
@@ -6,8 +11,12 @@ jdk:
 cache:
   directories:
     - .autoconf
+env:
+  matrix:
+    - TEST_SET="-Ptravis_e2e_skip"
+    - TEST_SET="-Ptravis_e2e"
 
 install: true
 
 script:
-  - bash travis.sh
+  - bash travis.sh $TEST_SET

--- a/tests/e2e-entity/src/test/java/org/glassfish/jersey/tests/e2e/json/JaxbTest.java
+++ b/tests/e2e-entity/src/test/java/org/glassfish/jersey/tests/e2e/json/JaxbTest.java
@@ -108,7 +108,7 @@ public class JaxbTest extends AbstractJsonTest {
         if (javaVersion != null) {
             int pos =  javaVersion.lastIndexOf("_");
             if (pos > -1) {
-                final Integer minorVersion = Integer.valueOf(javaVersion.substring(pos+1));
+                final Integer minorVersion = Integer.valueOf(javaVersion.substring(pos + 1));
                 return minorVersion < 160 || minorVersion > 172; //only those between 161 and 172 minor
                                                                  // releases are not supported
             }

--- a/travis.sh
+++ b/travis.sh
@@ -1,7 +1,34 @@
 #!/bin/bash
+# Abort on Error
+set -e
 
-mvn -e -U -B clean install -Ptravis_e2e_skip 2>&1 | tee jersey-build.log | grep -E '(---)|(Building)|(Tests run)|(T E S T S)'
-echo '------------------------------------------------------------------------'
-tail -100 jersey-build.log
-cd tests
-mvn -e -B test -Ptravis_e2e
+export PING_SLEEP=30s
+export WORKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export BUILD_OUTPUT=$WORKDIR/build.out
+
+touch $BUILD_OUTPUT
+
+dump_output() {
+   echo Tailing the last 500 lines of output:
+   tail -500 $BUILD_OUTPUT
+}
+error_handler() {
+  echo ERROR: An error was encountered with the build.
+  dump_output
+  exit 1
+}
+# If an error occurs, run our error handler to output a tail of the build
+trap 'error_handler' ERR
+
+# Set up a repeating loop to send some output to Travis.
+
+bash -c "while true; do tail -5 $BUILD_OUTPUT; sleep $PING_SLEEP; done" &
+PING_LOOP_PID=$!
+
+mvn -e -U -B clean install $1 >> $BUILD_OUTPUT 2>&1
+
+# The build finished without returning an error so dump a tail of the output
+dump_output
+
+# nicely terminate the ping output loop
+kill $PING_LOOP_PID


### PR DESCRIPTION
A little improvement in Travis CI build script - running 2 profiles in parallel (takes about 25 minutes each) thus the whole build takes about 25 minutes (per longer profile build)

Code style check fixed as well (test modified) so the build shall pass successfully 

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>