### PR TITLE
Issue #3846: Skip comment lines in service files in OSGi

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/OsgiRegistry.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/OsgiRegistry.java
@@ -210,6 +210,9 @@ public final class OsgiRegistry implements SynchronousBundleListener {
                     if (providerClassName.trim().length() == 0) {
                         continue;
                     }
+                    if (providerClassName.startsWith("#")) {
+                        continue;
+                    }
                     if (LOGGER.isLoggable(Level.FINEST)) {
                         LOGGER.log(Level.FINEST, "SPI provider: {0}", providerClassName);
                     }


### PR DESCRIPTION
This avoids trouble with service files like https://github.com/eclipse-ee4j/jersey/blob/12a057315292a624ceb31b58bd04eec3cb19a819/inject/cdi2-se/src/main/resources/META-INF/services/org.glassfish.jersey.internal.inject.InjectionManagerFactory