### PR TITLE
Double profiles Travis CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
     - .autoconf
 env:
   matrix:
-    - TEST_SET="-Ptravis_e2e_skip"
-    - TEST_SET="-Ptravis_e2e"
+    - TEST_SET="-Ptravis_main"
+    - TEST_SET="-fn -Dtest=BroadcasterTest,ClientCloseTest,ResponseWriterOutputStreamTest -DfailIfNoTests=false"
 
 install: true
 

--- a/media/sse/pom.xml
+++ b/media/sse/pom.xml
@@ -75,6 +75,18 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <inherited>true</inherited>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <enableAssertions>false</enableAssertions>
+                    <excludes>
+                        <exclude>${exclude.sse.tests}</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/media/sse/src/test/java/org/glassfish/jersey/media/sse/ClientCloseTest.java
+++ b/media/sse/src/test/java/org/glassfish/jersey/media/sse/ClientCloseTest.java
@@ -43,6 +43,8 @@ import static junit.framework.TestCase.assertTrue;
  */
 public class ClientCloseTest extends JerseyTest {
 
+    private static final int LATCH_WAIT_TIMEOUT = 16;
+
     /**
      * The test test that SSE connection is really closed when EventSource.close() is called.
      * <p/>
@@ -66,7 +68,7 @@ public class ClientCloseTest extends JerseyTest {
         // Server sends 3 events we are interested in.
         IntStream.range(0, 3).forEach((i) -> assertEquals("OK",
                 target("sse/send").request().get().readEntity(String.class)));
-        assertTrue(eventLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(eventLatch.await(LATCH_WAIT_TIMEOUT, TimeUnit.SECONDS));
 
         // After receiving the 3 events, we try to close.
         eventSource.close();
@@ -74,7 +76,7 @@ public class ClientCloseTest extends JerseyTest {
         // Unfortunately the HTTPURLConnection is blocked in read() method, so it will close only after receiving the next event.
         assertEquals("OK", target("sse/send").request().get().readEntity(String.class));
         // Wait for the event that will unblock the HTTPURLConnection and result in sending FIN.
-        assertTrue(eventLatch2.await(5, TimeUnit.SECONDS));
+        assertTrue(eventLatch2.await(LATCH_WAIT_TIMEOUT, TimeUnit.SECONDS));
         // Now it is interesting. Client has sent FIN, but Grizzly does not listen for client input (selector READ key is
         // disabled), while streaming the response. For some reason we need to send 2 more events for Grizzly to notice
         // that the client is gone.

--- a/pom.xml
+++ b/pom.xml
@@ -764,7 +764,6 @@
             <properties>
                 <release.tests.args>-Dskip.tests=true</release.tests.args>
                 <skip.tests>true</skip.tests>
-                <skip.e2e>true</skip.e2e>
             </properties>
         </profile>
         <profile>
@@ -1183,25 +1182,9 @@
 
             the whole build is run as clean install but excludes several e2e tests because of the not grepped output
             -->
-            <id>travis_e2e_skip</id>
+            <id>travis_main</id>
             <properties>
-                <skip.e2e>true</skip.e2e>
-            </properties>
-        </profile>
-        <profile>
-            <!--
-             Profile is aimed to run the build on travis
-            due to travis limitations for output (max 4MB) this profile is used to run e2e tests only.
-
-            the only thing which is happen using throfile is run of e2e tests (without additional build or so)
-            everything is already build using travis_e2e_skip profile
-
-            the whole build is run as test -Ptravis_e2e
-            -->
-            <id>travis_e2e</id>
-            <properties>
-                <skip.e2e>false</skip.e2e>
-                <skip.tests>true</skip.tests>
+                <exclude.sse.tests>**/BroadcasterTest*,**/ClientCloseTest*,**/ResponseWriterOutputStreamTest*</exclude.sse.tests>
             </properties>
         </profile>
     </profiles>
@@ -1995,6 +1978,6 @@
         <xerces.version>2.11.0</xerces.version>
         <xmlunit.version>1.6</xmlunit.version>
         <yasson.version>1.0.1</yasson.version>
-        <skip.e2e>false</skip.e2e>
+        <exclude.sse.tests>none</exclude.sse.tests>
     </properties>
 </project>

--- a/tests/e2e-client/pom.xml
+++ b/tests/e2e-client/pom.xml
@@ -41,7 +41,6 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
-                    <skipTests>${skip.e2e}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e-entity/pom.xml
+++ b/tests/e2e-entity/pom.xml
@@ -41,7 +41,9 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
-                    <skipTests>${skip.e2e}</skipTests>
+                    <excludes>
+                        <exclude>${exclude.sse.tests}</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e-server/pom.xml
+++ b/tests/e2e-server/pom.xml
@@ -41,7 +41,6 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
-                    <skipTests>${skip.e2e}</skipTests>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e-testng/pom.xml
+++ b/tests/e2e-testng/pom.xml
@@ -45,7 +45,6 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
-                    <skipTests>${skip.e2e}</skipTests>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/tests/e2e/pom.xml
+++ b/tests/e2e/pom.xml
@@ -41,7 +41,9 @@
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                     <enableAssertions>false</enableAssertions>
-                    <skipTests>${skip.e2e}</skipTests>
+                    <excludes>
+                        <exclude>${exclude.sse.tests}</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/container/ResponseWriterOutputStreamTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/container/ResponseWriterOutputStreamTest.java
@@ -43,6 +43,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class ResponseWriterOutputStreamTest extends JerseyContainerTest {
 
+    private static final String CHECK_STRING = "RESOURCE";
+
     @Path("/")
     public static class Resource {
 
@@ -53,23 +55,23 @@ public class ResponseWriterOutputStreamTest extends JerseyContainerTest {
 
             final ContainerResponse response = new ContainerResponse(context, Response.ok().build());
             final OutputStream os = context.getResponseWriter()
-                    .writeResponseStatusAndHeaders("RESOURCE".getBytes().length, response);
-            os.write("RESOURCE".getBytes());
+                    .writeResponseStatusAndHeaders(CHECK_STRING.getBytes().length, response);
+            os.write(CHECK_STRING.getBytes());
             os.close();
         }
 
         @POST
         @Produces("text/plain")
-        public void post(final ContainerRequest context) throws IOException {
+        public synchronized void post(final ContainerRequest context) throws IOException {
             assertThat(context.getMethod(), is("POST"));
 
             final String s = context.readEntity(String.class);
-            assertEquals("RESOURCE", s);
+            assertEquals(CHECK_STRING, s);
 
             final ContainerResponse response = new ContainerResponse(context, Response.ok().build());
             final OutputStream os = context.getResponseWriter()
-                    .writeResponseStatusAndHeaders("RESOURCE".getBytes().length, response);
-            os.write("RESOURCE".getBytes());
+                    .writeResponseStatusAndHeaders(s.getBytes().length, response);
+            os.write(s.getBytes());
             os.close();
         }
     }
@@ -81,12 +83,12 @@ public class ResponseWriterOutputStreamTest extends JerseyContainerTest {
 
     @Test
     public void testGet() {
-        assertThat(target().request().get(String.class), is("RESOURCE"));
+        assertThat(target().request().get(String.class), is(CHECK_STRING));
     }
 
     @Test
     public void testPost() {
-        assertThat(target().request().post(Entity.text("RESOURCE"), String.class), is("RESOURCE"));
+        assertThat(target().request().post(Entity.text(CHECK_STRING), String.class), is(CHECK_STRING));
     }
 
     @Test

--- a/travis.sh
+++ b/travis.sh
@@ -25,7 +25,7 @@ trap 'error_handler' ERR
 bash -c "while true; do tail -5 $BUILD_OUTPUT; sleep $PING_SLEEP; done" &
 PING_LOOP_PID=$!
 
-mvn -e -U -B clean install $1 >> $BUILD_OUTPUT 2>&1
+mvn -e -U -B clean install $1 $2 $3>> $BUILD_OUTPUT 2>&1
 
 # The build finished without returning an error so dump a tail of the output
 dump_output


### PR DESCRIPTION
The purpose of the pull request is to provide another improvement for continuous integration builds on Travis. For now the whole build process is divided into 2 parallel parts (using provided Travis CI build scripts tooling). One profile performs the whole build including 99% of tests. And the 2nd part performs build and only several tests which are considered to be unstable thus they can not be relied in the normal test suite flow.

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>