### PR TITLE
Travis uses Eclipse Repo to get latest SNAPSHOTs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1204,6 +1204,20 @@
                 <skip.tests>true</skip.tests>
             </properties>
         </profile>
+	<profile>
+            <!-- Use -Peclipse_repo to use SNAPSHOTs stored in Eclipse's Nexus instance ("Nightly Builds") -->
+            <id>eclipse_repo</id>
+	    <repositories>
+                <repository>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <id>repo.jaxrs-api.eclipse.org</id>
+                    <name>JAX-RS API Repository - Snapshots</name>
+                    <url>https://repo.eclipse.org/content/repositories/jax-rs-api-snapshots</url>
+                </repository>
+            </repositories>
+	</profile>
     </profiles>
 
     <reporting>

--- a/travis.sh
+++ b/travis.sh
@@ -25,7 +25,7 @@ trap 'error_handler' ERR
 bash -c "while true; do tail -5 $BUILD_OUTPUT; sleep $PING_SLEEP; done" &
 PING_LOOP_PID=$!
 
-mvn -e -U -B clean install $1 >> $BUILD_OUTPUT 2>&1
+mvn -e -U -B -Peclipse_repo clean install $1 >> $BUILD_OUTPUT 2>&1
 
 # The build finished without returning an error so dump a tail of the output
 dump_output


### PR DESCRIPTION
To be able to continously build support for JAX-RS API's new features into Jersey, accessing the Eclipse Foundation's Repository is essential, because it is the central place the EF's admins want nightly builds to be stored.

This PR adds the repository using the profile `eclipse_repo`, which is defined in the POM and explicitly enabled by the Travis CI driver script.