### PR TITLE
FIX #3849: Add vnd.api+json to LoggingFeature

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -79,13 +79,13 @@ abstract class LoggingInterceptor implements WriterInterceptor {
 
     private static final Set<MediaType> READABLE_APP_MEDIA_TYPES = new HashSet<MediaType>() {{
         add(TEXT_MEDIA_TYPE);
+        add(APPLICATION_VND_API_JSON);
         add(MediaType.APPLICATION_ATOM_XML_TYPE);
         add(MediaType.APPLICATION_FORM_URLENCODED_TYPE);
         add(MediaType.APPLICATION_JSON_TYPE);
         add(MediaType.APPLICATION_SVG_XML_TYPE);
         add(MediaType.APPLICATION_XHTML_XML_TYPE);
         add(MediaType.APPLICATION_XML_TYPE);
-        add(APPLICATION_VND_API_JSON);
     }};
 
     private static final Comparator<Map.Entry<String, List<String>>> COMPARATOR =

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -70,10 +70,12 @@ abstract class LoggingInterceptor implements WriterInterceptor {
     private static final String NOTIFICATION_PREFIX = "* ";
     private static final MediaType TEXT_MEDIA_TYPE = new MediaType("text", "*");
 
-    // application/vnd.api+json (documented here: http://jsonapi.org/)
-    // is a modified form of JSON, which is not present in the JAX-RS
-    // MediaType class as a static constant. Requested in Issue #3849
-    private static final MediaType APPLICATION_VND_API_JSON = new MediaType("application","vnd.api+json");
+    /**
+     * application/vnd.api+json (documented here: http://jsonapi.org/)
+     * is a modified form of JSON, which is not present in the JAX-RS
+     * MediaType class as a static constant. Requested in Issue #3849
+    */
+    private static final MediaType APPLICATION_VND_API_JSON = new MediaType("application", "vnd.api+json");
 
     private static final Set<MediaType> READABLE_APP_MEDIA_TYPES = new HashSet<MediaType>() {{
         add(TEXT_MEDIA_TYPE);

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -85,7 +85,7 @@ abstract class LoggingInterceptor implements WriterInterceptor {
         add(MediaType.APPLICATION_SVG_XML_TYPE);
         add(MediaType.APPLICATION_XHTML_XML_TYPE);
         add(MediaType.APPLICATION_XML_TYPE);
-        add(APPLICATION_VND_API_JSON); 
+        add(APPLICATION_VND_API_JSON);
     }};
 
     private static final Comparator<Map.Entry<String, List<String>>> COMPARATOR =

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -70,6 +70,11 @@ abstract class LoggingInterceptor implements WriterInterceptor {
     private static final String NOTIFICATION_PREFIX = "* ";
     private static final MediaType TEXT_MEDIA_TYPE = new MediaType("text", "*");
 
+    // application/vnd.api+json (documented here: http://jsonapi.org/)
+    // is a modified form of JSON, which is not present in the JAX-RS
+    // MediaType class as a static constant. Requested in Issue #3849
+    private static final MediaType APPLICATION_VND_API_JSON = new MediaType("application","vnd.api+json");
+
     private static final Set<MediaType> READABLE_APP_MEDIA_TYPES = new HashSet<MediaType>() {{
         add(TEXT_MEDIA_TYPE);
         add(MediaType.APPLICATION_ATOM_XML_TYPE);
@@ -78,6 +83,7 @@ abstract class LoggingInterceptor implements WriterInterceptor {
         add(MediaType.APPLICATION_SVG_XML_TYPE);
         add(MediaType.APPLICATION_XHTML_XML_TYPE);
         add(MediaType.APPLICATION_XML_TYPE);
+        add(APPLICATION_VND_API_JSON); 
     }};
 
     private static final Comparator<Map.Entry<String, List<String>>> COMPARATOR =

--- a/core-common/src/test/java/org/glassfish/jersey/logging/LoggingInterceptorTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/logging/LoggingInterceptorTest.java
@@ -51,6 +51,11 @@ public class LoggingInterceptorTest {
     public void testReadableTypeAppSubJson() {
         assertTrue(LoggingInterceptor.isReadable(new MediaType("application", "json")));
     }
+    
+    @Test
+    public void testReadableTypeApplicationSubVndApiJson() {
+    	assertTrue(LoggingInterceptor.isReadable(new MediaType("application", "vnd.api+json")))
+    }
 
     @Test
     public void testReadableTypeAppSubBinary() {

--- a/core-common/src/test/java/org/glassfish/jersey/logging/LoggingInterceptorTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/logging/LoggingInterceptorTest.java
@@ -51,10 +51,10 @@ public class LoggingInterceptorTest {
     public void testReadableTypeAppSubJson() {
         assertTrue(LoggingInterceptor.isReadable(new MediaType("application", "json")));
     }
-    
+
     @Test
     public void testReadableTypeApplicationSubVndApiJson() {
-    	assertTrue(LoggingInterceptor.isReadable(new MediaType("application", "vnd.api+json")))
+        assertTrue(LoggingInterceptor.isReadable(new MediaType("application", "vnd.api+json")))
     }
 
     @Test

--- a/core-common/src/test/java/org/glassfish/jersey/logging/LoggingInterceptorTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/logging/LoggingInterceptorTest.java
@@ -54,7 +54,7 @@ public class LoggingInterceptorTest {
 
     @Test
     public void testReadableTypeApplicationSubVndApiJson() {
-        assertTrue(LoggingInterceptor.isReadable(new MediaType("application", "vnd.api+json")))
+        assertTrue(LoggingInterceptor.isReadable(new MediaType("application", "vnd.api+json")));
     }
 
     @Test


### PR DESCRIPTION
Original Issue:

> It would be nice if the [vnd.api+json](http://www.iana.org/assignments/media-types/application/vnd.api%2Bjson) media type, used by the [JSON API](http://jsonapi.org/) standard, could be added to the media types logged by the LoggingFeature.Verbosity PAYLOAD_TEXT.


Signed-off-by: Arjun Vikram <arjvik@gmail.com>