### PR TITLE
copyright check (run maven plugin) in builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   matrix:
     - TEST_SET="-Ptravis_e2e_skip"
     - TEST_SET="-Ptravis_e2e"
+    - TEST_SET="glassfish-copyright:copyright"
 
 install: true
 

--- a/travis.sh
+++ b/travis.sh
@@ -25,7 +25,11 @@ trap 'error_handler' ERR
 bash -c "while true; do tail -5 $BUILD_OUTPUT; sleep $PING_SLEEP; done" &
 PING_LOOP_PID=$!
 
-mvn -e -U -B clean install $1 >> $BUILD_OUTPUT 2>&1
+if [ "$1" = "glassfish-copyright:copyright" ]; then
+    mvn glassfish-copyright:copyright
+else
+    mvn -e -U -B clean install $1 >> $BUILD_OUTPUT 2>&1
+fi
 
 # The build finished without returning an error so dump a tail of the output
 dump_output


### PR DESCRIPTION
Another Travis CI build part added which checks copyright. Added build runs approx. for 2 minutes.

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>