### PR TITLE
Fix copyright check using new plugin version

### DIFF
--- a/etc/config/copyright-exclude
+++ b/etc/config/copyright-exclude
@@ -35,6 +35,7 @@ jaxb.index
 /etc/jersey-1-migrated-tests
 /etc/config/copyright-exclude
 /etc/config/copyright.txt
+/etc/config/edl-copyright.txt
 /LICENSE.md
 /third-party-license-readme.txt
 nb-configuration.xml

--- a/etc/config/edl-copyright.txt
+++ b/etc/config/edl-copyright.txt
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) YYYY Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: BSD-3-Clause
+ */

--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>1.39</version>
+                    <version>1.49</version>
                     <configuration>
                         <excludeFile>etc/config/copyright-exclude</excludeFile>
                         <!--svn|mercurial|git - defaults to svn-->
@@ -585,6 +585,7 @@
                         <!-- check that year is correct -->
                         <ignoreYear>false</ignoreYear>
                         <templateFile>etc/config/copyright.txt</templateFile>
+                        <bsdTemplateFile>etc/config/edl-copyright.txt</bsdTemplateFile>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
copyright check aligned with master to support BSD license 

Signed-off-by: Jan Supol <jan.supol@oracle.com>