### PR TITLE
#3905 Fix warnings when checking CDI bean is JAX-RS resource

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/model/IntrospectionModeller.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/IntrospectionModeller.java
@@ -183,8 +183,10 @@ final class IntrospectionModeller {
                     method.getGenericParameterTypes()[0],
                     method.getAnnotations());
             if (null != p) {
-                ResourceMethodValidator.validateParameter(p, method.getMethod(), method.getMethod().toGenericString(), "1",
+                if (!disableValidation) {
+                    ResourceMethodValidator.validateParameter(p, method.getMethod(), method.getMethod().toGenericString(), "1",
                         InvocableValidator.isSingleton(handlerClass));
+                }
 
                 // we do not inject entity parameters into class instance fields and properties.
                 if (p.getSource() != Parameter.Source.ENTITY) {
@@ -208,8 +210,11 @@ final class IntrospectionModeller {
                         field.getGenericType(),
                         field.getAnnotations());
                 if (null != p) {
-                    ResourceMethodValidator.validateParameter(p, field, field.toGenericString(), field.getName(),
+                    if (!disableValidation) {
+                        ResourceMethodValidator.validateParameter(p, field, field.toGenericString(), field.getName(),
                             isInSingleton);
+                    }
+
                     // we do not inject entity and unknown parameters into class instance fields and properties.
                     if (p.getSource() != Parameter.Source.ENTITY) {
                         injectableParameters.add(p);

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
@@ -144,7 +144,10 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
         }
     });
 
-    private final Cache<Class<?>, Boolean> jaxRsResourceCache = new Cache<>(clazz -> Resource.from(clazz) != null);
+    // Check first if a class is a JAX-RS resource, and only if so check with validation.
+    // This prevents unnecessary warnings being logged for pure CDI beans.
+    private final Cache<Class<?>, Boolean> jaxRsResourceCache = new Cache<>(
+            clazz -> Resource.from(clazz, true) != null && Resource.from(clazz) != null);
 
     private final Hk2CustomBoundTypesProvider customHk2TypesProvider;
     private final InjectionManagerStore injectionManagerStore;


### PR DESCRIPTION
#3905 Check with validation disabled first. Only if it's indeed a JAX-RS bean, perform validation.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>