### PR TITLE
Update to Bean Validation 2.0 (Hibernate 6)

### DIFF
--- a/examples/declarative-linking/pom.xml
+++ b/examples/declarative-linking/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.web</groupId>
+            <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
         </dependency>
 

--- a/ext/bean-validation/pom.xml
+++ b/ext/bean-validation/pom.xml
@@ -83,7 +83,7 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
 
@@ -94,7 +94,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.web</groupId>
+            <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
         </dependency>
 

--- a/ext/cdi/jersey-cdi1x-validation/pom.xml
+++ b/ext/cdi/jersey-cdi1x-validation/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator-cdi</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -51,6 +51,13 @@
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
             <version>1.2</version>
+            <exclusions>
+                <!-- Remove ancient javax.el that causes problems with Hibernate -->
+                <exclusion>
+                    <groupId>javax.el</groupId>
+                    <artifactId>el-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/ext/cdi/jersey-cdi1x-validation/src/main/java/org/glassfish/jersey/ext/cdi1x/validation/internal/CdiInterceptorWrapper.java
+++ b/ext/cdi/jersey-cdi1x-validation/src/main/java/org/glassfish/jersey/ext/cdi1x/validation/internal/CdiInterceptorWrapper.java
@@ -27,8 +27,8 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
-import org.hibernate.validator.internal.cdi.interceptor.MethodValidated;
-import org.hibernate.validator.internal.cdi.interceptor.ValidationInterceptor;
+import org.hibernate.validator.cdi.internal.interceptor.MethodValidated;
+import org.hibernate.validator.cdi.internal.interceptor.ValidationInterceptor;
 
 /**
  * JAX-RS wrapper for Hibernate CDI bean validation interceptor.

--- a/ext/cdi/jersey-cdi1x-validation/src/main/java/org/glassfish/jersey/ext/cdi1x/validation/internal/CdiInterceptorWrapperExtension.java
+++ b/ext/cdi/jersey-cdi1x-validation/src/main/java/org/glassfish/jersey/ext/cdi1x/validation/internal/CdiInterceptorWrapperExtension.java
@@ -43,7 +43,7 @@ import javax.interceptor.Interceptor;
 import org.glassfish.jersey.internal.util.collection.Cache;
 import org.glassfish.jersey.server.model.Resource;
 
-import org.hibernate.validator.internal.cdi.interceptor.ValidationInterceptor;
+import org.hibernate.validator.cdi.internal.interceptor.ValidationInterceptor;
 
 /**
  * CDI extension to register {@link CdiInterceptorWrapper}.
@@ -78,7 +78,7 @@ public class CdiInterceptorWrapperExtension implements Extension {
      * @param afterTypeDiscovery CDI bootstrap event.
      */
     private void afterTypeDiscovery(@Observes final AfterTypeDiscovery afterTypeDiscovery) {
-        afterTypeDiscovery.getInterceptors().remove(ValidationInterceptor.class);
+        afterTypeDiscovery.getInterceptors().removeIf(ValidationInterceptor.class::equals);
     }
 
     /**

--- a/ext/mvc-bean-validation/pom.xml
+++ b/ext/mvc-bean-validation/pom.xml
@@ -58,6 +58,10 @@
                     <groupId>javax.el</groupId>
                     <artifactId>javax.el-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/incubator/declarative-linking/pom.xml
+++ b/incubator/declarative-linking/pom.xml
@@ -54,7 +54,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.web</groupId>
+            <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/media/json-binding/pom.xml
+++ b/media/json-binding/pom.xml
@@ -77,6 +77,13 @@
         <dependency>
             <groupId>org.eclipse</groupId>
             <artifactId>yasson</artifactId>
+            <exclusions>
+                <!-- Remove ancient javax.el that causes problems with Hibernate -->
+                <exclusion>
+                    <groupId>javax.el</groupId>
+                    <artifactId>el-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1656,7 +1656,7 @@
                 <version>${javax.el.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.web</groupId>
+                <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>${javax.el.impl.version}</version>
             </dependency>
@@ -1673,13 +1673,13 @@
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${validation.impl.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate</groupId>
+                <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator-cdi</artifactId>
                 <version>${validation.impl.version}</version>
             </dependency>
@@ -1943,11 +1943,11 @@
         <javassist.version>3.22.0-CR2</javassist.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <javax.annotation.bundle.version>1.2</javax.annotation.bundle.version>
-        <javax.el.version>2.2.4</javax.el.version>
-        <javax.el.impl.version>2.2.4</javax.el.impl.version>
+        <javax.el.version>3.0.1-b06</javax.el.version>
+        <javax.el.impl.version>3.0.1-b09</javax.el.impl.version>
         <javax.interceptor.version>1.2</javax.interceptor.version>
         <javax.persistence.version>1.0</javax.persistence.version>
-        <javax.validation.api.version>1.1.0.Final</javax.validation.api.version>
+        <javax.validation.api.version>2.0.1.Final</javax.validation.api.version>
         <jaxb.api.version>2.2.7</jaxb.api.version>
         <jaxb.ri.version>2.2.7</jaxb.ri.version>
         <jsonb.api.version>1.0</jsonb.api.version>
@@ -1990,7 +1990,7 @@
         <simple.version>6.0.1</simple.version>
         <slf4j.version>1.7.12</slf4j.version>
         <spring4.version>4.3.4.RELEASE</spring4.version>
-        <validation.impl.version>5.1.3.Final</validation.impl.version> <!-- 5.3.3.Final doesn't work - osgi bv tests -->
+        <validation.impl.version>6.0.11.Final</validation.impl.version>
         <weld.version>2.2.14.Final</weld.version> <!-- 2.4.1 doesn't work - bv tests -->
         <weld3.version>3.0.0.Final</weld3.version>
         <xerces.version>2.11.0</xerces.version>

--- a/tests/integration/cdi-beanvalidation-webapp/pom.xml
+++ b/tests/integration/cdi-beanvalidation-webapp/pom.xml
@@ -46,6 +46,13 @@
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <!-- Remove ancient javax.el that causes problems with Hibernate -->
+                <exclusion>
+                    <groupId>javax.el</groupId>
+                    <artifactId>el-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
@@ -53,7 +60,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator-cdi</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/tests/integration/jersey-2673/pom.xml
+++ b/tests/integration/jersey-2673/pom.xml
@@ -63,7 +63,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
             </plugin>
         </plugins>

--- a/tests/integration/jersey-2689/pom.xml
+++ b/tests/integration/jersey-2689/pom.xml
@@ -81,7 +81,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
             </plugin>
         </plugins>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -236,6 +236,43 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-maven-plugin</artifactId>
+                    <configuration>
+                        <skip>${skip.tests}</skip>
+                        <scanIntervalSeconds>10</scanIntervalSeconds>
+                        <stopPort>9999</stopPort>
+                        <stopKey>STOP</stopKey>
+                        <webApp>
+                            <contextPath>/</contextPath>
+                            <webInfIncludeJarPattern>.*/.*jersey-[^/]\.jar$</webInfIncludeJarPattern>
+                        </webApp>
+                        <httpConnector>
+                            <port>${jersey.config.test.container.port}</port>
+                            <idleTimeout>60000</idleTimeout>
+                        </httpConnector>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>start-jetty</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                                <goal>start</goal>
+                            </goals>
+                            <configuration>
+                                <scanIntervalSeconds>0</scanIntervalSeconds>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>stop-jetty</id>
+                            <phase>post-integration-test</phase>
+                            <goals>
+                                <goal>stop</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/tests/integration/servlet-2.5-autodiscovery-2/pom.xml
+++ b/tests/integration/servlet-2.5-autodiscovery-2/pom.xml
@@ -61,7 +61,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
-              <groupId>org.mortbay.jetty</groupId>
+              <groupId>org.eclipse.jetty</groupId>
               <artifactId>jetty-maven-plugin</artifactId>
             </plugin>
         </plugins>

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -274,7 +274,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <scope>test</scope>
         </dependency>
@@ -289,8 +289,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/BeanValidationTest.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/BeanValidationTest.java
@@ -68,10 +68,10 @@ public class BeanValidationTest {
 
                 // validation
                 mavenBundle().groupId("org.glassfish.jersey.ext").artifactId("jersey-bean-validation").versionAsInProject(),
-                mavenBundle().groupId("org.hibernate").artifactId("hibernate-validator").versionAsInProject(),
+                mavenBundle().groupId("org.hibernate.validator").artifactId("hibernate-validator").versionAsInProject(),
                 mavenBundle().groupId("org.jboss.logging").artifactId("jboss-logging").versionAsInProject(),
                 mavenBundle().groupId("com.fasterxml").artifactId("classmate").versionAsInProject(),
-                mavenBundle().groupId("javax.el").artifactId("javax.el-api").versionAsInProject()
+                mavenBundle().groupId("org.glassfish").artifactId("javax.el").versionAsInProject()
         ));
 
         options = Helper.addPaxExamMavenLocalRepositoryProperty(options);

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/JsonMoxyTest.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/JsonMoxyTest.java
@@ -23,7 +23,6 @@ import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
 import org.glassfish.jersey.moxy.json.MoxyJsonConfig;
-import org.glassfish.jersey.moxy.json.MoxyJsonFeature;
 import org.glassfish.jersey.osgi.test.util.Helper;
 
 import org.eclipse.persistence.jaxb.BeanValidationMode;
@@ -61,10 +60,10 @@ public class JsonMoxyTest extends AbstractJsonOsgiIntegrationTest {
                 mavenBundle().groupId("org.glassfish").artifactId("javax.json").versionAsInProject(),
 
                 // validation
-                mavenBundle().groupId("org.hibernate").artifactId("hibernate-validator").versionAsInProject(),
+                mavenBundle().groupId("org.hibernate.validator").artifactId("hibernate-validator").versionAsInProject(),
                 mavenBundle().groupId("org.jboss.logging").artifactId("jboss-logging").versionAsInProject(),
                 mavenBundle().groupId("com.fasterxml").artifactId("classmate").versionAsInProject(),
-                mavenBundle().groupId("javax.el").artifactId("javax.el-api").versionAsInProject()
+                mavenBundle().groupId("org.glassfish").artifactId("javax.el").versionAsInProject()
         ));
 
         return Helper.asArray(options);


### PR DESCRIPTION
This is an attempt to update to version 2.0 of the [JSR 380](https://beanvalidation.org/2.0/) Bean Validation spec by updating the Hibernate version to 6.0, in order to resolve #3871.

Hibernate now [requires](https://developer.jboss.org/wiki/HibernateValidatorMigrationGuide#jive_content_id_60x) an implementation of version 3.0 of JSR 341 if a `ResourceBundleMessageInterpolator` is used, so the corresponding dependencies needed updating too. It seems that CDI API and yasson were pulling in an old JSR 341 API with a different group ID; ignoring them out fixed dependency issues in tests.

This also caused integration tests that used old Jetty plugin and depended on BV to break, since such old version (8.x) of Jetty doesn't offer a JSR 341 3.0 implementation. I switched those to use the new Jetty plugin which is already a project dependency. (It's probably something that should be eventually done for all integration tests anyways.)

According to the referenced issue a CQ will be needed for upgrading all these dependencies, but the system to do so is locked to committers only, so unfortunately I could not do anything about that. However since there was already an issue in the project I was tempted to go forward with this change.

>Signed-off-by: mszabo-wikia <mszabo@wikia-inc.com>