### PR TITLE
Jersey dependencies version upgrade (part I)

### DIFF
--- a/containers/glassfish/jersey-gf-ejb/pom.xml
+++ b/containers/glassfish/jersey-gf-ejb/pom.xml
@@ -72,6 +72,10 @@
             <artifactId>container-common</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-config</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ext/mvc-jsp/pom.xml
+++ b/ext/mvc-jsp/pom.xml
@@ -88,7 +88,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
+            <artifactId>javax.servlet.jsp-api</artifactId>
             <version>${jsp.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/jackson/jaxrs/util/EndpointAsBeanProperty.java
+++ b/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/jackson/jaxrs/util/EndpointAsBeanProperty.java
@@ -50,7 +50,7 @@ public class EndpointAsBeanProperty
         if (_type == type) {
             return this;
         }
-        return new Std(_name, type, _wrapperName, _contextAnnotations, _member, _metadata);
+        return new Std(_name, type, _wrapperName, _member, _metadata);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -1400,6 +1400,11 @@
                 <version>1.0.1</version>
             </dependency>
             <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-config</artifactId>
+                <version>${hk2.config.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish.hk2.external</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>${hk2.version}</version>
@@ -1923,11 +1928,11 @@
         <checkstyle.mvn.plugin.version>2.16</checkstyle.mvn.plugin.version>
         <checkstyle.version>6.8.1</checkstyle.version>
         <easymock.version>3.3</easymock.version>
-        <ejb.version>3.2</ejb.version>
-        <gf.impl.version>4.0</gf.impl.version>
+        <ejb.version>3.2.2</ejb.version>
+        <gf.impl.version>5.0</gf.impl.version>
         <fasterxml.classmate.version>1.3.3</fasterxml.classmate.version>
-        <findbugs.glassfish.version>1.3</findbugs.glassfish.version>
-        <findbugs.version>3.0.2</findbugs.version>
+        <findbugs.glassfish.version>1.7</findbugs.glassfish.version>
+        <findbugs.version>3.0.3</findbugs.version>
         <freemarker.version>2.3.27-incubating</freemarker.version>
         <gae.version>1.9.59</gae.version>
         <gpg.mvn.plugin.version>1.6</gpg.mvn.plugin.version>
@@ -1936,17 +1941,18 @@
         <guava.version>18.0</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
         <xmlunit.version>1.6</xmlunit.version>
-        <hk2.version>2.5.0-b42</hk2.version>
+        <hk2.version>2.5.0-b62</hk2.version>
+        <hk2.config.version>2.5.0-b56</hk2.config.version>
         <httpclient.version>4.5</httpclient.version> <!-- TODO: 4.5.2 doesn't work; apache client connector tests -->
-        <jackson.version>2.8.10</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
         <jackson1.version>1.9.13</jackson1.version>
-        <javassist.version>3.22.0-CR2</javassist.version>
-        <javax.annotation.version>1.2</javax.annotation.version>
-        <javax.annotation.bundle.version>1.2</javax.annotation.bundle.version>
+        <javassist.version>3.22.0-GA</javassist.version>
+        <javax.annotation.version>1.3.2</javax.annotation.version>
+        <javax.annotation.bundle.version>1.3.2</javax.annotation.bundle.version>
         <javax.el.version>3.0.1-b06</javax.el.version>
         <javax.el.impl.version>3.0.1-b09</javax.el.impl.version>
-        <javax.interceptor.version>1.2</javax.interceptor.version>
-        <javax.persistence.version>1.0</javax.persistence.version>
+        <javax.interceptor.version>1.2.2</javax.interceptor.version>
+        <javax.persistence.version>1.0.2</javax.persistence.version>
         <javax.validation.api.version>2.0.1.Final</javax.validation.api.version>
         <jaxb.api.version>2.2.7</jaxb.api.version>
         <jaxb.ri.version>2.2.7</jaxb.ri.version>
@@ -1958,21 +1964,19 @@
         <jersey1.last.final.version>${jersey1.version}</jersey1.last.final.version>
         <jettison.version>1.3.7</jettison.version> <!-- TODO: 1.3.8 doesn't work; AbstractJsonTest complexBeanWithAttributes -->
         <jetty.plugin.version>6.1.26</jetty.plugin.version>
-        <jetty.version>9.4.7.v20170914</jetty.version>
+        <jetty.version>9.4.12.v20180830</jetty.version>
         <jetty.servlet.api.25.version>6.1.14</jetty.servlet.api.25.version>
         <jmh.version>1.10.2</jmh.version>
         <jmockit.version>1.41</jmockit.version>
         <jsonp.ri.version>1.1</jsonp.ri.version>
-        <jsonp.jaxrs.version>1.1.1</jsonp.jaxrs.version>
-        <jsp.version>2.0</jsp.version>
+        <jsonp.jaxrs.version>1.1.2</jsonp.jaxrs.version>
+        <jsp.version>2.3.3</jsp.version>
         <jstl.version>1.2</jstl.version>
-        <jta.api.version>1.2</jta.api.version>
+        <jta.api.version>1.3</jta.api.version>
         <kryo.version>4.0.1</kryo.version>
-        <logback.version>1.2.3</logback.version>
-        <mimepull.version>1.9.6</mimepull.version>
+        <mimepull.version>1.9.7</mimepull.version>
         <mockito.version>1.10.19</mockito.version>
         <moxy.version>2.6.4</moxy.version>
-        <mockito.version>1.10.19</mockito.version>
         <mustache.version>0.8.17</mustache.version>
         <netty.version>4.1.5.Final</netty.version>
         <nexus-staging.mvn.plugin.version>1.6.7</nexus-staging.mvn.plugin.version>
@@ -1983,18 +1987,16 @@
         <paxexam.mvn.plugin.version>1.2.4</paxexam.mvn.plugin.version>
         <rxjava.version>1.2.5</rxjava.version>
         <rxjava2.version>2.0.4</rxjava2.version>
-        <rome.version>1.0</rome.version>
         <servlet2.version>2.4</servlet2.version>
         <servlet3.version>3.0.1</servlet3.version>
-        <servlet4.version>4.0.0</servlet4.version>
+        <servlet4.version>4.0.1</servlet4.version>
         <simple.version>6.0.1</simple.version>
-        <slf4j.version>1.7.12</slf4j.version>
+        <slf4j.version>1.7.21</slf4j.version>
         <spring4.version>4.3.4.RELEASE</spring4.version>
         <validation.impl.version>6.0.11.Final</validation.impl.version>
         <weld.version>2.2.14.Final</weld.version> <!-- 2.4.1 doesn't work - bv tests -->
         <weld3.version>3.0.0.Final</weld3.version>
         <xerces.version>2.11.0</xerces.version>
-        <xmlunit.version>1.6</xmlunit.version>
         <yasson.version>1.0.1</yasson.version>
         <skip.e2e>false</skip.e2e>
     </properties>


### PR DESCRIPTION
Versions are upgraded for following dependencies:

1. Nucleus super pom related https://github.com/javaee/glassfish/blob/master/nucleus/parent/pom.xml
2. javax.* dependencies (except jaxb)
3. org.glassfish.* dependencies (except mockito glassfish plugin)

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>