### PR TITLE
Using JAX-RS 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1919,7 +1919,7 @@
         <jaxb.ri.version>2.2.7</jaxb.ri.version>
         <jsonb.api.version>1.0</jsonb.api.version>
         <jaxrs.api.spec.version>2.1</jaxrs.api.spec.version>
-        <jaxrs.api.impl.version>2.1</jaxrs.api.impl.version>
+        <jaxrs.api.impl.version>2.1.1</jaxrs.api.impl.version>
         <jboss.logging.version>3.3.0.Final</jboss.logging.version>
         <jersey1.version>1.19.3</jersey1.version>
         <jersey1.last.final.version>${jersey1.version}</jersey1.last.final.version>


### PR DESCRIPTION
JAX-RS 2.1.1 was released today, so Jersey contained in Jakarta EE 8 should use this particular version.

Signed-off-by: Markus KARG <markus@headcrashing.eu>