### PR TITLE
fixes for Eclipse Jenkins environment (adaptopenjdk, shell etc)

### DIFF
--- a/test-framework/maven/container-runner-maven-plugin/src/main/resources/runner/gf4/download.sh
+++ b/test-framework/maven/container-runner-maven-plugin/src/main/resources/runner/gf4/download.sh
@@ -47,7 +47,7 @@ fi
 
 if [ "$OVERWRITE" = "true" -o ! -d "$DIST_DIR"/"$DIST_SUBDIR" ]; then
     rm -rf "$DIST_DIR"/"$DIST_SUBDIR"
-
+    mkdir -p "$DIST_DIR"
     unzip -o "$DIST_TGT_LOCATION" -d "$DIST_DIR"
     chmod -R 777 "$DIST_DIR"/"$DIST_SUBDIR"
 fi

--- a/tests/e2e-entity/src/test/java/org/glassfish/jersey/tests/e2e/json/JaxbTest.java
+++ b/tests/e2e-entity/src/test/java/org/glassfish/jersey/tests/e2e/json/JaxbTest.java
@@ -121,6 +121,10 @@ public class JaxbTest extends AbstractJsonTest {
                 final Integer minorVersion = (isNumeric(rawMinorVersion)) ? Integer.valueOf(rawMinorVersion) : 0;
                 return minorVersion < 160 || minorVersion > 172; //only those between 161 and 172 minor
                                                                  // releases are not supported
+            } else if (javaVersion.contains("adoptopenjdk")) {
+                return false; //because that is exactly that case when
+                // Eclipse Jenkins runs JVM of adoptopenjdk of not supported version
+                //and we even do not have a chance to recognize that
             }
         }
         return  true;

--- a/tests/integration/servlet-2.5-mvc-3/src/test/java/org/glassfish/jersey/tests/integration/servlet_25_mvc_3/ItemITCase.java
+++ b/tests/integration/servlet-2.5-mvc-3/src/test/java/org/glassfish/jersey/tests/integration/servlet_25_mvc_3/ItemITCase.java
@@ -24,6 +24,8 @@ import org.glassfish.jersey.tests.integration.servlet_25_mvc_3.resource.Book;
 
 import org.junit.Test;
 
+import java.nio.charset.Charset;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -64,7 +66,7 @@ public class ItemITCase extends TestSupport {
 
         assertItemHtmlResponse(htmlIso);
         assertFalse("Response shouldn't contain Ha\u0161ek but was: " + htmlIso, htmlIso.contains("Ha\u0161ek"));
-        assertResponseContains(htmlIso, new String("Ha\u0161ek".getBytes(), "ISO-8859-2"));
+        assertResponseContains(htmlIso, new String("Ha\u0161ek".getBytes(Charset.forName("UTF-8")), "ISO-8859-2"));
     }
 
     @Test


### PR DESCRIPTION
Changes to perform builds on Eclipse Jenkins (which has specific environment and Jersey does not run on it as is)

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>