### PR TITLE
PAYARA-3121 Jersey Crashes for EJB Classes of Same Name

### DIFF
--- a/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
+++ b/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
@@ -388,7 +388,7 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
                         if (rawType.isInstance(result)
                                 || remoteAndLocalIfaces(rawType)
                                         .stream()
-                                        .filter(iFaces -> iFaces.isInstance(result))
+                                        .filter(iface -> iface.isInstance(result))
                                         .findAny()
                                         .isPresent()) {
                             return result;
@@ -422,7 +422,7 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
                         if (rawType.isInstance(result)
                                 || remoteAndLocalIfaces(rawType)
                                         .stream()
-                                        .filter(iFaces -> iFaces.isInstance(result))
+                                        .filter(iface -> iface.isInstance(result))
                                         .findAny()
                                         .isPresent()) {
                             return result;

--- a/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
+++ b/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 [Payara Foundation and/or its affiliates].
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -13,8 +14,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
-
 package org.glassfish.jersey.gf.ejb.internal;
 
 import java.lang.annotation.Annotation;

--- a/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
+++ b/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 [Payara Foundation and/or its affiliates].
+ * Copyright (c) [2018-2019] [Payara Foundation and/or its affiliates].
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -383,17 +383,9 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
                 Object result;
                 try {
                     result = ic.lookup(jndiName);
-                    if (result != null) {
-                        if (rawType.isInstance(result)
-                                || remoteAndLocalIfaces(rawType)
-                                        .stream()
-                                        .filter(iface -> iface.isInstance(result))
-                                        .findAny()
-                                        .isPresent()) {
-                            return result;
-                        }
+                    if (result != null && isLookupInstanceValid(rawType, result)) {
+                        return result;
                     }
-
                 } catch (NamingException e) {
                     ne = e;
                 }
@@ -417,15 +409,8 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
                 Object result;
                 try {
                     result = ic.lookup(jndiName);
-                    if (result != null) {
-                        if (rawType.isInstance(result)
-                                || remoteAndLocalIfaces(rawType)
-                                        .stream()
-                                        .filter(iface -> iface.isInstance(result))
-                                        .findAny()
-                                        .isPresent()) {
-                            return result;
-                        }
+                    if (result != null && isLookupInstanceValid(rawType, result)) {
+                        return result;
                     }
                 } catch (NamingException e) {
                     ne = e;
@@ -433,5 +418,14 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
             }
             throw (ne != null) ? ne : new NamingException();
         }
+    }
+
+    private static boolean isLookupInstanceValid(Class<?> rawType, Object result){
+        return rawType.isInstance(result)
+                                || remoteAndLocalIfaces(rawType)
+                                        .stream()
+                                        .filter(iface -> iface.isInstance(result))
+                                        .findAny()
+                                        .isPresent();
     }
 }

--- a/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
+++ b/containers/glassfish/jersey-gf-ejb/src/main/java/org/glassfish/jersey/gf/ejb/internal/EjbComponentProvider.java
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
+// Portions Copyright [2018] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.jersey.gf.ejb.internal;
 
@@ -331,7 +332,7 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
                 LocalizationMessages.EJB_INTERFACE_HANDLING_METHOD_LOOKUP_EXCEPTION(method, component, iFace), ex);
     }
 
-    private List<Class> remoteAndLocalIfaces(final Class<?> resourceClass) {
+    private static List<Class> remoteAndLocalIfaces(final Class<?> resourceClass) {
         final List<Class> allLocalOrRemoteIfaces = new LinkedList<>();
         if (resourceClass.isAnnotationPresent(Remote.class)) {
             allLocalOrRemoteIfaces.addAll(Arrays.asList(resourceClass.getAnnotation(Remote.class).value()));
@@ -357,18 +358,22 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
         }
     }
 
-    private static Object lookup(InitialContext ic, Class<?> c, String name, EjbComponentProvider provider)
+    private static Object lookup(InitialContext ic, Class<?> rawType, String name, EjbComponentProvider provider)
             throws NamingException {
         try {
-            return lookupSimpleForm(ic, name, provider);
+            return lookupSimpleForm(ic, rawType, name, provider);
         } catch (NamingException ex) {
-            LOGGER.log(Level.WARNING, LocalizationMessages.EJB_CLASS_SIMPLE_LOOKUP_FAILED(c.getName()), ex);
+            LOGGER.log(Level.WARNING, LocalizationMessages.EJB_CLASS_SIMPLE_LOOKUP_FAILED(rawType.getName()), ex);
 
-            return lookupFullyQualifiedForm(ic, c, name, provider);
+            return lookupFullyQualifiedForm(ic, rawType, name, provider);
         }
     }
 
-    private static Object lookupSimpleForm(InitialContext ic, String name, EjbComponentProvider provider) throws NamingException {
+    private static Object lookupSimpleForm(
+            InitialContext ic,
+            Class<?> rawType,
+            String name,
+            EjbComponentProvider provider) throws NamingException {
         if (provider.libNames.isEmpty()) {
             String jndiName = "java:module/" + name;
             return ic.lookup(jndiName);
@@ -380,8 +385,16 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
                 try {
                     result = ic.lookup(jndiName);
                     if (result != null) {
-                        return result;
+                        if (rawType.isInstance(result)
+                                || remoteAndLocalIfaces(rawType)
+                                        .stream()
+                                        .filter(iFaces -> iFaces.isInstance(result))
+                                        .findAny()
+                                        .isPresent()) {
+                            return result;
+                        }
                     }
+
                 } catch (NamingException e) {
                     ne = e;
                 }
@@ -390,20 +403,30 @@ public final class EjbComponentProvider implements ComponentProvider, ResourceMe
         }
     }
 
-    private static Object lookupFullyQualifiedForm(InitialContext ic, Class<?> c, String name, EjbComponentProvider provider)
-            throws NamingException {
+    private static Object lookupFullyQualifiedForm(
+            InitialContext ic,
+            Class<?> rawType,
+            String name,
+            EjbComponentProvider provider) throws NamingException {
         if (provider.libNames.isEmpty()) {
-            String jndiName = "java:module/" + name + "!" + c.getName();
+            String jndiName = "java:module/" + name + "!" + rawType.getName();
             return ic.lookup(jndiName);
         } else {
             NamingException ne = null;
             for (String moduleName : provider.libNames) {
-                String jndiName = "java:app/" + moduleName + "/" + name + "!" + c.getName();
+                String jndiName = "java:app/" + moduleName + "/" + name + "!" + rawType.getName();
                 Object result;
                 try {
                     result = ic.lookup(jndiName);
                     if (result != null) {
-                        return result;
+                        if (rawType.isInstance(result)
+                                || remoteAndLocalIfaces(rawType)
+                                        .stream()
+                                        .filter(iFaces -> iFaces.isInstance(result))
+                                        .findAny()
+                                        .isPresent()) {
+                            return result;
+                        }
                     }
                 } catch (NamingException e) {
                     ne = e;


### PR DESCRIPTION
When Jersey endpoints annotated with `@Stateless` have the same name, the second one deployed won't load and throws the following exception:

**Application structure :**
```
Ear_______
         |
         |___first-war ---> @Path("") @Stateless fish.payara.test.jersey.first.TestEndpoint
         |
         |___second-war ---> @Path("") @Stateless fish.payara.test.jersey.second.TestEndpoint
```
**Exception :**
```
[2018-09-20T15:52:39.872+0100] [Payara 5.183] [WARNING] [] [javax.enterprise.web] [tid: _ThreadID=35 _ThreadName=http-thread-pool::http-listener-1(3)] [timeMillis: 1537455159872] [levelValue: 900] [[
  StandardWrapperValve[fish.payara.test.broken.jersey.second.ApplicationConfig]: Servlet.service() for servlet fish.payara.test.broken.jersey.second.ApplicationConfig threw exception
java.lang.IllegalArgumentException: object is not an instance of declaring class
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:76)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:148)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:191)
        at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$TypeOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:243)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:103)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:493)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:415)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:104)
        at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:277)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:272)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:268)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:316)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:298)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:268)
        at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:289)
        at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:256)
        at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:704)
        at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:416)
        at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:370)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:389)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:342)
        at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:229)
        at org.apache.catalina.core.StandardWrapper.service(StandardWrapper.java:1628)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:258)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:160)
        at org.apache.catalina.core.StandardPipeline.doInvoke(StandardPipeline.java:755)
        at org.apache.catalina.core.StandardPipeline.invoke(StandardPipeline.java:575)
        at com.sun.enterprise.web.WebPipeline.invoke(WebPipeline.java:99)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:159)
        at org.apache.catalina.connector.CoyoteAdapter.doService(CoyoteAdapter.java:371)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:238)
        at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:516)
        at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:213)
        at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:182)
        at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:156)
        at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:218)
        at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:95)
        at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:260)
        at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:177)
        at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:109)
        at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:88)
        at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:53)
        at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:524)
        at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:89)
        at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:94)
        at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.access$100(WorkerThreadIOStrategy.java:33)
        at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:114)
        at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:569)
        at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:549)
        at java.lang.Thread.run(Thread.java:748)
]]
```
Sample app to reproduce the issue : [broken-jersey-sample.zip](https://github.com/eclipse-ee4j/jersey/files/2446160/broken-jersey-sample.zip)