### PR TITLE
ParamConverterFactory should use LinkedHashSet to preserve ordering

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/inject/ParamConverterFactory.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/inject/ParamConverterFactory.java
@@ -19,7 +19,7 @@ package org.glassfish.jersey.server.internal.inject;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -49,7 +49,7 @@ public class ParamConverterFactory implements ParamConverterProvider {
 
     ParamConverterFactory(Set<ParamConverterProvider> providers, Set<ParamConverterProvider> customProviders) {
 
-        Set<ParamConverterProvider> copyProviders = new HashSet<>(providers);
+        Set<ParamConverterProvider> copyProviders = new LinkedHashSet<>(providers);
         converterProviders = new ArrayList<>();
         converterProviders.addAll(customProviders);
         copyProviders.removeAll(customProviders);


### PR DESCRIPTION
This pull request has been migrated from jersey/jersey#3669. It fixes the first issue described in #3670.

In a nutshell: If you provide a custom `ParamConverterProvider` for a data type for which there is also a builtin one provided by Jersey, a random one wins and gets executed. This changes even between deployments. This issue is caused by a `HashSet` in `ParamConverterFactory` which should actually be a `LinkedHashSet` to preserve the ordering.