### PR TITLE
JAX-RS 2.1.2 (Jakarta Maven Coordinates)

### DIFF
--- a/bundles/jaxrs-ri/pom.xml
+++ b/bundles/jaxrs-ri/pom.xml
@@ -44,8 +44,8 @@
     <dependencies>
         <!-- JAX-RS API Sources-->
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <version>${jaxrs.api.impl.version}</version>
             <classifier>sources</classifier>
             <optional>true</optional>

--- a/bundles/jaxrs-ri/src/main/assembly/assembly-bin.xml
+++ b/bundles/jaxrs-ri/src/main/assembly/assembly-bin.xml
@@ -41,10 +41,10 @@
             <directoryMode>0755</directoryMode>
             <fileMode>0644</fileMode>
             <includes>
-                <include>javax.ws.rs:*</include>
+                <include>jakarta.ws.rs:*</include>
             </includes>
             <excludes>
-                <exclude>javax.ws.rs:*:*:sources:*</exclude>
+                <exclude>jakarta.ws.rs:*:*:sources:*</exclude>
             </excludes>
         </dependencySet>
         <!-- JAX-RS RI Binaries-->

--- a/bundles/jaxrs-ri/src/main/assembly/assembly-src-licensee.xml
+++ b/bundles/jaxrs-ri/src/main/assembly/assembly-src-licensee.xml
@@ -48,7 +48,7 @@
                 </excludes>
             </unpackOptions>
             <includes>
-                <include>javax.ws.rs:*:*:sources:*</include>
+                <include>jakarta.ws.rs:*:*:sources:*</include>
                 <include>org.glassfish.jersey.*:*:*:sources:*</include>
             </includes>
         </dependencySet>

--- a/bundles/jaxrs-ri/src/main/assembly/assembly-src.xml
+++ b/bundles/jaxrs-ri/src/main/assembly/assembly-src.xml
@@ -48,7 +48,7 @@
                 </excludes>
             </unpackOptions>
             <includes>
-                <include>javax.ws.rs:*:*:sources:*</include>
+                <include>jakarta.ws.rs:*:*:sources:*</include>
                 <include>org.glassfish.jersey.*:*:*:sources:*</include>
             </includes>
         </dependencySet>

--- a/bundles/jaxrs-ri/src/main/assembly/common-dependencies.xml
+++ b/bundles/jaxrs-ri/src/main/assembly/common-dependencies.xml
@@ -27,7 +27,7 @@
             <directoryMode>0755</directoryMode>
             <fileMode>0644</fileMode>
             <excludes>
-                <exclude>javax.ws.rs:*</exclude>
+                <exclude>jakarta.ws.rs:*</exclude>
                 <exclude>org.glassfish.jersey.*:*</exclude>
                 <!-- CDI API dependencies come from yasson, cdi is optional there -->
                 <exclude>javax.enterprise:cdi-api:jar:*</exclude>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -54,8 +54,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/containers/pom.xml
+++ b/containers/pom.xml
@@ -59,8 +59,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/core-client/pom.xml
+++ b/core-client/pom.xml
@@ -94,8 +94,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/core-common/pom.xml
+++ b/core-common/pom.xml
@@ -167,8 +167,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/core-server/pom.xml
+++ b/core-server/pom.xml
@@ -167,8 +167,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/JarFileScannerTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/JarFileScannerTest.java
@@ -54,14 +54,14 @@ public class JarFileScannerTest {
         final String[] entries = classPath.split(System.getProperty("path.separator"));
 
         for (final String entry : entries) {
-            if (entry.contains("javax.ws.rs-api")) {
+            if (entry.contains("jakarta.ws.rs-api")) {
                 jaxRsApiPath = entry;
                 break;
             }
         }
 
         if (jaxRsApiPath == null) {
-            fail("Could not find javax.ws.rs-api.");
+            fail("Could not find jakarta.ws.rs-api.");
         }
     }
 

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/PackageNamesScannerTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/PackageNamesScannerTest.java
@@ -59,14 +59,14 @@ public class PackageNamesScannerTest {
         final String[] entries = classPath.split(System.getProperty("path.separator"));
 
         for (final String entry : entries) {
-            if (entry.contains("javax.ws.rs-api")) {
+            if (entry.contains("jakarta.ws.rs-api")) {
                 jaxRsApiPath = entry;
                 break;
             }
         }
 
         if (jaxRsApiPath == null) {
-            fail("Could not find javax.ws.rs-api.");
+            fail("Could not find jakarta.ws.rs-api.");
         }
     }
 

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/VFSSchemeResourceFinderTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/VFSSchemeResourceFinderTest.java
@@ -50,14 +50,14 @@ public class VFSSchemeResourceFinderTest {
         final String[] entries = classPath.split(System.getProperty("path.separator"));
 
         for (final String entry : entries) {
-            if (entry.contains("javax.ws.rs-api")) {
+            if (entry.contains("jakarta.ws.rs-api")) {
                 jaxRsApiPath = entry;
                 break;
             }
         }
 
         if (jaxRsApiPath == null) {
-            fail("Could not find javax.ws.rs-api.");
+            fail("Could not find jakarta.ws.rs-api.");
         }
     }
 
@@ -75,7 +75,7 @@ public class VFSSchemeResourceFinderTest {
             while (entries.hasMoreElements()) {
                 final JarEntry entry = entries.nextElement();
 
-                if (entry.getName().endsWith(".class")) {
+                if (entry.getName().startsWith("javax/ws/rs") && entry.getName().endsWith(".class")) {
                     actualEntries++;
                 }
             }

--- a/docs/src/main/docbook/dependencies.xml
+++ b/docs/src/main/docbook/dependencies.xml
@@ -93,8 +93,8 @@
             </para>
 
             <programlisting language="xml">&lt;dependency&gt;
-    &lt;groupId>javax.ws.rs&lt;/groupId&gt;
-    &lt;artifactId>javax.ws.rs-api&lt;/artifactId&gt;
+    &lt;groupId>jakarta.ws.rs&lt;/groupId&gt;
+    &lt;artifactId>jakarta.ws.rs-api&lt;/artifactId&gt;
     &lt;version&gt;&jax-rs-api-jar.version;&lt;/version&gt;
     &lt;scope&gt;provided&lt;/scope&gt;
 &lt;/dependency&gt;</programlisting>

--- a/examples/cdi-webapp/pom.xml
+++ b/examples/cdi-webapp/pom.xml
@@ -35,8 +35,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -135,8 +135,8 @@
                     <scope>compile</scope>
                 </dependency>
                 <dependency>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>javax.ws.rs-api</artifactId>
+                    <groupId>jakarta.ws.rs</groupId>
+                    <artifactId>jakarta.ws.rs-api</artifactId>
                     <scope>compile</scope>
                 </dependency>
                 <dependency>

--- a/examples/etc/gf-project-src-pom.xsl
+++ b/examples/etc/gf-project-src-pom.xsl
@@ -73,8 +73,8 @@
                 <artifactId>jersey-mvc</artifactId>
               </exclusion>
               <exclusion>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
               </exclusion>
             </exclusions>
         </xsl:copy>
@@ -87,8 +87,8 @@
             <xsl:apply-templates />
             <exclusions>
                 <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>javax.ws.rs-api</artifactId>
+                    <groupId>jakarta.ws.rs</groupId>
+                    <artifactId>jakarta.ws.rs-api</artifactId>
                 </exclusion>
 
 

--- a/examples/etc/wls-project-src-pom.xsl
+++ b/examples/etc/wls-project-src-pom.xsl
@@ -74,8 +74,8 @@
                 <artifactId>javax.inject</artifactId>
             </exclusion>
             <exclusion>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
             </exclusion>
         </exclusions>
     </xsl:template>
@@ -101,8 +101,8 @@
                         <artifactId>javax.inject</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>javax.ws.rs</groupId>
-                        <artifactId>javax.ws.rs-api</artifactId>
+                        <groupId>jakarta.ws.rs</groupId>
+                        <artifactId>jakarta.ws.rs-api</artifactId>
                     </exclusion>
                 </exclusions>
             </xsl:if>

--- a/examples/etc/wls1213-project-src-pom.xsl
+++ b/examples/etc/wls1213-project-src-pom.xsl
@@ -73,8 +73,8 @@
                 <artifactId>javax.inject</artifactId>
             </exclusion>
             <exclusion>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
             </exclusion>
         </exclusions>
     </xsl:template>
@@ -101,8 +101,8 @@
                         <artifactId>javax.inject</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>javax.ws.rs</groupId>
-                        <artifactId>javax.ws.rs-api</artifactId>
+                        <groupId>jakarta.ws.rs</groupId>
+                        <artifactId>jakarta.ws.rs-api</artifactId>
                     </exclusion>
                 </exclusions>
             </xsl:if>

--- a/examples/extended-wadl-webapp/src/test/java/org/glassfish/jersey/examples/extendedwadl/ExtendedWadlWebappOsgiTest.java
+++ b/examples/extended-wadl-webapp/src/test/java/org/glassfish/jersey/examples/extendedwadl/ExtendedWadlWebappOsgiTest.java
@@ -113,7 +113,7 @@ public class ExtendedWadlWebappOsgiTest {
                 mavenBundle().groupId("org.javassist").artifactId("javassist").versionAsInProject(),
 
                 // JAX-RS API
-                mavenBundle().groupId("javax.ws.rs").artifactId("javax.ws.rs-api").versionAsInProject(),
+                mavenBundle().groupId("jakarta.ws.rs").artifactId("jakarta.ws.rs-api").versionAsInProject(),
 
                 // Jersey bundles
                 mavenBundle().groupId("org.glassfish.jersey.core").artifactId("jersey-common").versionAsInProject(),

--- a/examples/managed-beans-webapp/pom.xml
+++ b/examples/managed-beans-webapp/pom.xml
@@ -35,8 +35,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/examples/osgi-helloworld-webapp/additional-bundle/pom.xml
+++ b/examples/osgi-helloworld-webapp/additional-bundle/pom.xml
@@ -29,8 +29,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/examples/osgi-helloworld-webapp/alternate-version-bundle/pom.xml
+++ b/examples/osgi-helloworld-webapp/alternate-version-bundle/pom.xml
@@ -29,8 +29,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/AbstractWebAppTest.java
+++ b/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/AbstractWebAppTest.java
@@ -143,7 +143,7 @@ public abstract class AbstractWebAppTest {
                 mavenBundle().groupId("org.glassfish.hk2.external").artifactId("aopalliance-repackaged").versionAsInProject(),
                 mavenBundle().groupId("org.javassist").artifactId("javassist").versionAsInProject(),
                 // JAX-RS API
-                mavenBundle().groupId("javax.ws.rs").artifactId("javax.ws.rs-api").versionAsInProject(),
+                mavenBundle().groupId("jakarta.ws.rs").artifactId("jakarta.ws.rs-api").versionAsInProject(),
                 // validation - required by jersey-container-servlet-core
                 mavenBundle().groupId("javax.validation").artifactId("validation-api").versionAsInProject(),
                 // Jersey bundles

--- a/examples/osgi-helloworld-webapp/lib-bundle/pom.xml
+++ b/examples/osgi-helloworld-webapp/lib-bundle/pom.xml
@@ -29,8 +29,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/examples/osgi-helloworld-webapp/war-bundle/pom.xml
+++ b/examples/osgi-helloworld-webapp/war-bundle/pom.xml
@@ -50,8 +50,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/examples/osgi-http-service/functional-test/src/test/java/org/glassfish/jersey/examples/osgihttpservice/test/AbstractHttpServiceTest.java
+++ b/examples/osgi-http-service/functional-test/src/test/java/org/glassfish/jersey/examples/osgihttpservice/test/AbstractHttpServiceTest.java
@@ -107,7 +107,7 @@ public abstract class AbstractHttpServiceTest {
                 mavenBundle().groupId("org.javassist").artifactId("javassist").versionAsInProject(),
 
                 // JAX-RS API
-                mavenBundle().groupId("javax.ws.rs").artifactId("javax.ws.rs-api").versionAsInProject(),
+                mavenBundle().groupId("jakarta.ws.rs").artifactId("jakarta.ws.rs-api").versionAsInProject(),
 
                 // validation
                 mavenBundle().groupId("javax.validation").artifactId("validation-api").versionAsInProject(),

--- a/examples/server-async-standalone/client/pom.xml
+++ b/examples/server-async-standalone/client/pom.xml
@@ -28,8 +28,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -58,8 +58,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/ext/servlet-portability/pom.xml
+++ b/ext/servlet-portability/pom.xml
@@ -51,8 +51,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/incubator/html-json/pom.xml
+++ b/incubator/html-json/pom.xml
@@ -52,8 +52,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.netbeans.html</groupId>

--- a/incubator/kryo/pom.xml
+++ b/incubator/kryo/pom.xml
@@ -36,8 +36,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1348,8 +1348,8 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>${jaxrs.api.impl.version}</version>
             </dependency>
             <dependency>
@@ -1958,7 +1958,7 @@
         <jaxb.ri.version>2.2.7</jaxb.ri.version>
         <jsonb.api.version>1.0</jsonb.api.version>
         <jaxrs.api.spec.version>2.1</jaxrs.api.spec.version>
-        <jaxrs.api.impl.version>2.1</jaxrs.api.impl.version>
+        <jaxrs.api.impl.version>2.1.2</jaxrs.api.impl.version>
         <jboss.logging.version>3.3.0.Final</jboss.logging.version>
         <jersey1.version>1.19.3</jersey1.version>
         <jersey1.last.final.version>${jersey1.version}</jersey1.last.final.version>

--- a/security/oauth1-client/pom.xml
+++ b/security/oauth1-client/pom.xml
@@ -62,8 +62,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/security/oauth2-client/pom.xml
+++ b/security/oauth2-client/pom.xml
@@ -60,8 +60,8 @@
         </dependency>
 
         <!--<dependency>-->
-            <!--<groupId>javax.ws.rs</groupId>-->
-            <!--<artifactId>javax.ws.rs-api</artifactId>-->
+            <!--<groupId>jakarta.ws.rs</groupId>-->
+            <!--<artifactId>jakarta.ws.rs-api</artifactId>-->
         <!--</dependency>-->
     </dependencies>
 

--- a/tests/integration/cdi-beanvalidation-webapp/pom.xml
+++ b/tests/integration/cdi-beanvalidation-webapp/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/cdi-ejb-test-webapp/pom.xml
+++ b/tests/integration/cdi-ejb-test-webapp/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/cdi-iface-with-non-jaxrs-impl-test-webapp/pom.xml
+++ b/tests/integration/cdi-iface-with-non-jaxrs-impl-test-webapp/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/cdi-multimodule/lib/pom.xml
+++ b/tests/integration/cdi-multimodule/lib/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/cdi-multimodule/war1/pom.xml
+++ b/tests/integration/cdi-multimodule/war1/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/cdi-multimodule/war2/pom.xml
+++ b/tests/integration/cdi-multimodule/war2/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/cdi-multipart-webapp/pom.xml
+++ b/tests/integration/cdi-multipart-webapp/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/cdi-test-webapp/pom.xml
+++ b/tests/integration/cdi-test-webapp/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/cdi-with-jersey-injection-custom-hk2-banned-webapp/pom.xml
+++ b/tests/integration/cdi-with-jersey-injection-custom-hk2-banned-webapp/pom.xml
@@ -59,8 +59,8 @@
                     <artifactId>jersey-common</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>javax.ws.rs-api</artifactId>
+                    <groupId>jakarta.ws.rs</groupId>
+                    <artifactId>jakarta.ws.rs-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/tests/integration/client-connector-provider/pom.xml
+++ b/tests/integration/client-connector-provider/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/ejb-multimodule-reload/lib/pom.xml
+++ b/tests/integration/ejb-multimodule-reload/lib/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/ejb-multimodule-reload/war1/pom.xml
+++ b/tests/integration/ejb-multimodule-reload/war1/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/ejb-multimodule-reload/war2/pom.xml
+++ b/tests/integration/ejb-multimodule-reload/war2/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/ejb-multimodule/lib/pom.xml
+++ b/tests/integration/ejb-multimodule/lib/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/ejb-multimodule/war/pom.xml
+++ b/tests/integration/ejb-multimodule/war/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/ejb-test-webapp/pom.xml
+++ b/tests/integration/ejb-test-webapp/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/j-376/pom.xml
+++ b/tests/integration/j-376/pom.xml
@@ -34,8 +34,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/tests/integration/j-59/lib/pom.xml
+++ b/tests/integration/j-59/lib/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/j-59/war/pom.xml
+++ b/tests/integration/j-59/war/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/jersey-2137/pom.xml
+++ b/tests/integration/jersey-2137/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/jersey-2154/pom.xml
+++ b/tests/integration/jersey-2154/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tests/integration/spring4/pom.xml
+++ b/tests/integration/spring4/pom.xml
@@ -46,8 +46,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>compile</scope>
         </dependency>
 

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/util/Helper.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/util/Helper.java
@@ -159,7 +159,7 @@ public class Helper {
         if (includeJerseyJaxRsLibs) {
             options.addAll(expandedList(
                     // JAX-RS API
-                    mavenBundle().groupId("javax.ws.rs").artifactId("javax.ws.rs-api").versionAsInProject(),
+                    mavenBundle().groupId("jakarta.ws.rs").artifactId("jakarta.ws.rs-api").versionAsInProject(),
 
                     // Jersey bundles
                     mavenBundle().groupId("org.glassfish.jersey.core").artifactId("jersey-common").versionAsInProject(),

--- a/tests/performance/test-cases/filter-dynamic/pom.xml
+++ b/tests/performance/test-cases/filter-dynamic/pom.xml
@@ -38,8 +38,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/filter-global/pom.xml
+++ b/tests/performance/test-cases/filter-global/pom.xml
@@ -38,8 +38,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/filter-name/pom.xml
+++ b/tests/performance/test-cases/filter-name/pom.xml
@@ -38,8 +38,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/interceptor-dynamic/pom.xml
+++ b/tests/performance/test-cases/interceptor-dynamic/pom.xml
@@ -38,8 +38,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/interceptor-global/pom.xml
+++ b/tests/performance/test-cases/interceptor-global/pom.xml
@@ -38,8 +38,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/interceptor-name/pom.xml
+++ b/tests/performance/test-cases/interceptor-name/pom.xml
@@ -38,8 +38,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/mbw-custom-provider/pom.xml
+++ b/tests/performance/test-cases/mbw-custom-provider/pom.xml
@@ -37,8 +37,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/mbw-json-jackson/pom.xml
+++ b/tests/performance/test-cases/mbw-json-jackson/pom.xml
@@ -37,8 +37,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/mbw-text-plain/pom.xml
+++ b/tests/performance/test-cases/mbw-text-plain/pom.xml
@@ -37,8 +37,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/mbw-xml-jaxb/pom.xml
+++ b/tests/performance/test-cases/mbw-xml-jaxb/pom.xml
@@ -37,8 +37,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/param-srl/pom.xml
+++ b/tests/performance/test-cases/param-srl/pom.xml
@@ -38,8 +38,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/tests/performance/test-cases/proxy-injection/pom.xml
+++ b/tests/performance/test-cases/proxy-injection/pom.xml
@@ -38,8 +38,8 @@
     <dependencies>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Using JAX-RS 2.1.2 (i. e. Jakarta Maven Coordinates) instead of JAX-RS 2.1 (i. e. javax Maven Coordinates).