### PR TITLE
Using Apache HTML/Java API version 1.5.1 

### DIFF
--- a/incubator/html-json/pom.xml
+++ b/incubator/html-json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.26-SNAPSHOT</version>
+        <version>2.27-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.jersey.media</groupId>
@@ -39,7 +39,7 @@
     </description>
 
     <properties>
-        <net.java.html.version>1.0</net.java.html.version>
+        <net.java.html.version>1.5.1</net.java.html.version>
     </properties>
 
     <repositories>

--- a/incubator/html-json/pom.xml
+++ b/incubator/html-json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.27-SNAPSHOT</version>
+        <version>2.28-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.jersey.media</groupId>

--- a/incubator/pom.xml
+++ b/incubator/pom.xml
@@ -38,7 +38,7 @@
     <modules>
         <module>declarative-linking</module>
         <module>gae-integration</module>
-        <!--<module>html-json</module>-->
+        <module>html-json</module>
         <module>kryo</module>
         <module>open-tracing</module>
     </modules>


### PR DESCRIPTION
*HTML/Java API* has been donated to Apache foundation. It is available in [incubator-netbeans-html4j](https://github.com/apache/incubator-netbeans-html4j). Switching to version `1.5.1` which has been released under Apache license to perform the message reader/write persistance