### PR TITLE
Release http(content)/http2(frame) bytebuf to prevent memory leak

### DIFF
--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/JerseyClientHandler.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/JerseyClientHandler.java
@@ -101,7 +101,7 @@ class JerseyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
                     }
                 });
 
-                jerseyResponse.setEntityStream(new NettyInputStream(isList));
+                jerseyResponse.setEntityStream(new NettyInputStream(isList, ctx));
             } else {
                 jerseyResponse.setEntityStream(new InputStream() {
                     @Override

--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
@@ -16,6 +16,9 @@
 
 package org.glassfish.jersey.netty.connector.internal;
 
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.channel.ChannelHandlerContext;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -64,8 +67,11 @@ public class NettyInputStream extends InputStream {
 
     private final LinkedBlockingDeque<InputStream> isList;
 
-    public NettyInputStream(LinkedBlockingDeque<InputStream> isList) {
+    private final ChannelHandlerContext ctx;
+
+    public NettyInputStream(LinkedBlockingDeque<InputStream> isList, ChannelHandlerContext ctx) {
         this.isList = isList;
+        this.ctx = ctx;
     }
 
     @Override
@@ -87,6 +93,14 @@ public class NettyInputStream extends InputStream {
 
             if (take.available() > 0) {
                 isList.addFirst(take);
+            } else {
+                // Must run on channel's eventloop thread
+                ctx.executor().submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        releaseBuffer(take);
+                    }
+                });
             }
 
             return read;
@@ -113,6 +127,13 @@ public class NettyInputStream extends InputStream {
 
             if (take.available() > 0) {
                 isList.addFirst(take);
+            } else {
+                ctx.executor().submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        releaseBuffer(take);
+                    }
+                });
             }
 
             return read;
@@ -141,4 +162,15 @@ public class NettyInputStream extends InputStream {
         }
         return false;
     }
+
+    private void releaseBuffer(InputStream stream) {
+        if (stream instanceof ByteBufInputStream) {
+            try {
+                stream.close();
+            } catch (IOException e) {
+                // should not happen
+            }
+        }
+    }
+
 }

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/HttpVersionChooser.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/HttpVersionChooser.java
@@ -20,7 +20,7 @@ import java.net.URI;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpServerCodec;
-import io.netty.handler.codec.http2.Http2Codec;
+import io.netty.handler.codec.http2.Http2MultiplexCodecBuilder;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
@@ -45,7 +45,8 @@ class HttpVersionChooser extends ApplicationProtocolNegotiationHandler {
     @Override
     protected void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception {
         if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
-            ctx.pipeline().addLast(new Http2Codec(true, new JerseyHttp2ServerHandler(baseUri, container)));
+            // Http2Codec is removed in version 4.1.15.
+            ctx.pipeline().addLast(Http2MultiplexCodecBuilder.forServer(new JerseyHttp2ServerHandler(baseUri, container)).build());
             return;
         }
 

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
@@ -99,7 +99,10 @@ class JerseyServerHandler extends ChannelInboundHandlerAdapter {
             ByteBuf content = httpContent.content();
 
             if (content.isReadable()) {
-                isList.add(new ByteBufInputStream(content));
+                isList.add(new ByteBufInputStream(content, true));
+            } else {
+                // Discard empty content directly
+                httpContent.release();
             }
 
             if (msg instanceof LastHttpContent) {
@@ -158,7 +161,7 @@ class JerseyServerHandler extends ChannelInboundHandlerAdapter {
                 }
             });
 
-            requestContext.setEntityStream(new NettyInputStream(isList));
+            requestContext.setEntityStream(new NettyInputStream(isList, ctx));
         } else {
             requestContext.setEntityStream(new InputStream() {
                 @Override

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerInitializer.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerInitializer.java
@@ -26,8 +26,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
-import io.netty.handler.codec.http2.Http2Codec;
 import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.handler.codec.http2.Http2MultiplexCodecBuilder;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.stream.ChunkedWriteHandler;
@@ -113,7 +113,7 @@ class JerseyServerInitializer extends ChannelInitializer<SocketChannel> {
             @Override
             public HttpServerUpgradeHandler.UpgradeCodec newUpgradeCodec(CharSequence protocol) {
                 if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                    return new Http2ServerUpgradeCodec(new Http2Codec(true, new JerseyHttp2ServerHandler(baseUri, container)));
+                    return new Http2ServerUpgradeCodec(Http2MultiplexCodecBuilder.forServer(new JerseyHttp2ServerHandler(baseUri, container)).build());
                 } else {
                     return null;
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -1978,7 +1978,7 @@
         <mockito.version>1.10.19</mockito.version>
         <moxy.version>2.6.4</moxy.version>
         <mustache.version>0.8.17</mustache.version>
-        <netty.version>4.1.5.Final</netty.version>
+        <netty.version>4.1.30.Final</netty.version>
         <nexus-staging.mvn.plugin.version>1.6.7</nexus-staging.mvn.plugin.version>
         <opentracing.version>0.30.0</opentracing.version>
         <osgi.version>4.2.0</osgi.version>


### PR DESCRIPTION
As the last handler that accessed the http data(bytebuf), Jersey handler has the responsibility to release them.
That require support for `releaseOnClose` in `ByteBufInputStream` since `4.1.7.Final`.
Drop by to construct http2 pipeline via builder style.([detail](https://github.com/netty/netty/commit/74f24a5c19f8f351e9c6a7a84bdd9fbcc7a07ada))
Bump the version of netty to `4.1.30.Final`.