### PR TITLE
Apache html java json persistance ee4 j

### DIFF
--- a/incubator/html-json/pom.xml
+++ b/incubator/html-json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.incubator</groupId>
         <artifactId>project</artifactId>
-        <version>2.27-SNAPSHOT</version>
+        <version>2.28-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.jersey.media</groupId>

--- a/incubator/pom.xml
+++ b/incubator/pom.xml
@@ -38,7 +38,7 @@
     <modules>
         <module>declarative-linking</module>
         <module>gae-integration</module>
-        <!--<module>html-json</module>-->
+        <module>html-json</module>
         <module>kryo</module>
         <module>open-tracing</module>
     </modules>


### PR DESCRIPTION
*HTML/Java API* has been donated to Apache foundation. It is available in [incubator-netbeans-html4j](https://github.com/apache/incubator-netbeans-html4j). Switching to version `1.5.1` which has been released under Apache license to perform the message reader/write persistence.

Backport of PR #3964  to `EE4J_8` branch.