### PR TITLE
Upgrade Netty and expose Netty Context

### DIFF
--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
@@ -43,6 +43,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.glassfish.jersey.internal.PropertiesDelegate;
 import org.glassfish.jersey.netty.connector.internal.NettyInputStream;
+import org.glassfish.jersey.netty.httpserver.NettySecurityContext;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.internal.ContainerUtils;
 
@@ -121,7 +122,7 @@ class JerseyServerHandler extends ChannelInboundHandlerAdapter {
         URI requestUri = URI.create(baseUri + ContainerUtils.encodeUnsafeCharacters(s));
 
         ContainerRequest requestContext = new ContainerRequest(
-                baseUri, requestUri, req.method().name(), getSecurityContext(),
+                baseUri, requestUri, req.method().name(), getSecurityContext(ctx),
                 new PropertiesDelegate() {
 
                     private final Map<String, Object> properties = new HashMap<>();
@@ -176,29 +177,8 @@ class JerseyServerHandler extends ChannelInboundHandlerAdapter {
         return requestContext;
     }
 
-    private SecurityContext getSecurityContext() {
-        return new SecurityContext() {
-
-            @Override
-            public boolean isUserInRole(final String role) {
-                return false;
-            }
-
-            @Override
-            public boolean isSecure() {
-                return false;
-            }
-
-            @Override
-            public Principal getUserPrincipal() {
-                return null;
-            }
-
-            @Override
-            public String getAuthenticationScheme() {
-                return null;
-            }
-        };
+    private NettySecurityContext getSecurityContext(ChannelHandlerContext ctx) {
+        return new NettySecurityContext(ctx);
     }
 
     @Override

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerInitializer.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerInitializer.java
@@ -26,8 +26,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
-import io.netty.handler.codec.http2.Http2Codec;
 import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.handler.codec.http2.Http2MultiplexCodecBuilder;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.stream.ChunkedWriteHandler;
@@ -113,7 +113,8 @@ class JerseyServerInitializer extends ChannelInitializer<SocketChannel> {
             @Override
             public HttpServerUpgradeHandler.UpgradeCodec newUpgradeCodec(CharSequence protocol) {
                 if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                    return new Http2ServerUpgradeCodec(new Http2Codec(true, new JerseyHttp2ServerHandler(baseUri, container)));
+                    return new Http2ServerUpgradeCodec(Http2MultiplexCodecBuilder.forServer(
+                                new JerseyHttp2ServerHandler(baseUri, container)).build());
                 } else {
                     return null;
                 }

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/NettySecurityContext.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/NettySecurityContext.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018 Ian Kirk. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.netty.httpserver;
+
+import java.security.Principal;
+
+import javax.ws.rs.core.SecurityContext;
+
+import io.netty.channel.ChannelHandlerContext;
+
+public class NettySecurityContext implements SecurityContext {
+    private ChannelHandlerContext ctx;
+
+    public NettySecurityContext(ChannelHandlerContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public ChannelHandlerContext getNettyContext() {
+        return this.ctx;
+    }
+
+    @Override
+    public boolean isUserInRole(final String role) {
+        return false;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public String getAuthenticationScheme() {
+        return null;
+    }
+};

--- a/pom.xml
+++ b/pom.xml
@@ -1978,7 +1978,7 @@
         <mockito.version>1.10.19</mockito.version>
         <moxy.version>2.6.4</moxy.version>
         <mustache.version>0.8.17</mustache.version>
-        <netty.version>4.1.5.Final</netty.version>
+        <netty.version>4.1.31.Final</netty.version>
         <nexus-staging.mvn.plugin.version>1.6.7</nexus-staging.mvn.plugin.version>
         <opentracing.version>0.30.0</opentracing.version>
         <osgi.version>4.2.0</osgi.version>


### PR DESCRIPTION
Bumped netty version to latest
Updated API usage to match
Enhanced returned SecurityContext to include Netty information

Signed-off-by: Ian <eclipse@wut.to>