### PR TITLE
Break from looping over FormDataBodyParts once first match is found.

### DIFF
--- a/media/multipart/src/main/java/org/glassfish/jersey/media/multipart/FormDataMultiPart.java
+++ b/media/multipart/src/main/java/org/glassfish/jersey/media/multipart/FormDataMultiPart.java
@@ -107,6 +107,7 @@ public class FormDataMultiPart extends MultiPart {
             }
             if (name.equals(((FormDataBodyPart) bodyPart).getName())) {
                 result = (FormDataBodyPart) bodyPart;
+                break; // Break to return first result found.
             }
         }
         return result;


### PR DESCRIPTION
Since this is supposed to return the first result found, it seems appropriate to break from the `for` loop once we have a `result`.