### PR TITLE
Update maven-enforcer-plugin to 3.0.0-M2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.0.0-M2</version>
                     <executions>
                         <execution>
                             <id>enforce-versions</id>


### PR DESCRIPTION
The version of the `maven-enforcer-plugin` currently used in the project is not compatible with Java 11, causing all project builds to fail on Java 11 due to the plugin's inability to parse the version string:
```
Caused by: java.lang.StringIndexOutOfBoundsException: begin 0, end 3, length 2
    at java.lang.String.checkBoundsBeginEnd (String.java:3319)
    at java.lang.String.substring (String.java:1874)
    at org.apache.commons.lang.SystemUtils.getJavaVersionAsFloat (SystemUtils.java:1122)
    at org.apache.commons.lang.SystemUtils.<clinit> (SystemUtils.java:818)
    at org.apache.maven.plugins.enforcer.RequireJavaVersion.execute (RequireJavaVersion.java:52)
    at org.apache.maven.plugins.enforcer.EnforceMojo.execute (EnforceMojo.java:193)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:954)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
```
This issue is fixed in the latest 3.0.0-M2 version of the plugin. This PR updates the version used by Jersey to 3.0.0-M2.

Refs https://github.com/eclipse-ee4j/jersey/issues/3965

Signed-off-by: mszabo-wikia <mszabo@wikia-inc.com>