### PR TITLE
Add dependency on jakarta.activation-api to core-common

### DIFF
--- a/core-common/pom.xml
+++ b/core-common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/core-common/pom.xml
+++ b/core-common/pom.xml
@@ -177,6 +177,11 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${jakarta.activation.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -1976,6 +1976,7 @@
         <httpclient.version>4.5</httpclient.version> <!-- TODO: 4.5.2 doesn't work; apache client connector tests -->
         <jackson.version>2.9.8</jackson.version>
         <jackson1.version>1.9.13</jackson1.version>
+        <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <javassist.version>3.22.0-GA</javassist.version>
         <javax.annotation.version>1.3.4</javax.annotation.version>
         <javax.el.version>3.0.2</javax.el.version>

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -379,7 +379,7 @@
         <dependency>
             <groupId>com.sun.activation</groupId>
             <artifactId>jakarta.activation</artifactId>
-            <version>1.2.1</version>
+            <version>${jakarta.activation.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
The class `org.glassfish.jersey.message.internal.DataSourceProvider` in the `core-common` submodule references the `javax.activation.DataSource` interface. This results in a compilation error on Java 11, which no longer provides the activation API built-in. This PR adds `jakarta.activation-api` as a dependency to the module to resolve the issue.

(Sidenote: as of this change, `core-common` compilation still fails due to use of `sun.misc.Contended` in `org.glassfish.jersey.internal.jsr166.SubmissionPublisher`—there does not seem to be a backwards compatible migration path there.)

Signed-off-by: mszabo-wikia <mszabo@wikia-inc.com>