### PR TITLE
Travis CI is caching local Maven Repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ jdk:
 cache:
   directories:
     - .autoconf
+    - $HOME/.m2
+
 env:
   matrix:
     - TEST_SET="-Ptravis_e2e_skip"


### PR DESCRIPTION
Improves Travis CI performance by loading one big folder instead of running a lot of single dependency downloads (in my tests, performance was about doubled). :-)

Unfortunately EF has no similar solution at hand for Jenkins (at least right now off-the-box). :-(