### PR TITLE
Fix usage of sun.misc.Contended in core-common

### DIFF
--- a/core-common/src/main/java/jdk/internal/vm/annotation/Contended.java
+++ b/core-common/src/main/java/jdk/internal/vm/annotation/Contended.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jdk.internal.vm.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This utility annotation allows Jersey to be compiled on JDK 8,
+ * which uses {@link sun.misc.Contended} instead of {@link jdk.internal.vm.annotation.Contended}.
+ *
+ * On JDK 11 at runtime, the system will use the proper {@link jdk.internal.vm.annotation.Contended} class from the JDK.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+public @interface Contended {
+}

--- a/core-common/src/main/java/org/glassfish/jersey/internal/jsr166/SubmissionPublisher.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/jsr166/SubmissionPublisher.java
@@ -1011,6 +1011,7 @@ public class SubmissionPublisher<T> implements Flow.Publisher<T>,
      */
     @SuppressWarnings("serial")
     @sun.misc.Contended
+    @jdk.internal.vm.annotation.Contended
     private static final class BufferedSubscription<T>
             implements Flow.Subscription, ForkJoinPool.ManagedBlocker {
         // Order-sensitive field declarations

--- a/core-common/src/main/java/sun/misc/Contended.java
+++ b/core-common/src/main/java/sun/misc/Contended.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package sun.misc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This utility annotation allows Jersey to be compiled on JDK 11,
+ * which removed {@link sun.misc.Contended} in favor of {@link jdk.internal.vm.annotation.Contended}.
+ *
+ * On older Java versions at runtime, the system will use the proper {@link sun.misc.Contended} class from the JDK.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+public @interface Contended {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
                             <link>http://hk2.java.net/nonav/hk2-api/apidocs</link>
                         </links>
                         <excludePackageNames>
-                            *.internal.*:*.tests.*
+                            *.internal.*:*.tests.*:sun.*
                         </excludePackageNames>
                         <sourceFileExcludes>
                             <exclude>bundles/**</exclude>


### PR DESCRIPTION
The `sun.misc.Contended` annotation has been moved to `jdk.internal.vm.annotation` package for Java 11, which breaks compilation as `org.glassfish.jersey.internal.jsr166.SubmissionPublisher.BufferedSubscription` uses it. This PR adds two dummy `@Contended` annotations that allow the project to be compiled on Java >8; at runtime, the JDK will pick up whichever of the `@Contended` annotations is provided by the JDK.

An alternative may be to simply remove the `@Contended` usage from `org.glassfish.jersey.internal.jsr166.SubmissionPublisher.BufferedSubscription`.  Because the class is not a system class, the annotation will only ever take effect if Jersey users explicitly opt-in by running their JVM with the `-XX:-RestrictContended` flag.

Signed-off-by: mszabo-wikia <mszabo@wikia-inc.com>