### PR TITLE
Allow for determining media type for RequestContext#abortWith

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/package-info.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * Jersey client-side internal classes.
+ */
+package org.glassfish.jersey.client.internal;

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/routing/AbortedRequestMediaTypeDeterminer.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/routing/AbortedRequestMediaTypeDeterminer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.client.internal.routing;
+
+import org.glassfish.jersey.internal.routing.CombinedMediaType;
+import org.glassfish.jersey.internal.routing.ContentTypeDeterminer;
+import org.glassfish.jersey.internal.routing.RequestSpecificConsumesProducesAcceptor;
+import org.glassfish.jersey.internal.util.ReflectionHelper;
+import org.glassfish.jersey.message.MessageBodyWorkers;
+import org.glassfish.jersey.message.internal.AcceptableMediaType;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Client side {@link Response} media type determinator utility class.
+ * Used for determining media type when {@link ClientRequestContext#abortWith(Response)} on
+ * {@link javax.ws.rs.client.ClientRequestFilter#filter(ClientRequestContext)} is used without specifying the response
+ * media type.
+ */
+public class AbortedRequestMediaTypeDeterminer extends ContentTypeDeterminer {
+
+    private static final AbortedRouting ABORTED_ROUTING = new AbortedRouting();
+
+    public AbortedRequestMediaTypeDeterminer(MessageBodyWorkers workers) {
+        super(workers);
+    }
+
+    /**
+     * Determine the {@link MediaType} of the {@link Response} based on writers suitable for the given entity instance.
+     *
+     * @param entity                entity instance to determine the media type for
+     * @param acceptableMediaTypes  acceptable media types from request.
+     * @return                      media type of the response.
+     */
+    public MediaType determineResponseMediaType(
+            final Object entity,
+            final List<AcceptableMediaType> acceptableMediaTypes) {
+
+        final GenericType type = ReflectionHelper.genericTypeFor(entity);
+        final CombinedMediaType wildcardType = CombinedMediaType.create(MediaType.WILDCARD_TYPE,
+                new CombinedMediaType.EffectiveMediaType(MediaType.WILDCARD_TYPE));
+        final RequestSpecificConsumesProducesAcceptor<AbortedRouting> selectedMethod =
+                new RequestSpecificConsumesProducesAcceptor<>(wildcardType, wildcardType, true, ABORTED_ROUTING);
+        // Media types producible by method.
+        final List<MediaType> methodProducesTypes = Collections.singletonList(MediaType.WILDCARD_TYPE);
+
+        return determineResponseMediaType(type.getRawType(), type.getType(), selectedMethod, acceptableMediaTypes,
+                methodProducesTypes, null);
+    }
+
+    /**
+     * An information that the routing aborted by  {@code javax.ws.rs.client.ClientRequestContext#abortWith(Response)}.
+     */
+    private static final class AbortedRouting {
+
+        @Override
+        public String toString() {
+            return "{Aborted by ClientRequestFilter}";
+        }
+    }
+
+}

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/routing/package-info.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/routing/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * Jersey client-side internal routing API classes.
+ */
+package org.glassfish.jersey.client.internal.routing;

--- a/core-common/src/main/java/org/glassfish/jersey/internal/routing/CombinedMediaType.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/routing/CombinedMediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.jersey.server.internal.routing;
+package org.glassfish.jersey.internal.routing;
 
 import java.util.Comparator;
 
@@ -33,12 +33,12 @@ import org.glassfish.jersey.message.internal.QualitySourceMediaType;
  * @author Jakub Podlesak
  * @author Miroslav Fuksa
  */
-final class CombinedMediaType {
+public final class CombinedMediaType {
 
     /**
      * Constant combined type representing no match.
      */
-    static final CombinedMediaType NO_MATCH = new CombinedMediaType(null, 0, 0, 0);
+    public static final CombinedMediaType NO_MATCH = new CombinedMediaType(null, 0, 0, 0);
 
     private static int matchedWildcards(MediaType clientMt, EffectiveMediaType serverMt) {
         return b2i(clientMt.isWildcardType() ^ serverMt.isWildcardType())
@@ -85,6 +85,14 @@ final class CombinedMediaType {
     }
 
     /**
+     *  Get combined client/server {@link MediaType}, stripped of q and qs parameters.
+     * @return Combined client/server media type, stripped of q and qs parameters.
+     */
+    public MediaType getCombinedType() {
+        return combinedType;
+    }
+
+    /**
      * Create combined client/server media type.
      *
      * if the two types are not compatible, {@link #NO_MATCH} is returned.
@@ -93,7 +101,7 @@ final class CombinedMediaType {
      * @param serverType server-side media type.
      * @return combined client/server media type.
      */
-    static CombinedMediaType create(MediaType clientType, EffectiveMediaType serverType) {
+    public static CombinedMediaType create(MediaType clientType, EffectiveMediaType serverType) {
         if (!clientType.isCompatible(serverType.getMediaType())) {
             return NO_MATCH;
         }
@@ -112,7 +120,7 @@ final class CombinedMediaType {
      * Comparator used to compare {@link CombinedMediaType}. The comparator sorts the elements of list
      * in the ascending order from the most appropriate to the least appropriate combined media type.
      */
-    static final Comparator<CombinedMediaType> COMPARATOR = new Comparator<CombinedMediaType>() {
+    public static final Comparator<CombinedMediaType> COMPARATOR = new Comparator<CombinedMediaType>() {
 
         @Override
         public int compare(CombinedMediaType c1, CombinedMediaType c2) {
@@ -149,7 +157,7 @@ final class CombinedMediaType {
      * obtained from user annotations {@link Consumes} or {@link Produces} or has no
      * annotation and therefore was derived from {@link MessageBodyWorkers}.
      */
-    static class EffectiveMediaType {
+    public static class EffectiveMediaType {
 
         /**
          * True if the MediaType was not defined by annotation and therefore was
@@ -227,7 +235,7 @@ final class CombinedMediaType {
          * @return {@code true} if the {@code MediaType} was not defined by annotation and therefore was derived from
          * Message Body Providers, {@code false} otherwise.
          */
-        boolean isDerived() {
+        public boolean isDerived() {
             return derived;
         }
 

--- a/core-common/src/main/java/org/glassfish/jersey/internal/routing/ContentTypeDeterminer.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/routing/ContentTypeDeterminer.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.internal.routing;
+
+import org.glassfish.jersey.message.MessageBodyWorkers;
+import org.glassfish.jersey.message.WriterModel;
+import org.glassfish.jersey.message.internal.AcceptableMediaType;
+import org.glassfish.jersey.message.internal.MediaTypes;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * Utility class containing methods used on both client and server side for determining media type of a response based
+ * on provided {@link MessageBodyWorkers}.
+ */
+public class ContentTypeDeterminer {
+
+    protected ContentTypeDeterminer(MessageBodyWorkers workers) {
+        this.workers = workers;
+    }
+
+    protected MessageBodyWorkers workers;
+
+    /**
+     * Determine the {@link MediaType} of the {@link Response} based on writers suitable for the given entity class,
+     * pre-selected method and acceptable media types.
+     *
+     * @param entityClass          entity class to determine the media type for.
+     * @param entityType           entity type for writers.
+     * @param selectedMethod       pre-selected (invoked) method.
+     * @param acceptableMediaTypes acceptable media types from request.
+     * @param methodProducesTypes  media types producible by resource method
+     * @return                     media type of the response.
+     */
+    protected MediaType determineResponseMediaType(
+            final Class<?> entityClass,
+            final Type entityType,
+            final RequestSpecificConsumesProducesAcceptor<?> selectedMethod,
+            final List<AcceptableMediaType> acceptableMediaTypes,
+            final List<MediaType> methodProducesTypes,
+            final Annotation[] handlingMethodAnnotations) {
+
+        // Entity class can be null when considering HEAD method || empty entity.
+        final Class<?> responseEntityClass = entityClass;
+
+        // Applicable entity providers
+        final List<WriterModel> writersForEntityType = workers.getWritersModelsForType(responseEntityClass);
+
+        CombinedMediaType selected = null;
+        for (final MediaType acceptableMediaType : acceptableMediaTypes) {
+            for (final MediaType methodProducesType : methodProducesTypes) {
+                if (!acceptableMediaType.isCompatible(methodProducesType)) {
+                    // no need to go deeper if acceptable and method produces type are incompatible
+                    continue;
+                }
+
+                // Use writers suitable for entity class to determine the media type.
+                for (final WriterModel model : writersForEntityType) {
+                    for (final MediaType writerProduces : model.declaredTypes()) {
+                        if (!writerProduces.isCompatible(acceptableMediaType)
+                                || !methodProducesType.isCompatible(writerProduces)) {
+                            continue;
+                        }
+
+                        final CombinedMediaType.EffectiveMediaType effectiveProduces =
+                                new CombinedMediaType.EffectiveMediaType(
+                                        MediaTypes.mostSpecific(methodProducesType, writerProduces),
+                                        false);
+
+                        final CombinedMediaType candidate =
+                                CombinedMediaType.create(acceptableMediaType, effectiveProduces);
+
+                        if (candidate != CombinedMediaType.NO_MATCH) {
+                            // Look for a better compatible worker.
+                            if (selected == null || CombinedMediaType.COMPARATOR.compare(candidate, selected) < 0) {
+                                if (model.isWriteable(
+                                        responseEntityClass,
+                                        entityType,
+                                        handlingMethodAnnotations,
+                                        candidate.getCombinedType())) {
+                                    selected = candidate;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Found media type for current writer.
+        if (selected != null) {
+            return selected.getCombinedType();
+        }
+
+        // If the media type couldn't be determined, choose pre-selected one and wait whether interceptors change the mediaType
+        // so it can be written.
+        return selectedMethod.getProduces().getCombinedType();
+    }
+}

--- a/core-common/src/main/java/org/glassfish/jersey/internal/routing/RequestSpecificConsumesProducesAcceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/routing/RequestSpecificConsumesProducesAcceptor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.internal.routing;
+
+/**
+ * A {@link Comparable} concrete request content-type, accept header, and a methodRouting triplet
+ *
+ * @see CombinedMediaType
+ */
+@SuppressWarnings("ComparableImplementedButEqualsNotOverridden")
+public final class RequestSpecificConsumesProducesAcceptor<MethodRouting> implements Comparable {
+    private final CombinedMediaType consumes;
+    private final CombinedMediaType produces;
+    private final MethodRouting methodRouting;
+
+    private final boolean producesFromProviders;
+
+    public RequestSpecificConsumesProducesAcceptor(final CombinedMediaType consumes,
+                                            final CombinedMediaType produces,
+                                            final boolean producesFromProviders,
+                                            final MethodRouting methodRouting) {
+
+        this.methodRouting = methodRouting;
+        this.consumes = consumes;
+        this.produces = produces;
+        this.producesFromProviders = producesFromProviders;
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        if (o == null) {
+            return -1;
+        }
+        if (!(o instanceof RequestSpecificConsumesProducesAcceptor)) {
+            return -1;
+        }
+        RequestSpecificConsumesProducesAcceptor other = (RequestSpecificConsumesProducesAcceptor) o;
+        final int consumedComparison = CombinedMediaType.COMPARATOR.compare(consumes, other.consumes);
+        return (consumedComparison != 0)
+                ? consumedComparison : CombinedMediaType.COMPARATOR.compare(produces, other.produces);
+    }
+
+    /**
+     * Get request content type
+     * @return request content type
+     */
+    public CombinedMediaType getConsumes() {
+        return consumes;
+    }
+
+    /**
+     * Get specified method routing
+     * @return method routing
+     */
+    public MethodRouting getMethodRouting() {
+        return methodRouting;
+    }
+
+    /**
+     * Get Accept header media type
+     * @return request accept header
+     */
+    public CombinedMediaType getProduces() {
+        return produces;
+    }
+
+    /**
+     * Information whether {@link #getProduces()} was set by providers}. If not, resource method was annotated by
+     * {@code @Produces}
+     * @return {@code true} if the produces media type was set by providers and not by {@code @Produces} annotation.
+     */
+    public boolean producesFromProviders() {
+        return producesFromProviders;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s->%s:%s", consumes, produces, methodRouting);
+    }
+
+}

--- a/core-common/src/main/java/org/glassfish/jersey/internal/routing/package-info.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/routing/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * Common Jersey internal routing API classes.
+ */
+package org.glassfish.jersey.internal.routing;

--- a/core-common/src/test/java/org/glassfish/jersey/internal/routing/CombinedMediaTypeTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/internal/routing/CombinedMediaTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.jersey.server.internal.routing;
+package org.glassfish.jersey.internal.routing;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
Move media type determination logic from core-server to core-common to be used on both client and server. On the client side, when ClientRequest#abortWith is called, the media type should be determined as the Spec describes

Signed-off-by: Jan Supol <jan.supol@oracle.com>