### PR TITLE
Update JMockit version to 1.44 to support JDK 11

### DIFF
--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/PackageNamesScannerTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/PackageNamesScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,10 +20,8 @@ import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Tested;
 import mockit.Verifications;
-import mockit.integration.junit4.JMockit;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -46,7 +44,6 @@ import static org.junit.Assert.fail;
  * @author Eric Navarro
  * @author Michal Gajdos
  */
-@RunWith(JMockit.class)
 public class PackageNamesScannerTest {
 
     private static final String[] packages = {"javax.ws.rs"};

--- a/core-server/src/test/resources/server.policy
+++ b/core-server/src/test/resources/server.policy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,6 +58,8 @@ grant codebase "file:${project.build.directory}/test-classes/-" {
   permission org.jboss.vfs.VirtualFilePermission "<<ALL FILES>>", "read";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc.*";
+  permission java.lang.RuntimePermission "accessClassInPackage.sun.reflect";
+  permission java.lang.RuntimePermission "reflectionFactoryAccess";
 };
 
 grant codebase "file:${project.build.directory}/classes/-" {

--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,10 @@
                     <version>3.0.0-M3</version>
                     <configuration>
                         <!-- for convenience reasons, 'argLine' should not be overridden in child poms. if needed, a property should be declared and used here -->
-                        <argLine>-Xmx${surefire.maxmem.argline}m -Dfile.encoding=UTF8 ${surefire.security.argline} ${surefire.coverage.argline}</argLine>
+                        <argLine>
+                            -javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit.version}/jmockit-${jmockit.version}.jar
+                            -Xmx${surefire.maxmem.argline}m -Dfile.encoding=UTF8 ${surefire.security.argline} ${surefire.coverage.argline}
+                        </argLine>
                         <skipTests>${skip.tests}</skipTests>
                     </configuration>
                     <dependencies>
@@ -2013,7 +2016,7 @@
         <jetty.version>9.4.12.v20180830</jetty.version>
         <jetty.servlet.api.25.version>6.1.14</jetty.servlet.api.25.version>
         <jmh.version>1.10.2</jmh.version>
-        <jmockit.version>1.41</jmockit.version>
+        <jmockit.version>1.44</jmockit.version>
         <jsonp.ri.version>1.1.5</jsonp.ri.version>
         <jsonp.jaxrs.version>1.1.5</jsonp.jaxrs.version>
         <jsp.version>2.3.5</jsp.version>


### PR DESCRIPTION
JMockit needs -javavagent since 1.42
JMockit does not have @RunWith(JMockit) since 1.43
JMockit does not support java.util mocks since 1.45

Signed-off-by: Jan Supol <jan.supol@oracle.com>