### PR TITLE
Create ServiceHolderImpl with correct service implementation type

### DIFF
--- a/inject/hk2/src/main/java/org/glassfish/jersey/inject/hk2/AbstractHk2InjectionManager.java
+++ b/inject/hk2/src/main/java/org/glassfish/jersey/inject/hk2/AbstractHk2InjectionManager.java
@@ -134,7 +134,7 @@ abstract class AbstractHk2InjectionManager implements InjectionManager {
         return getServiceLocator().getAllServiceHandles(contract, qualifiers).stream()
                 .map(sh -> new ServiceHolderImpl<>(
                         sh.getService(),
-                        (Class<T>) sh.getActiveDescriptor().getImplementationClass(),
+                        (Class<T>) sh.getService().getClass(),
                         sh.getActiveDescriptor().getContractTypes(),
                         sh.getActiveDescriptor().getRanking()))
                 .collect(Collectors.toList());


### PR DESCRIPTION
As described in #4099, `ServiceHolder#getImplementationClass()` sometimes doesn't return the actual implementation class of the service, but `org.glassfish.jersey.inject.hk2.InstanceSupplierFactoryBridge` instead. This leads to the situation that Jersey looks for `@Priority` annotations on the wrong type (detailed description in #4099).

This change fixes the underlying problem and ordering via `@Priority` works fine now. Unforunately I wasn't able to reproduce the issue in an integration test. I guess that's because HK2 behaves differently when deploying a real app to Glassfish.
