### PR TITLE
Added integration test to reproduce #4099

### DIFF
--- a/tests/integration/jersey-4099/pom.xml
+++ b/tests/integration/jersey-4099/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <artifactId>project</artifactId>
+        <version>2.29-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jersey-4099</artifactId>
+    <packaging>war</packaging>
+    <name>jersey-tests-integration-jersey-4099</name>
+
+    <description>JERSEY-4099 - @Priority is not always picked up correctly for JAX-RS providers</description>
+
+    <dependencies>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-bundle</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Jersey modules -->
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-grizzly2-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.cdi</groupId>
+            <artifactId>jersey-weld2-se</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.cdi</groupId>
+            <artifactId>jersey-cdi1x</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyApplication.java
+++ b/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.jersey4099;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.core.Application;
+
+public class MyApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> classes = new HashSet<>();
+        classes.add(MyResource.class);
+        classes.add(MyPriority100Mapper.class);
+        classes.add(MyPriority200Mapper.class);
+        return classes;
+    }
+
+}

--- a/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyException.java
+++ b/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.integration.jersey4099;
+
+public class MyException extends RuntimeException {
+
+    // special exception type thrown from resource and mapped via two exception mappers
+
+}

--- a/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyPriority100Mapper.java
+++ b/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyPriority100Mapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.integration.jersey4099;
+
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * This mapper has a lower priority and should always be selected
+ */
+@Priority(100)
+public class MyPriority100Mapper implements ExceptionMapper<MyException> {
+
+    @Override
+    public Response toResponse(MyException exception) {
+        return Response.ok(this.getClass().getName()).build();
+    }
+
+}

--- a/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyPriority200Mapper.java
+++ b/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyPriority200Mapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.integration.jersey4099;
+
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Mapper with higher priority should lose against the other one
+ */
+@Priority(200)
+public class MyPriority200Mapper implements ExceptionMapper<MyException> {
+
+    @Override
+    public Response toResponse(MyException exception) {
+        return Response.ok(this.getClass().getName()).build();
+    }
+
+}

--- a/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyResource.java
+++ b/tests/integration/jersey-4099/src/main/java/org/glassfish/jersey/tests/integration/jersey4099/MyResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.integration.jersey4099;
+
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@RequestScoped
+@Path("/exception")
+public class MyResource {
+
+    @GET
+    public String get() {
+        throw new MyException();
+    }
+
+}

--- a/tests/integration/jersey-4099/src/main/webapp/WEB-INF/beans.xml
+++ b/tests/integration/jersey-4099/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all" version="2.0">
+
+    <!-- No special configuration required -->
+
+</beans>

--- a/tests/integration/jersey-4099/src/test/java/org/glassfish/jersey/tests/integration/jersey4099/PriorityAnnotationOnExceptionMappersTest.java
+++ b/tests/integration/jersey-4099/src/test/java/org/glassfish/jersey/tests/integration/jersey4099/PriorityAnnotationOnExceptionMappersTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.jersey4099;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.jboss.weld.environment.se.Weld;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class PriorityAnnotationOnExceptionMappersTest extends JerseyTest {
+
+    private Weld weld;
+
+    @Override
+    public void setUp() throws Exception {
+        weld = new Weld();
+        weld.initialize();
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        weld.shutdown();
+    }
+
+    @Override
+    protected ResourceConfig configure() {
+        return ResourceConfig.forApplicationClass(MyApplication.class);
+    }
+
+    @Test
+    public void testCorrectMapperSelectedAccordingToPriorityAnnotation() {
+
+        assertThat(
+                target("/exception").request().get(String.class),
+                containsString("MyPriority100Mapper")  // Prio 100 mapper should win
+        );
+
+    }
+
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -89,6 +89,7 @@
         <module>jersey-780</module>
         <module>jersey-3670</module>
         <module>jersey-3992</module>
+        <module>jersey-4099</module>
         <module>portability-jersey-1</module>
         <module>portability-jersey-2</module>
         <module>property-check</module>


### PR DESCRIPTION
This pull request contains a new integration test which reproduces #4099. Please see #4099 for a detailed description of the problem.

Steps to reproduce:
  * Remove the `@Ignored` annotation in `PriorityAnnotationOnExceptionMappersTest`
  * Run the test a few times
  * You will see that the test randomly passes or fails

Setting a breakpoint here will show the root cause of the problem:

https://github.com/eclipse-ee4j/jersey/blob/895c293e366afce166e508ae9db23f9e4b9b5f80/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java#L363-L371

The method scans `InstanceSupplierFactoryBridge` instead of the actual implementation class for the `@Priority` annotation.
