### PR TITLE
update jax-rs document url and css source url

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -94,8 +94,7 @@
                     <calloutsExtension>true</calloutsExtension>
                     <highlightDefaultLanguage />
                     <highlightSource>true</highlightSource>
-                    <htmlStylesheet>/jersey.github.io/documentation.css</htmlStylesheet>
-                    <!--<htmlStylesheet>https://jersey.java.net/documentation.css</htmlStylesheet>-->
+                    <htmlStylesheet>https://jersey.github.io/documentation.css</htmlStylesheet>
                     <linenumberingExtension>true</linenumberingExtension>
                     <linenumberingEveryNth>1</linenumberingEveryNth>
                     <partAutolabel>true</partAutolabel>

--- a/docs/src/main/docbook/jersey.ent
+++ b/docs/src/main/docbook/jersey.ent
@@ -26,7 +26,7 @@
 <!ENTITY experimentalrepository "snapshots">
 <!ENTITY guava.version "$guava-version">
 <!ENTITY jaxb-api-jar.version "$jaxb-api-jar-version">
-<!ENTITY jax-rs.version "$jax-rs-api-jar-version">
+<!ENTITY jax-rs.version "$jax-rs-version">
 <!ENTITY javax-el.version "$javax-el-version">
 <!ENTITY javax-el-impl.version "$javax-el-impl-version">
 <!ENTITY jax-rs-api-jar.version "$jax-rs-api-jar-version">
@@ -54,7 +54,7 @@
 <!ENTITY jaxb.release.uri "http://jaxb.java.net/nonav/&jaxb-api-jar.version;">
 <!ENTITY jaxb.javadoc.uri "&jaxb.release.uri;/docs/api/javax/xml/bind">
 <!ENTITY jaxrs.release.uri "http://jax-rs-spec.java.net/nonav/&jax-rs.version;">
-<!ENTITY jaxrs.javadoc.uri "https://jersey.github.io/apidocs-javax.jax-rs/&jax-rs.version;/javax/ws/rs">
+<!ENTITY jaxrs.javadoc.uri "https://jax-rs.github.io/apidocs/&jax-rs.version;/javax/ws/rs">
 <!ENTITY jaxrs21.javadoc.uri "#/javax/ws/rs">   <!-- TODO - once we have published javadocs to link here -->
 
 <!ENTITY jersey.ext.bean-validation.deps.link "<link xlink:href='&jersey.project-info.uri.prefix;/jersey-bean-validation/dependencies.html'>jersey-bean-validation</link>" >


### PR DESCRIPTION
- update jax-rs url to `https://jax-rs.github.io/apidocs/<JAX_RS_SPEC_VERSION>/`, which version is `2.1`
- update css url to `https://jersey.github.io/documentation.css`

### Build JavaDoc

```bash
cd docs
mvn package
```

- Open `target/docbook/index/jaxrs-resources.html` in browser.
- The CSS style and the link of `@Path`, `@GET`, `@PUT`, `@POST`, `@DELETE`, and so on will be correct.