### PR TITLE
Add Support to set useSystemProperties

### DIFF
--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
@@ -134,6 +134,8 @@ public final class ApacheClientProperties {
      */
     public static final String RETRY_HANDLER = "jersey.config.apache.client.retryHandler";
 
+    public static final String USE_SYSTEM_PROPERTIES = "jersey.config.apache.client.useSystemProperties";
+
     /**
      * Get the value of the specified property.
      *

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -280,6 +280,13 @@ class ApacheConnector implements Connector {
             this.cookieStore = null;
         }
         clientBuilder.setDefaultRequestConfig(requestConfig);
+
+        final boolean useSystemProperties = PropertiesHelper
+                .isProperty(config.getProperties(), ApacheClientProperties.USE_SYSTEM_PROPERTIES);
+        if (useSystemProperties) {
+            clientBuilder.useSystemProperties();
+        }
+
         this.client = clientBuilder.build();
     }
 


### PR DESCRIPTION
I'd like to gauge interest in a change like this. This gives users of the `ApacheConnectorProvider` class the ability to set `useSystemProperties` on the `HttpClientBuilder` class in `ApacheConnector`. This is achieved like the existing hooks by adding a new property to `ApacheClientProperties`.

Let me know if there is interest and I can include some javadocs and any necessary tests you guys recommend.