### PR TITLE
Support for JAX-RS 2.2's hasProperties method

### DIFF
--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyHttp2ServerHandler.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyHttp2ServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -131,6 +131,11 @@ class JerseyHttp2ServerHandler extends ChannelDuplexHandler {
                 new PropertiesDelegate() {
 
                     private final Map<String, Object> properties = new HashMap<>();
+
+                    @Override
+                    public boolean hasProperty(final String name) {
+                        return properties.containsKey(name);
+                    }
 
                     @Override
                     public Object getProperty(String name) {

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -125,6 +125,11 @@ class JerseyServerHandler extends ChannelInboundHandlerAdapter {
                 new PropertiesDelegate() {
 
                     private final Map<String, Object> properties = new HashMap<>();
+
+                    @Override
+                    public boolean hasProperty(final String name) {
+                        return properties.containsKey(name);
+                    }
 
                     @Override
                     public Object getProperty(String name) {

--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -322,6 +322,11 @@ public class ClientConfig implements Configurable<ClientConfig>, ExtendedConfig 
         @Override
         public Map<String, Object> getProperties() {
             return commonConfig.getConfiguration().getProperties();
+        }
+
+        @Override
+        public boolean hasProperty(final String name) {
+            return commonConfig.getConfiguration().hasProperty(name);
         }
 
         @Override

--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientRequest.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -177,6 +177,11 @@ public class ClientRequest extends OutboundMessageContext implements ClientReque
         }
 
         return (result == null) ? null : PropertiesHelper.convertValue(result, type);
+    }
+
+    @Override
+    public boolean hasProperty(final String name) {
+        return propertiesDelegate.hasProperty(name);
     }
 
     @Override

--- a/core-client/src/test/java/org/glassfish/jersey/client/ClientConfigTest.java
+++ b/core-client/src/test/java/org/glassfish/jersey/client/ClientConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -101,6 +101,13 @@ public class ClientConfigTest {
         } catch (UnsupportedOperationException ex) {
             // ok
         }
+    }
+
+    @Test
+    public void testHasProperty() {
+        ClientConfig instance = new ClientConfig().property("name", "value");
+        assertTrue(instance.hasProperty("name"));
+        assertFalse(instance.hasProperty("other"));
     }
 
     @Test

--- a/core-client/src/test/java/org/glassfish/jersey/client/ClientRequestTest.java
+++ b/core-client/src/test/java/org/glassfish/jersey/client/ClientRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,6 +85,9 @@ public class ClientRequestTest {
         assertFalse(request.getConfiguration().getPropertyNames().contains("name"));
         assertFalse(request.getPropertyNames().contains("name"));
 
+        assertFalse(request.getConfiguration().hasProperty("name"));
+        assertFalse(request.hasProperty("name"));
+
         assertNull(request.getConfiguration().getProperty("name"));
         assertNull(request.getProperty("name"));
 
@@ -101,6 +104,9 @@ public class ClientRequestTest {
 
         assertTrue(request.getConfiguration().getPropertyNames().contains("name"));
         assertFalse(request.getPropertyNames().contains("name"));
+
+        assertTrue(request.getConfiguration().hasProperty("name"));
+        assertFalse(request.hasProperty("name"));
 
         assertEquals("value-global", request.getConfiguration().getProperty("name"));
         assertNull(request.getProperty("name"));
@@ -120,6 +126,9 @@ public class ClientRequestTest {
         assertFalse(request.getConfiguration().getPropertyNames().contains("name"));
         assertTrue(request.getPropertyNames().contains("name"));
 
+        assertFalse(request.getConfiguration().hasProperty("name"));
+        assertTrue(request.hasProperty("name"));
+
         assertNull(request.getConfiguration().getProperty("name"));
         assertEquals("value-request", request.getProperty("name"));
 
@@ -137,6 +146,9 @@ public class ClientRequestTest {
 
         assertTrue(request.getConfiguration().getPropertyNames().contains("name"));
         assertTrue(request.getPropertyNames().contains("name"));
+
+        assertTrue(request.getConfiguration().hasProperty("name"));
+        assertTrue(request.hasProperty("name"));
 
         assertEquals("value-global", request.getConfiguration().getProperty("name"));
         assertEquals("value-request", request.getProperty("name"));

--- a/core-common/src/main/java/org/glassfish/jersey/internal/MapPropertiesDelegate.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/MapPropertiesDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,6 +61,11 @@ public final class MapPropertiesDelegate implements PropertiesDelegate {
                 this.store.put(name, that.getProperty(name));
             }
         }
+    }
+
+    @Override
+    public boolean hasProperty(final String name) {
+        return store.containsKey(name);
     }
 
     @Override

--- a/core-common/src/main/java/org/glassfish/jersey/internal/PropertiesDelegate.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/PropertiesDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,21 @@ public interface PropertiesDelegate {
      */
     public Object getProperty(String name);
 
+    /**
+     * Returns {@code true} if the property with the given name registered in the current request/response
+     * exchange context, or {@code false} if there is no property by that name.
+     * <p>
+     * Use the {@link #getProperty} method with a property name to get the value of
+     * a property.
+     * </p>
+     *
+     * @return {@code true} if a property matching the given name exists, or
+     *         {@code false} otherwise.
+     * @see #getProperty
+     */
+    public default boolean hasProperty(String name) {
+        return getProperty(name) != null;
+    }
 
     /**
      * Returns an immutable {@link java.util.Collection collection} containing the property

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/InterceptorExecutor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/InterceptorExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -86,6 +86,11 @@ abstract class InterceptorExecutor<T> implements InterceptorContext, PropertiesD
         this.mediaType = mediaType;
         this.propertiesDelegate = propertiesDelegate;
         this.tracingLogger = TracingLogger.getInstance(propertiesDelegate);
+    }
+
+    @Override
+    public boolean hasProperty(final String name) {
+        return propertiesDelegate.hasProperty(name);
     }
 
     @Override

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/TracingAwarePropertiesDelegate.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/TracingAwarePropertiesDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,6 +56,14 @@ public final class TracingAwarePropertiesDelegate implements PropertiesDelegate 
             tracingLogger = (TracingLogger) object;
         }
         propertiesDelegate.setProperty(name, object);
+    }
+
+    @Override
+    public boolean hasProperty(final String name) {
+        if (tracingLogger != null && TracingLogger.PROPERTY_NAME.equals(name)) {
+            return true;
+        }
+        return propertiesDelegate.hasProperty(name);
     }
 
     @Override

--- a/core-server/src/main/java/org/glassfish/jersey/server/ContainerRequest.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ContainerRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -245,6 +245,11 @@ public class ContainerRequest extends InboundMessageContext
      */
     public <T> T readEntity(final Class<T> rawType, final Type type, final Annotation[] annotations) {
         return super.readEntity(rawType, type, annotations, propertiesDelegate);
+    }
+
+    @Override
+    public boolean hasProperty(final String name) {
+        return propertiesDelegate.hasProperty(name);
     }
 
     @Override

--- a/core-server/src/main/java/org/glassfish/jersey/server/ResourceConfig.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ResourceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -725,6 +725,11 @@ public class ResourceConfig extends Application implements Configurable<Resource
     @Override
     public final Map<String, Object> getProperties() {
         return state.getProperties();
+    }
+
+    @Override
+    public final boolean hasProperty(final String name) {
+        return state.hasProperty(name);
     }
 
     @Override

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/RuntimeDelegateImpl.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/RuntimeDelegateImpl.java
@@ -120,7 +120,17 @@ public class RuntimeDelegateImpl extends AbstractRuntimeDelegate {
 
             @Override
             public final JAXRS.Configuration build() {
-                return this.properties::get;
+                return new JAXRS.Configuration() {
+                    @Override
+                    public final boolean hasProperty(final String name) {
+                        return properties.containsKey(name);
+                    }
+
+                    @Override
+                    public final Object property(final String name) {
+                        return properties.get(name);
+                    }
+                };
             }
         };
     }
@@ -138,14 +148,28 @@ public class RuntimeDelegateImpl extends AbstractRuntimeDelegate {
 
                 @Override
                 public final Configuration configuration() {
-                    return name -> {
-                        switch (name) {
-                        case JAXRS.Configuration.PORT:
-                            return server.port();
-                        case ServerProperties.HTTP_SERVER_CLASS:
-                            return server.getClass();
-                        default:
-                            return configuration.property(name);
+                    return new Configuration() {
+                        @Override
+                        public final boolean hasProperty(final String name) {
+                            switch (name) {
+                            case JAXRS.Configuration.PORT:
+                            case ServerProperties.HTTP_SERVER_CLASS:
+                                return true;
+                            default:
+                                return configuration.hasProperty(name);
+                            }
+                        }
+
+                        @Override
+                        public final Object property(final String name) {
+                            switch (name) {
+                            case JAXRS.Configuration.PORT:
+                                return server.port();
+                            case ServerProperties.HTTP_SERVER_CLASS:
+                                return server.getClass();
+                            default:
+                                return configuration.property(name);
+                            }
                         }
                     };
                 }

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/RuntimeDelegateImplTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/RuntimeDelegateImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package org.glassfish.jersey.server.internal;
 
 import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -41,6 +42,8 @@ import javax.ws.rs.JAXRS.Configuration;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.ext.RuntimeDelegate;
 
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
 import org.glassfish.jersey.internal.ServiceFinder;
 import org.glassfish.jersey.internal.ServiceFinder.ServiceIteratorProvider;
 import org.glassfish.jersey.server.ServerProperties;
@@ -106,6 +109,12 @@ public class RuntimeDelegateImplTest {
 
         // then
         assertThat(configuration, is(notNullValue()));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PROTOCOL));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.HOST));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PORT));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.ROOT_PATH));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CONTEXT));
         assertThat(configuration.property(JAXRS.Configuration.PROTOCOL), is("HTTP"));
         assertThat(configuration.property(JAXRS.Configuration.HOST), is("localhost"));
         assertThat(configuration.property(JAXRS.Configuration.PORT), is(JAXRS.Configuration.DEFAULT_PORT));
@@ -131,6 +140,7 @@ public class RuntimeDelegateImplTest {
 
         // then
         assertThat(configuration, is(notNullValue()));
+        assertThat(configuration, hasProperty("property"));
         assertThat(configuration.property("property"), is("value"));
     }
 
@@ -150,6 +160,12 @@ public class RuntimeDelegateImplTest {
 
         // then
         assertThat(configuration, is(notNullValue()));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PROTOCOL));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.HOST));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PORT));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.ROOT_PATH));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CONTEXT));
         assertThat(configuration.protocol(), is("HTTPS"));
         assertThat(configuration.host(), is("hostname"));
         assertThat(configuration.port(), is(8080));
@@ -171,6 +187,12 @@ public class RuntimeDelegateImplTest {
 
         // then
         assertThat(configuration, is(notNullValue()));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PROTOCOL));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.HOST));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PORT));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.ROOT_PATH));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CONTEXT));
         assertThat(configuration.protocol(), is("HTTPS"));
         assertThat(configuration.host(), is("hostname"));
         assertThat(configuration.port(), is(8080));
@@ -218,6 +240,14 @@ public class RuntimeDelegateImplTest {
 
         // then
         assertThat(configuration, is(notNullValue()));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PROTOCOL));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.HOST));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PORT));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.ROOT_PATH));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CONTEXT));
+        assertThat(configuration, hasProperty(ServerProperties.HTTP_SERVER_CLASS));
+        assertThat(configuration, hasProperty(ServerProperties.AUTO_START));
         assertThat(configuration.protocol(), is("HTTPS"));
         assertThat(configuration.host(), is("hostname"));
         assertThat(configuration.port(), is(8080));
@@ -315,6 +345,13 @@ public class RuntimeDelegateImplTest {
         // then
         assertThat(instance, is(notNullValue()));
         assertThat(configuration, is(notNullValue()));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PROTOCOL));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.HOST));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.PORT));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.ROOT_PATH));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CLIENT_AUTHENTICATION));
+        assertThat(configuration, hasProperty(JAXRS.Configuration.SSL_CONTEXT));
+        assertThat(configuration, hasProperty(ServerProperties.HTTP_SERVER_CLASS));
         assertThat(configuration.protocol(), is("HTTPS"));
         assertThat(configuration.host(), is("hostname"));
         assertThat(configuration.port(), is(8888));
@@ -332,4 +369,21 @@ public class RuntimeDelegateImplTest {
         ServiceFinder.setIteratorProvider(null);
     }
 
+   /**
+    * Creates a matcher that matches any examined object whose <code>hasProperty</code> method
+    * returns {@code true} for the provided property name.
+    * For example:
+    * <pre>assertThat(configuration, hasProperty("HOST"))</pre>
+    *
+    * @param propertyName
+    *     the property name to check
+    */
+    private static final Matcher<Configuration> hasProperty(final String propertyName) {
+        return new FeatureMatcher<Configuration, Boolean>(is(TRUE), "hasProperty", "hasProperty") {
+            @Override
+            protected final Boolean featureValueOf(final Configuration actual) {
+                return actual.hasProperty(propertyName);
+            }
+        };
+    }
 }


### PR DESCRIPTION
This PR provides support for the new `#hasProperties(String)` method introduced by JAX-RS 2.2.

The code changes allow potential performance improvements by directly accessing the underlying key set's retrieval method (where applicable) instead of pulling the actual property value. While the effect typically is not dramatic, this might be at least slightly faster in some use cases.