### PR TITLE
Support for JAX-RS Extensions

### DIFF
--- a/incubator/jaxrs-extension/pom.xml
+++ b/incubator/jaxrs-extension/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Markus KARG. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.jersey.incubator</groupId>
+        <artifactId>project</artifactId>
+        <version>2.29-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.glassfish.jersey.spi</groupId>
+    <artifactId>jersey-spi-jaxrs-extension</artifactId>
+    <name>jersey-spi-jaxrs-extension</name>
+
+    <description>
+        Automatically loads JAX-RS components implementing the JAX-RS Extension interface.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/incubator/jaxrs-extension/src/main/java/org/glassfish/jersey/internal/spi/JaxRsExtensions.java
+++ b/incubator/jaxrs-extension/src/main/java/org/glassfish/jersey/internal/spi/JaxRsExtensions.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Markus KARG. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.internal.spi;
+
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Extension;
+
+import org.glassfish.jersey.internal.ServiceFinder;
+
+/**
+ * This component enables support for {@link Extension JAX-RS extensions}.
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ */
+public final class JaxRsExtensions implements ForcedAutoDiscoverable {
+
+    @Override
+    public final void configure(final FeatureContext context) {
+        for (final Class<?> serviceClass : ServiceFinder.find(Extension.class, true).toClassArray()) {
+            if (!context.getConfiguration().isRegistered(serviceClass)) {
+                context.register(serviceClass);
+            }
+        }
+    }
+
+}

--- a/incubator/jaxrs-extension/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable
+++ b/incubator/jaxrs-extension/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable
@@ -1,0 +1,1 @@
+org.glassfish.jersey.internal.spi.JaxRsExtensions

--- a/incubator/pom.xml
+++ b/incubator/pom.xml
@@ -41,6 +41,7 @@
         <module>html-json</module>
         <module>kryo</module>
         <module>open-tracing</module>
+        <module>jaxrs-extension</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
**This draft is a work in progress aiming at support for JAX-RS 2.2's new `javax.ws.rs.ext.Extension` interface in Jersey 2.30.**

The draft PR serves to host the discussion about *how* the implementation should be designed. Possible choices could be:
1. As a standalone module, as currently showcased by the new incubator module demonstrated by this draft PR. *This would be most simple as it is almost done, but it does not feel like making it a first class Jersey citizen.*
2. Replacing the existing `ForcedAutoDiscoverable` interface everywhere in the code by the new `javax.ws.rs.ext.Extension`.
3. Adding it *additionally* to `ForcedAutoDiscoverable` in the existing code as a third code path besides handling `AutoDiscoverable` and `ForcedAutoDiscoverable`.
4. ...others...

Please discuss the design of choice. I would be happy to provide an according implementation.