### PR TITLE
Changes to support the upcoming JAX-RS 2.2 API.

### DIFF
--- a/containers/jdk-http/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/containers/jdk-http/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.glassfish.jersey.server.internal.RuntimeDelegateImpl

--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/JerseyPublisher.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/JerseyPublisher.java
@@ -45,6 +45,8 @@ public class JerseyPublisher<T> implements Flow.Publisher<T> {
 
     private final PublisherStrategy strategy;
 
+    private boolean cascadingClose;
+
     /**
      * Creates a new JerseyPublisher using the {@link ForkJoinPool#commonPool()} for async delivery to subscribers
      * (unless it does not support a parallelism level of at least two, in which case, a new Thread is created to run
@@ -315,6 +317,17 @@ public class JerseyPublisher<T> implements Flow.Publisher<T> {
      * completed.
      */
     public void close() {
+        close(true);
+    }
+
+    /**
+     * Same as {@link #close()} but with control as to whether registered subscribers should be
+     * closed or not.
+     *
+     * @param cascading Boolean controlling whether to close subscribers or not.
+     */
+    public void close(boolean cascading) {
+        cascadingClose = cascading;
         submissionPublisher.close();
     }
 
@@ -364,7 +377,7 @@ public class JerseyPublisher<T> implements Flow.Publisher<T> {
         return submissionPublisher.getMaxBufferCapacity();
     }
 
-    public static class SubscriberWrapper<T> implements Flow.Subscriber<T> {
+    public class SubscriberWrapper<T> implements Flow.Subscriber<T> {
         private Flow.Subscriber<? super T> subscriber;
         private Flow.Subscription subscription = null;
 
@@ -400,7 +413,10 @@ public class JerseyPublisher<T> implements Flow.Publisher<T> {
 
         @Override
         public void onComplete() {
-            subscriber.onComplete();
+            // Propagate only when cascadingClose is true
+            if (cascadingClose) {
+                subscriber.onComplete();
+            }
         }
 
         public Flow.Subscriber<? super T> getWrappedSubscriber() {

--- a/core-common/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/core-common/src/main/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.glassfish.jersey.internal.RuntimeDelegateImpl

--- a/core-common/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/core-common/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.glassfish.jersey.internal.RuntimeDelegateImpl

--- a/core-common/src/test/resources/META-INF/services/org.glassfish.jersey.internal.spi.AutoDiscoverable
+++ b/core-common/src/test/resources/META-INF/services/org.glassfish.jersey.internal.spi.AutoDiscoverable
@@ -1,0 +1,1 @@
+org.glassfish.jersey.logging.LoggingFeatureAutoDiscoverable

--- a/examples/extended-wadl-webapp/src/test/java/org/glassfish/jersey/examples/extendedwadl/ExtendedWadlWebappOsgiTest.java
+++ b/examples/extended-wadl-webapp/src/test/java/org/glassfish/jersey/examples/extendedwadl/ExtendedWadlWebappOsgiTest.java
@@ -79,6 +79,7 @@ public class ExtendedWadlWebappOsgiTest {
     BundleContext bundleContext;
 
     private static final Logger LOGGER = Logger.getLogger(ExtendedWadlWebappOsgiTest.class.getName());
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
 
     // we want to re-use the port number as set for Jersey test container to avoid CT port number clashes
     private static final String testContainerPort = System.getProperty(TestProperties.CONTAINER_PORT);
@@ -95,6 +96,7 @@ public class ExtendedWadlWebappOsgiTest {
         List<Option> options = Arrays.asList(options(
                 // systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("FINEST"),
                 systemProperty("org.osgi.framework.system.packages.extra").value("jakarta.annotation"),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl"),
 
                 // javax.annotation must go first!
                 mavenBundle().groupId("jakarta.annotation").artifactId("jakarta.annotation-api").versionAsInProject(),

--- a/examples/helloworld/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/examples/helloworld/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.glassfish.jersey.internal.RuntimeDelegateImpl

--- a/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/WebAppFelixTest.java
+++ b/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/WebAppFelixTest.java
@@ -27,20 +27,22 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerSuite;
 import static org.junit.Assert.assertEquals;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
 public class WebAppFelixTest extends AbstractWebAppTest {
 
     private static final Logger LOGGER = Logger.getLogger(WebAppFelixTest.class.getName());
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
 
     @Override
     public List<Option> osgiRuntimeOptions() {
         return Arrays.asList(CoreOptions.options(
                 mavenBundle()
                         .groupId("org.apache.felix").artifactId("org.apache.felix.eventadmin")
-                        .versionAsInProject()
-        )
+                        .versionAsInProject(),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl"))
         );
     }
 

--- a/examples/osgi-http-service/functional-test/src/test/java/org/glassfish/jersey/examples/osgihttpservice/test/AbstractHttpServiceTest.java
+++ b/examples/osgi-http-service/functional-test/src/test/java/org/glassfish/jersey/examples/osgihttpservice/test/AbstractHttpServiceTest.java
@@ -65,6 +65,7 @@ public abstract class AbstractHttpServiceTest {
     private static final String CONTEXT = "/jersey-http-service";
     private static final URI baseUri = UriBuilder.fromUri("http://localhost").port(port).path(CONTEXT).build();
     private static final String BundleLocationProperty = "jersey.bundle.location";
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
 
     private static final Logger LOGGER = Logger.getLogger(AbstractHttpServiceTest.class.getName());
 
@@ -84,6 +85,7 @@ public abstract class AbstractHttpServiceTest {
                 systemProperty(BundleLocationProperty).value(bundleLocation),
                 systemProperty("jersey.config.test.container.port").value(String.valueOf(port)),
                 systemProperty("org.osgi.framework.system.packages.extra").value("jakarta.annotation"),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl"),
 
                 // do not remove the following line
                 // systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("FINEST"),

--- a/tests/e2e/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/tests/e2e/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.glassfish.jersey.internal.RuntimeDelegateImpl

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/ApacheOsgiIntegrationTest.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/ApacheOsgiIntegrationTest.java
@@ -41,6 +41,7 @@ import org.ops4j.pax.exam.junit.PaxExam;
 
 import static org.junit.Assert.assertEquals;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 
 /**
  * @author Adam Lindenthal (adam.lindenthal at oracle.com)
@@ -49,6 +50,7 @@ import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 public class ApacheOsgiIntegrationTest {
 
     private static final URI baseUri = UriBuilder.fromUri("http://localhost").port(Helper.getPort()).path("/jersey").build();
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
 
     @Configuration
     public static Option[] configuration() {
@@ -58,9 +60,9 @@ public class ApacheOsgiIntegrationTest {
                 mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpcore-osgi").versionAsInProject(),
                 mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpclient-osgi").versionAsInProject(),
                 mavenBundle().groupId("org.glassfish.jersey.connectors").artifactId("jersey-apache-connector")
-                        .versionAsInProject()
-
-        ));
+                        .versionAsInProject(),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl")
+                ));
         return Helper.asArray(options);
     }
 

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/util/Helper.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/util/Helper.java
@@ -45,6 +45,11 @@ public class Helper {
     private static final int port = getEnvVariable(TestProperties.CONTAINER_PORT, 8080);
 
     /**
+     * JAX-RS delegate property.
+     */
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
+
+    /**
      * Returns an integer value of given system property, or a default value
      * as defined by the other method parameter, if the system property can
      * not be used.
@@ -127,6 +132,7 @@ public class Helper {
                 systemProperty("org.osgi.service.http.port").value(String.valueOf(port)),
                 systemProperty(TestProperties.CONTAINER_PORT).value(String.valueOf(port)),
                 systemProperty("org.osgi.framework.system.packages.extra").value("javax.annotation"),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl"),
 
                 // javax.annotation has to go first!
                 mavenBundle().groupId("jakarta.annotation").artifactId("jakarta.annotation-api").versionAsInProject(),

--- a/tests/osgi/functional/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/tests/osgi/functional/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+org.glassfish.jersey.internal.RuntimeDelegateImpl


### PR DESCRIPTION
Removal of default runtime delegate and new close(boolean) method in SSE API.

(From branch JAXRS_2_2, cherry-pick 10b22cbca153737d00c0b0e02f302712a00565cc)