### PR TITLE
Fix 4147: ASM7 in AnnotationAcceptingListener.AnnotatedClassVisitor

### DIFF
--- a/core-server/src/main/java/jersey/repackaged/org/objectweb/asm/ClassReader.java
+++ b/core-server/src/main/java/jersey/repackaged/org/objectweb/asm/ClassReader.java
@@ -30,6 +30,7 @@ package jersey.repackaged.org.objectweb.asm;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.logging.Logger;
 
 /**
  * A parser to make a {@link ClassVisitor} visit a ClassFile structure, as defined in the Java
@@ -42,6 +43,8 @@ import java.io.InputStream;
  * @author Eugene Kuleshov
  */
 public class ClassReader {
+
+  private static final Logger LOGGER = Logger.getLogger(ClassReader.class.getName());
 
   /**
    * A flag to skip the Code attributes. If this flag is set the Code attributes are neither parsed
@@ -190,7 +193,10 @@ public class ClassReader {
     this.b = classFileBuffer;
     // Check the class' major_version. This field is after the magic and minor_version fields, which
     // use 4 and 2 bytes respectively.
-    if (checkClassVersion && readShort(classFileOffset + 6) > Opcodes.V13) {
+    if (checkClassVersion && readShort(classFileOffset + 6) == Opcodes.V14) {
+      LOGGER.warning("Unsupported class file major version " + readShort(classFileOffset + 6));
+    }
+    if (checkClassVersion && readShort(classFileOffset + 6) > Opcodes.V14) {
       throw new IllegalArgumentException(
           "Unsupported class file major version " + readShort(classFileOffset + 6));
     }

--- a/core-server/src/main/java/jersey/repackaged/org/objectweb/asm/Opcodes.java
+++ b/core-server/src/main/java/jersey/repackaged/org/objectweb/asm/Opcodes.java
@@ -269,6 +269,7 @@ public interface Opcodes {
   int V11 = 0 << 16 | 55;
   int V12 = 0 << 16 | 56;
   int V13 = 0 << 16 | 57;
+  int V14 = 0 << 16 | 58;
 
   /**
    * Version flag indicating that the class is using 'preview' features.

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/AnnotationAcceptingListener.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/AnnotationAcceptingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -38,7 +38,9 @@ import jersey.repackaged.org.objectweb.asm.ClassReader;
 import jersey.repackaged.org.objectweb.asm.ClassVisitor;
 import jersey.repackaged.org.objectweb.asm.FieldVisitor;
 import jersey.repackaged.org.objectweb.asm.MethodVisitor;
+import jersey.repackaged.org.objectweb.asm.ModuleVisitor;
 import jersey.repackaged.org.objectweb.asm.Opcodes;
+import jersey.repackaged.org.objectweb.asm.TypePath;
 
 /**
  * A scanner listener that processes Java class files (resource names
@@ -164,7 +166,7 @@ public final class AnnotationAcceptingListener implements ResourceProcessor {
         private boolean isAnnotated;
 
         private AnnotatedClassVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         public void visit(final int version, final int access, final String name,
@@ -225,6 +227,25 @@ public final class AnnotationAcceptingListener implements ResourceProcessor {
                                          final String string0, final String string1,
                                          final String[] string2) {
             // Do nothing
+            return null;
+        }
+
+        public ModuleVisitor visitModule(final String name, final int access, final String version) {
+            // Do nothing
+            return null;
+        }
+
+        public void visitNestHost(final String nestHost) {
+            // do nothing
+        }
+
+        public void visitNestMember(final String nestMember) {
+            // do nothing
+        }
+
+        public AnnotationVisitor visitTypeAnnotation(
+                final int typeRef, final TypePath typePath, final String descriptor, final boolean visible) {
+            //do nothing
             return null;
         }
 

--- a/tests/integration/asm/pom.xml
+++ b/tests/integration/asm/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <version>2.29-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>asm</artifactId>
+    <name>jersey-asm-integration</name>
+    <description>
+        Controls a new version of ASM being repackaged does not break Jersey
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tests/integration/asm/src/test/java/org/glassfish/jersey/integration/asm/AnnotatedClassVisitorTest.java
+++ b/tests/integration/asm/src/test/java/org/glassfish/jersey/integration/asm/AnnotatedClassVisitorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.integration.asm;
+
+import jersey.repackaged.org.objectweb.asm.ClassVisitor;
+import org.glassfish.jersey.server.internal.scanning.AnnotationAcceptingListener;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+public class AnnotatedClassVisitorTest {
+
+    @Test
+    public void testInheritedMethodsFromClassVisitor() {
+        Class<?> annotatedClassVisitorClass = null;
+        final Class<?> classVisitorClass = ClassVisitor.class;
+
+        final Class<?>[] listenerClasses = AnnotationAcceptingListener.class.getDeclaredClasses();
+
+        for (Class<?> c : listenerClasses) {
+            if (c.getName().contains("AnnotatedClassVisitor")) {
+                annotatedClassVisitorClass = c;
+                break;
+            }
+        }
+
+        final List<Method> classVisitorMethods = Arrays.asList(classVisitorClass.getDeclaredMethods());
+        final List<Method> annotatedClassVisitorMethods = Arrays.asList(annotatedClassVisitorClass.getDeclaredMethods());
+        boolean containsAllMethods = true;
+        for (Method classVisitorMethod : classVisitorMethods) {
+            boolean foundClassVisitorMethod = false;
+            for (Method annotatedClassVisitorMethod : annotatedClassVisitorMethods) {
+                if (annotatedClassVisitorMethod.getName().equals(classVisitorMethod.getName())
+                        && annotatedClassVisitorMethod.getReturnType() == classVisitorMethod.getReturnType()
+                        && annotatedClassVisitorMethod.getParameterCount() == classVisitorMethod.getParameterCount()) {
+                    final Class<?>[] annotatedClassVisitorTypes = annotatedClassVisitorMethod.getParameterTypes();
+                    final Class<?>[] classVisitorTypes = classVisitorMethod.getParameterTypes();
+                    boolean typesMatch = true;
+                    for (int i = 0; i != annotatedClassVisitorTypes.length; i++) {
+                        if (annotatedClassVisitorTypes[i] != classVisitorTypes[i]) {
+                            typesMatch = false;
+                            break;
+                        }
+                    }
+                    if (typesMatch) {
+                        foundClassVisitorMethod = true;
+                        //System.out.println("found method " + classVisitorMethod.getName());
+                        break;
+                    }
+                }
+            }
+            if (!foundClassVisitorMethod) {
+                containsAllMethods = false;
+                System.out.append("Method ")
+                        .append(classVisitorMethod.getName())
+                        .println(" not implemented by AnnotationAcceptingListener.AnnotatedClassVisitor");
+            }
+        }
+        Assert.assertThat(containsAllMethods, Matchers.is(true));
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -33,6 +33,7 @@
     <name>jersey-tests-integration</name>
 
     <modules>
+        <module>asm</module>
         <module>async-jersey-filter</module>
         <module>cdi-beanvalidation-webapp</module>
         <module>cdi-ejb-test-webapp</module>


### PR DESCRIPTION
Added test for check of new ASM ClassVisitor methods
Allow for ASM inspecting JDK 14 classes and files a warning, an exception is thrown for JDK 15

Signed-off-by: Jan Supol <jan.supol@oracle.com>