### PR TITLE
prepare jersey (2.30) to be ready to work as JAXRS impl without default 

### DIFF
--- a/core-client/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/core-client/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder

--- a/core-client/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/core-client/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder

--- a/examples/extended-wadl-webapp/src/test/java/org/glassfish/jersey/examples/extendedwadl/ExtendedWadlWebappOsgiTest.java
+++ b/examples/extended-wadl-webapp/src/test/java/org/glassfish/jersey/examples/extendedwadl/ExtendedWadlWebappOsgiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -79,6 +79,8 @@ public class ExtendedWadlWebappOsgiTest {
     BundleContext bundleContext;
 
     private static final Logger LOGGER = Logger.getLogger(ExtendedWadlWebappOsgiTest.class.getName());
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
+    private static final String JAXRS_CLIENT_BUILDER = "javax.ws.rs.client.ClientBuilder";
 
     // we want to re-use the port number as set for Jersey test container to avoid CT port number clashes
     private static final String testContainerPort = System.getProperty(TestProperties.CONTAINER_PORT);
@@ -95,6 +97,8 @@ public class ExtendedWadlWebappOsgiTest {
         List<Option> options = Arrays.asList(options(
                 // systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("FINEST"),
                 systemProperty("org.osgi.framework.system.packages.extra").value("jakarta.annotation"),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl"),
+                systemProperty(JAXRS_CLIENT_BUILDER).value("org.glassfish.jersey.client.JerseyClientBuilder"),
 
                 // javax.annotation must go first!
                 mavenBundle().groupId("jakarta.annotation").artifactId("jakarta.annotation-api").versionAsInProject(),

--- a/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/WebAppFelixTest.java
+++ b/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/WebAppFelixTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -27,20 +27,24 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerSuite;
 import static org.junit.Assert.assertEquals;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerSuite.class)
 public class WebAppFelixTest extends AbstractWebAppTest {
 
     private static final Logger LOGGER = Logger.getLogger(WebAppFelixTest.class.getName());
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
+    private static final String JAXRS_CLIENT_BUILDER = "javax.ws.rs.client.ClientBuilder";
 
     @Override
     public List<Option> osgiRuntimeOptions() {
         return Arrays.asList(CoreOptions.options(
                 mavenBundle()
                         .groupId("org.apache.felix").artifactId("org.apache.felix.eventadmin")
-                        .versionAsInProject()
-        )
+                        .versionAsInProject(),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl"),
+                systemProperty(JAXRS_CLIENT_BUILDER).value("org.glassfish.jersey.client.JerseyClientBuilder"))
         );
     }
 

--- a/examples/osgi-http-service/functional-test/src/test/java/org/glassfish/jersey/examples/osgihttpservice/test/AbstractHttpServiceTest.java
+++ b/examples/osgi-http-service/functional-test/src/test/java/org/glassfish/jersey/examples/osgihttpservice/test/AbstractHttpServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -65,6 +65,8 @@ public abstract class AbstractHttpServiceTest {
     private static final String CONTEXT = "/jersey-http-service";
     private static final URI baseUri = UriBuilder.fromUri("http://localhost").port(port).path(CONTEXT).build();
     private static final String BundleLocationProperty = "jersey.bundle.location";
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
+    private static final String JAXRS_CLIENT_BUILDER = "javax.ws.rs.client.ClientBuilder";
 
     private static final Logger LOGGER = Logger.getLogger(AbstractHttpServiceTest.class.getName());
 
@@ -84,6 +86,8 @@ public abstract class AbstractHttpServiceTest {
                 systemProperty(BundleLocationProperty).value(bundleLocation),
                 systemProperty("jersey.config.test.container.port").value(String.valueOf(port)),
                 systemProperty("org.osgi.framework.system.packages.extra").value("jakarta.annotation"),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl"),
+                systemProperty(JAXRS_CLIENT_BUILDER).value("org.glassfish.jersey.client.JerseyClientBuilder"),
 
                 // do not remove the following line
                 // systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("FINEST"),

--- a/examples/server-sent-events-jaxrs/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/examples/server-sent-events-jaxrs/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder

--- a/examples/server-sent-events-jaxrs/src/main/resources/META-INF/services/javax.ws.rs.sse.SseEventSource$Builder
+++ b/examples/server-sent-events-jaxrs/src/main/resources/META-INF/services/javax.ws.rs.sse.SseEventSource$Builder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.media.sse.internal.JerseySseEventSource$Builder

--- a/examples/sse-item-store-jaxrs-webapp/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/examples/sse-item-store-jaxrs-webapp/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder

--- a/examples/sse-item-store-jaxrs-webapp/src/main/resources/META-INF/services/javax.ws.rs.sse.SseEventSource$Builder
+++ b/examples/sse-item-store-jaxrs-webapp/src/main/resources/META-INF/services/javax.ws.rs.sse.SseEventSource$Builder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.media.sse.internal.JerseySseEventSource$Builder

--- a/ext/rx/rx-client-guava/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/ext/rx/rx-client-guava/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder

--- a/ext/rx/rx-client-rxjava/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/ext/rx/rx-client-rxjava/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder

--- a/ext/rx/rx-client-rxjava2/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/ext/rx/rx-client-rxjava2/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder

--- a/media/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseySseEventSourceTest.java
+++ b/media/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseySseEventSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,20 +16,14 @@
 
 package org.glassfish.jersey.media.sse.internal;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import javax.ws.rs.sse.SseEventSource;
 
 public class JerseySseEventSourceTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testNPEOnNull() {
-        thrown.expect(NullPointerException.class);
         SseEventSource.target(null);
     }
 }

--- a/tests/integration/jersey-2421/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/tests/integration/jersey-2421/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.glassfish.jersey.client.JerseyClientBuilder

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -187,6 +187,12 @@
             <version>4.4.6</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>4.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
             <scope>test</scope>

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/JaxRsRiBundleTest.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/JaxRsRiBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,6 +59,7 @@ public class JaxRsRiBundleTest {
         options.addAll(Helper.expandedList(
                 // vmOption("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"),
 
+                mavenBundle().groupId("jakarta.servlet").artifactId("jakarta.servlet-api").versionAsInProject(),
                 mavenBundle().groupId("org.glassfish.jersey.bundles").artifactId("jaxrs-ri").versionAsInProject(),
 
                 mavenBundle().groupId("org.mortbay.jetty").artifactId("servlet-api-2.5").versionAsInProject(),

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/util/Helper.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/util/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,6 +43,16 @@ public class Helper {
      * Jersey HTTP port.
      */
     private static final int port = getEnvVariable(TestProperties.CONTAINER_PORT, 8080);
+
+    /**
+     * JAX-RS delegate property.
+     */
+    private static final String JAXRS_RUNTIME_DELEGATE_PROPERTY = "javax.ws.rs.ext.RuntimeDelegate";
+
+    /**
+     * JAX-RS Client Builder property
+     */
+    private static final String JAXRS_CLIENT_BUILDER = "javax.ws.rs.client.ClientBuilder";
 
     /**
      * Returns an integer value of given system property, or a default value
@@ -127,6 +137,8 @@ public class Helper {
                 systemProperty("org.osgi.service.http.port").value(String.valueOf(port)),
                 systemProperty(TestProperties.CONTAINER_PORT).value(String.valueOf(port)),
                 systemProperty("org.osgi.framework.system.packages.extra").value("javax.annotation"),
+                systemProperty(JAXRS_RUNTIME_DELEGATE_PROPERTY).value("org.glassfish.jersey.internal.RuntimeDelegateImpl"),
+                systemProperty(JAXRS_CLIENT_BUILDER).value("org.glassfish.jersey.client.JerseyClientBuilder"),
 
                 // javax.annotation has to go first!
                 mavenBundle().groupId("jakarta.annotation").artifactId("jakarta.annotation-api").versionAsInProject(),


### PR DESCRIPTION
JAXRS 2.2 removes Jersey as the default impl. This PR aims to provide possibility for Jersey to work without being default JAXRS impl

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>