### PR TITLE
Test for PR 3905

### DIFF
--- a/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
+++ b/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
@@ -182,6 +182,7 @@ public abstract class JerseyTest {
         // not be set soon enough
         this.context = configureDeployment();
         this.testContainerFactory = getTestContainerFactory();
+        registerLogHandlerIfEnabled();
     }
 
     /**
@@ -203,6 +204,7 @@ public abstract class JerseyTest {
         // not be set soon enough
         this.context = configureDeployment();
         this.testContainerFactory = testContainerFactory;
+        registerLogHandlerIfEnabled();
     }
 
     /**
@@ -227,6 +229,7 @@ public abstract class JerseyTest {
     public JerseyTest(final Application jaxrsApplication) {
         this.context = DeploymentContext.newInstance(jaxrsApplication);
         this.testContainerFactory = getTestContainerFactory();
+        registerLogHandlerIfEnabled();
     }
 
     /**
@@ -577,10 +580,6 @@ public abstract class JerseyTest {
      */
     @Before
     public void setUp() throws Exception {
-        if (isLogRecordingEnabled()) {
-            registerLogHandler();
-        }
-
         final TestContainer testContainer = createTestContainer(context);
 
         // Set current instance of test container and start it.
@@ -793,6 +792,16 @@ public abstract class JerseyTest {
         }
 
         return rootLoggers;
+    }
+
+    /**
+     * Register {@link Handler log handler} to the list of root loggers
+     * if log recording is enabled.
+     */
+    private void registerLogHandlerIfEnabled() {
+        if (isLogRecordingEnabled()) {
+            registerLogHandler();
+        }
     }
 
     /**

--- a/tests/integration/cdi-log-check/pom.xml
+++ b/tests/integration/cdi-log-check/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <artifactId>project</artifactId>
+        <version>2.29-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cdi-log-check</artifactId>
+    <packaging>war</packaging>
+    <name>jersey-tests-cdi-log-check</name>
+
+    <description>Jersey CDI test web application</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <version>${javax.interceptor.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-bundle</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-util</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.cdi</groupId>
+            <artifactId>jersey-weld2-se</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.cdi</groupId>
+            <artifactId>jersey-cdi1x</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>run-external-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <jersey.config.test.container.factory>${external.container.factory}</jersey.config.test.container.factory>
+                                <jersey.config.test.container.port>${external.container.port}</jersey.config.test.container.port>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <!-- External test container configuration is done via properties to allow overriding via command line. -->
+                <external.container.factory>org.glassfish.jersey.test.external.ExternalTestContainerFactory</external.container.factory>
+                <external.container.port>8080</external.container.port>
+                <maven.test.skip>false</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/ClassBean.java
+++ b/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/ClassBean.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.cdi.resources;
+
+public interface ClassBean {
+    Class<?> get();
+
+    void set(Class<?> clazz);
+}

--- a/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/EchoResource.java
+++ b/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/EchoResource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.resources;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("echo")
+@RequestScoped
+@Fooed
+public class EchoResource {
+    public static final String OK = "OK";
+
+    @Inject
+    WarningClass warningClass;
+
+    @GET
+    public String get() {
+        return OK;
+    }
+
+}

--- a/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/FooInterceptor.java
+++ b/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/FooInterceptor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.resources;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Intercepted;
+import javax.enterprise.inject.spi.Bean;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import java.io.Serializable;
+
+@Interceptor
+@Fooed
+public class FooInterceptor implements Serializable {
+
+    @Inject
+    @Intercepted
+    private Bean<?> interceptedBean;
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    WarningClass warningClass;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext invocationContext) throws Exception {
+        warningClass.set(interceptedBean.getBeanClass());
+        return invocationContext.proceed();
+    }
+}
+

--- a/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/Fooed.java
+++ b/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/Fooed.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.resources;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Fooed {
+}

--- a/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/MyApplication.java
+++ b/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/MyApplication.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.resources;
+
+import org.glassfish.jersey.server.ServerProperties;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@ApplicationPath("/*")
+public class MyApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        final Set<Class<?>> classes = new HashSet<>();
+        classes.add(EchoResource.class);
+        classes.add(WarningResource.class);
+        return classes;
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put(ServerProperties.WADL_FEATURE_DISABLE, true);
+        return properties;
+    }
+}

--- a/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/WarningClass.java
+++ b/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/WarningClass.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.cdi.resources;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class WarningClass implements ClassBean {
+    private Class<?> clazz = WarningClass.class;
+
+    @Override
+    public Class<?> get() {
+        return clazz;
+    }
+
+    @Override
+    public void set(Class<?> clazz) {
+        this.clazz = clazz;
+    }
+}

--- a/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/WarningResource.java
+++ b/tests/integration/cdi-log-check/src/main/java/org/glassfish/jersey/tests/cdi/resources/WarningResource.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.cdi.resources;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("warning")
+@RequestScoped
+public class WarningResource {
+    @Inject
+    WarningClass warningClass;
+
+    @GET
+    public String get() {
+        return warningClass.get().getName();
+    }
+}

--- a/tests/integration/cdi-log-check/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/cdi-log-check/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+
+<beans
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+        http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    <interceptors>
+        <class>org.glassfish.jersey.tests.cdi.resources.FooInterceptor</class>
+    </interceptors>
+</beans>
+

--- a/tests/integration/cdi-log-check/src/main/webapp/WEB-INF/web.xml
+++ b/tests/integration/cdi-log-check/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+</web-app>

--- a/tests/integration/cdi-log-check/src/test/java/org/glassfish/jersey/tests/cdi/resources/CdiComponentProviderWarningTest.java
+++ b/tests/integration/cdi-log-check/src/test/java/org/glassfish/jersey/tests/cdi/resources/CdiComponentProviderWarningTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.resources;
+
+import org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory;
+import org.glassfish.jersey.server.internal.LocalizationMessages;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.glassfish.jersey.test.external.ExternalTestContainerFactory;
+import org.jboss.weld.environment.se.Weld;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.Assert.assertEquals;
+
+public class CdiComponentProviderWarningTest extends JerseyTest {
+    private Weld weld;
+
+    @Before
+    public void setup() {
+        Assume.assumeTrue(Hk2InjectionManagerFactory.isImmediateStrategy());
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        if (Hk2InjectionManagerFactory.isImmediateStrategy()) {
+            if (!ExternalTestContainerFactory.class.isAssignableFrom(getTestContainerFactory().getClass())) {
+                weld = new Weld();
+                weld.initialize();
+            }
+            super.setUp();
+        }
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        if (Hk2InjectionManagerFactory.isImmediateStrategy()) {
+            if (!ExternalTestContainerFactory.class.isAssignableFrom(getTestContainerFactory().getClass())) {
+                weld.shutdown();
+            }
+            super.tearDown();
+        }
+    }
+
+    @Override
+    protected Application configure() {
+        set(TestProperties.RECORD_LOG_LEVEL, Level.WARNING.intValue());
+        return new MyApplication();
+    }
+
+    @Test
+    public void testWarning() {
+        String echo = target("echo").request().get(String.class);
+        assertEquals(echo, EchoResource.OK);
+
+        String resource = target("warning").request().get(String.class);
+        assertEquals(resource, EchoResource.class.getName());
+
+        String warning = LocalizationMessages.PARAMETER_UNRESOLVABLE(echo, echo, echo);
+        String searchInLog = warning.substring(warning.lastIndexOf(echo) + echo.length());
+
+        List<?> logRecords = getLoggedRecords();
+        for (final LogRecord logRecord : getLoggedRecords()) {
+            if (logRecord.getLoggerName().equals("org.glassfish.jersey.internal.Errors")
+                    && logRecord.getMessage().contains(searchInLog)) {
+                Assert.fail("Checking CDI bean is a JAX-RS resource should not cast warnings");
+            }
+        }
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -37,6 +37,7 @@
         <module>cdi-beanvalidation-webapp</module>
         <module>cdi-ejb-test-webapp</module>
         <module>cdi-iface-with-non-jaxrs-impl-test-webapp</module>
+        <module>cdi-log-check</module>
         <module>cdi-multimodule</module>
         <module>ejb-multimodule-reload</module>
         <module>cdi-multipart-webapp</module>


### PR DESCRIPTION
Check the log for a warning that would have been in should the fix for
"3905: Fix warnings when checking CDI bean is JAX-RS resource" be not included

Signed-off-by: Jan Supol <jan.supol@oracle.com>