### PR TITLE
Rename ParameterInserters to ParameterUpdaters

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientBootstrapBag.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientBootstrapBag.java
@@ -17,7 +17,7 @@ package org.glassfish.jersey.client;
 
 
 import org.glassfish.jersey.internal.BootstrapBag;
-import org.glassfish.jersey.client.inject.ParameterInserterProvider;
+import org.glassfish.jersey.client.inject.ParameterUpdaterProvider;
 
 /**
  * {@inheritDoc}
@@ -28,14 +28,14 @@ import org.glassfish.jersey.client.inject.ParameterInserterProvider;
  */
 public class ClientBootstrapBag extends BootstrapBag {
 
-    private ParameterInserterProvider parameterInserterProvider;
+    private ParameterUpdaterProvider parameterUpdaterProvider;
 
-    public ParameterInserterProvider getParameterInserterProvider() {
-        requireNonNull(parameterInserterProvider, ParameterInserterProvider.class);
-        return parameterInserterProvider;
+    public ParameterUpdaterProvider getParameterUpdaterProvider() {
+        requireNonNull(parameterUpdaterProvider, ParameterUpdaterProvider.class);
+        return parameterUpdaterProvider;
     }
 
-    public void setParameterInserterProvider(ParameterInserterProvider provider) {
-        this.parameterInserterProvider = provider;
+    public void setParameterUpdaterProvider(ParameterUpdaterProvider provider) {
+        this.parameterUpdaterProvider = provider;
     }
 }

--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientBootstrapBag.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientBootstrapBag.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
@@ -35,7 +35,7 @@ import javax.ws.rs.core.Feature;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.ExtendedConfig;
 import org.glassfish.jersey.client.internal.LocalizationMessages;
-import org.glassfish.jersey.client.internal.inject.ParameterInserterConfigurator;
+import org.glassfish.jersey.client.internal.inject.ParameterUpdaterConfigurator;
 import org.glassfish.jersey.client.spi.Connector;
 import org.glassfish.jersey.client.spi.ConnectorProvider;
 import org.glassfish.jersey.internal.AutoDiscoverableConfigurator;
@@ -416,7 +416,7 @@ public class ClientConfig implements Configurable<ClientConfig>, ExtendedConfig 
             bootstrapBag.setManagedObjectsFinalizer(new ManagedObjectsFinalizer(injectionManager));
             List<BootstrapConfigurator> bootstrapConfigurators = Arrays.asList(new RequestScope.RequestScopeConfigurator(),
                     new ParamConverterConfigurator(),
-                    new ParameterInserterConfigurator(),
+                    new ParameterUpdaterConfigurator(),
                     new RuntimeConfigConfigurator(runtimeCfgState),
                     new ContextResolverFactory.ContextResolversConfigurator(),
                     new MessageBodyFactory.MessageBodyWorkersConfigurator(),

--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/inject/ParameterUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/inject/ParameterUpdater.java
@@ -28,12 +28,12 @@ package org.glassfish.jersey.client.inject;
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
  */
-public interface ParameterInserter<T, R> {
+public interface ParameterUpdater<T, R> {
 
     /**
-     * Name of the parameter to be inserted
+     * Name of the parameter to be udpated
      *
-     * @return name of the inserted parameter.
+     * @return name of the updated parameter.
      */
     String getName();
 
@@ -45,11 +45,11 @@ public interface ParameterInserter<T, R> {
     String getDefaultValueString();
 
     /**
-     * Insert the value using ParamConverter#toString (and using
+     * Update the value using ParamConverter#toString (and using
      * the configured {@link #getDefaultValueString() default value})
      *
      * @param parameters custom Java type instance value.
      * @return converted value.
      */
-    R insert(T parameters);
+    R update(T parameters);
 }

--- a/core-client/src/main/java/org/glassfish/jersey/client/inject/ParameterUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/inject/ParameterUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/inject/ParameterUpdaterProvider.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/inject/ParameterUpdaterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/inject/ParameterUpdaterProvider.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/inject/ParameterUpdaterProvider.java
@@ -20,22 +20,22 @@ package org.glassfish.jersey.client.inject;
 import org.glassfish.jersey.model.Parameter;
 
 /**
- * Provider of parameter inserter.
+ * Provider of parameter updater.
  *
  * @author Paul Sandoz
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
  */
-public interface ParameterInserterProvider {
+public interface ParameterUpdaterProvider {
 
     /**
-     * Get the inserter configured to insert value of given {@link Parameter parameter}.
+     * Get the updater configured to update value of given {@link Parameter parameter}.
      * <p />
      * If the default value has been set on the parameter, it will be configured
-     * in the inserter.
+     * in the updater.
      *
      * @param parameter client model parameter.
-     * @return inserter for the method parameter.
+     * @return updater for the method parameter.
      */
-    ParameterInserter<?, ?> get(Parameter parameter);
+    ParameterUpdater<?, ?> get(Parameter parameter);
 }

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/AbstractParamValueUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/AbstractParamValueUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/AbstractParamValueUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/AbstractParamValueUpdater.java
@@ -20,19 +20,19 @@ package org.glassfish.jersey.client.internal.inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.ext.ParamConverter;
 
-import org.glassfish.jersey.internal.inject.InserterException;
+import org.glassfish.jersey.internal.inject.UpdaterException;
 import org.glassfish.jersey.internal.util.collection.UnsafeValue;
 import org.glassfish.jersey.internal.util.collection.Values;
 
 /**
- * Abstract base class for implementing parameter value inserter
+ * Abstract base class for implementing parameter value updater
  * logic supplied using {@link ParamConverter parameter converters}.
  *
  * @author Paul Sandoz
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
  */
-abstract class AbstractParamValueInserter<T> {
+abstract class AbstractParamValueUpdater<T> {
 
     private final ParamConverter<T> paramConverter;
     private final String parameterName;
@@ -40,13 +40,13 @@ abstract class AbstractParamValueInserter<T> {
     private final UnsafeValue<String, RuntimeException> convertedDefaultValue;
 
     /**
-     * Constructor that initializes parameter inserter.
+     * Constructor that initializes parameter updater.
      *
      * @param converter          parameter converter.
      * @param parameterName      name of the parameter.
      * @param defaultValueString default parameter value string.
      */
-    protected AbstractParamValueInserter(ParamConverter<T> converter, String parameterName, final String defaultValue) {
+    protected AbstractParamValueUpdater(ParamConverter<T> converter, String parameterName, final String defaultValue) {
         this.paramConverter = converter;
         this.parameterName = parameterName;
         this.defaultValue = defaultValue;
@@ -69,7 +69,7 @@ abstract class AbstractParamValueInserter<T> {
     }
 
     /**
-     * Get the name of the parameter this inserter belongs to.
+     * Get the name of the parameter this updater belongs to.
      *
      * @return parameter name.
      */
@@ -87,17 +87,17 @@ abstract class AbstractParamValueInserter<T> {
     }
 
     /**
-     * Insert parameter value to string using the configured {@link ParamConverter parameter converter}.
+     * Update parameter value to string using the configured {@link ParamConverter parameter converter}.
      *
      * A {@link WebApplicationException} / {@link IllegalArgumentException} thrown
      * from the converter is propagated unchanged. Any other exception throws by
-     * the converter is wrapped in a new {@link InserterException} before rethrowing.
+     * the converter is wrapped in a new {@link UpdaterException} before rethrowing.
      *
-     * @param value parameter value to be converted/inserted.
-     * @return inserted value of a given Java type.
+     * @param value parameter value to be converted/updated.
+     * @return updated value of a given Java type.
      * @throws WebApplicationException in case the underlying parameter converter throws
      * a {@code WebApplicationException}. The exception is rethrown without a change.
-     * @throws InserterException wrapping any other exception thrown by the parameter converter.
+     * @throws UpdaterException wrapping any other exception thrown by the parameter converter.
      */
     protected final String toString(T value) {
         String result = convert(value);
@@ -113,7 +113,7 @@ abstract class AbstractParamValueInserter<T> {
         } catch (WebApplicationException | IllegalArgumentException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new InserterException(ex);
+            throw new UpdaterException(ex);
         }
     }
 

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/CollectionUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/CollectionUpdater.java
@@ -29,35 +29,35 @@ import static java.util.stream.Collectors.toList;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.ext.ParamConverter;
 import org.glassfish.jersey.client.internal.LocalizationMessages;
-import org.glassfish.jersey.client.inject.ParameterInserter;
+import org.glassfish.jersey.client.inject.ParameterUpdater;
 
 /**
- * Insert parameter value as a typed collection.
+ * Update parameter value as a typed collection.
  *
  * @param <T> parameter value type.
  * @author Paul Sandoz
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
  */
-abstract class CollectionInserter<T> extends AbstractParamValueInserter<T>
-        implements ParameterInserter<Collection<T>, Collection<String>> {
+abstract class CollectionUpdater<T> extends AbstractParamValueUpdater<T>
+        implements ParameterUpdater<Collection<T>, Collection<String>> {
 
     /**
-     * Create new collection parameter inserter.
+     * Create new collection parameter updater.
      *
      * @param converter          parameter converter to be used to convert parameter from a custom Java type.
      * @param parameterName      parameter name.
      * @param defaultValue default parameter String value.
      */
-    protected CollectionInserter(final ParamConverter<T> converter,
-                                  final String parameterName,
-                                  final String defaultValue) {
+    protected CollectionUpdater(final ParamConverter<T> converter,
+                                final String parameterName,
+                                final String defaultValue) {
         super(converter, parameterName, defaultValue);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public Collection<String> insert(final Collection<T> values) {
+    public Collection<String> update(final Collection<T> values) {
         Collection<String> results = Collections.EMPTY_LIST;
         if (values != null) {
             results = values
@@ -71,7 +71,7 @@ abstract class CollectionInserter<T> extends AbstractParamValueInserter<T>
     }
 
     /**
-     * Get a new collection instance that will be used to store the inserted parameters.
+     * Get a new collection instance that will be used to store the updated parameters.
      * <p/>
      * The method is overridden by concrete implementations to return an instance
      * of a proper collection sub-type.
@@ -80,7 +80,7 @@ abstract class CollectionInserter<T> extends AbstractParamValueInserter<T>
      */
     protected abstract Collection<String> newCollection();
 
-    private static final class ListValueOf<T> extends CollectionInserter<T> {
+    private static final class ListValueOf<T> extends CollectionUpdater<T> {
 
         ListValueOf(final ParamConverter<T> converter, final String parameter, final String defaultValue) {
             super(converter, parameter, defaultValue);
@@ -92,7 +92,7 @@ abstract class CollectionInserter<T> extends AbstractParamValueInserter<T>
         }
     }
 
-    private static final class SetValueOf<T> extends CollectionInserter<T> {
+    private static final class SetValueOf<T> extends CollectionUpdater<T> {
 
         SetValueOf(final ParamConverter<T> converter, final String parameter, final String defaultValue) {
             super(converter, parameter, defaultValue);
@@ -104,7 +104,7 @@ abstract class CollectionInserter<T> extends AbstractParamValueInserter<T>
         }
     }
 
-    private static final class SortedSetValueOf<T> extends CollectionInserter<T> {
+    private static final class SortedSetValueOf<T> extends CollectionUpdater<T> {
 
         SortedSetValueOf(final ParamConverter<T> converter, final String parameter, final String defaultValue) {
             super(converter, parameter, defaultValue);
@@ -117,7 +117,7 @@ abstract class CollectionInserter<T> extends AbstractParamValueInserter<T>
     }
 
     /**
-     * Get a new {@code CollectionInserter} instance.
+     * Get a new {@code CollectionUpdater} instance.
      *
      * @param collectionType     raw collection type.
      * @param converter          parameter converter to be used to convert parameter Java type values into
@@ -125,12 +125,12 @@ abstract class CollectionInserter<T> extends AbstractParamValueInserter<T>
      * @param parameterName      parameter name.
      * @param defaultValue default parameter string value.
      * @param <T>                converted parameter Java type.
-     * @return new collection parameter inserter instance.
+     * @return new collection parameter updated instance.
      */
-    public static <T> CollectionInserter getInstance(final Class<?> collectionType,
-                                                      final ParamConverter<T> converter,
-                                                      final String parameterName,
-                                                      final String defaultValue) {
+    public static <T> CollectionUpdater getInstance(final Class<?> collectionType,
+                                                    final ParamConverter<T> converter,
+                                                    final String parameterName,
+                                                    final String defaultValue) {
         if (List.class == collectionType) {
             return new ListValueOf<>(converter, parameterName, defaultValue);
         } else if (Set.class == collectionType) {
@@ -138,7 +138,7 @@ abstract class CollectionInserter<T> extends AbstractParamValueInserter<T>
         } else if (SortedSet.class == collectionType) {
             return new SortedSetValueOf<>(converter, parameterName, defaultValue);
         } else {
-            throw new ProcessingException(LocalizationMessages.COLLECTION_INSERTER_TYPE_UNSUPPORTED());
+            throw new ProcessingException(LocalizationMessages.COLLECTION_UPDATER_TYPE_UNSUPPORTED());
         }
     }
 }

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/CollectionUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/CollectionUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/ParameterUpdaterConfigurator.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/ParameterUpdaterConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/ParameterUpdaterConfigurator.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/ParameterUpdaterConfigurator.java
@@ -29,30 +29,30 @@ import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.internal.util.collection.LazyValue;
 import org.glassfish.jersey.internal.util.collection.Value;
 import org.glassfish.jersey.internal.util.collection.Values;
-import org.glassfish.jersey.client.inject.ParameterInserterProvider;
+import org.glassfish.jersey.client.inject.ParameterUpdaterProvider;
 
 /**
- * Configurator which initializes and register {@link ParameterInserterProvider} instance into
+ * Configurator which initializes and register {@link ParameterUpdaterProvider} instance into
  * {@link InjectionManager}.
  *
  * @author Petr Bouda
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
  */
-public class ParameterInserterConfigurator implements BootstrapConfigurator {
+public class ParameterUpdaterConfigurator implements BootstrapConfigurator {
 
     @Override
     public void init(InjectionManager injectionManager, BootstrapBag bootstrapBag) {
         ClientBootstrapBag clientBag = (ClientBootstrapBag) bootstrapBag;
 
-        // Param Converters must be initialized Lazy and created at the time of the call on inserter
+        // Param Converters must be initialized Lazy and created at the time of the call on updater
         LazyValue<ParamConverterFactory> lazyParamConverterFactory =
                 Values.lazy((Value<ParamConverterFactory>) () -> new ParamConverterFactory(
                         Providers.getProviders(injectionManager, ParamConverterProvider.class),
                         Providers.getCustomProviders(injectionManager, ParamConverterProvider.class)));
 
-        ParameterInserterFactory parameterInserter = new ParameterInserterFactory(lazyParamConverterFactory);
-        clientBag.setParameterInserterProvider(parameterInserter);
-        injectionManager.register(Bindings.service(parameterInserter)
-                        .to(ParameterInserterProvider.class));
+        ParameterUpdaterFactory parameterUpdaterFactory = new ParameterUpdaterFactory(lazyParamConverterFactory);
+        clientBag.setParameterUpdaterProvider(parameterUpdaterFactory);
+        injectionManager.register(Bindings.service(parameterUpdaterFactory)
+                        .to(ParameterUpdaterProvider.class));
     }
 }

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/ParameterUpdaterFactory.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/ParameterUpdaterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/ParameterUpdaterFactory.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/ParameterUpdaterFactory.java
@@ -25,7 +25,7 @@ import java.util.SortedSet;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.ext.ParamConverter;
 import javax.inject.Singleton;
-import org.glassfish.jersey.internal.inject.InserterException;
+import org.glassfish.jersey.internal.inject.UpdaterException;
 import org.glassfish.jersey.internal.inject.ParamConverterFactory;
 import org.glassfish.jersey.internal.util.ReflectionHelper;
 import org.glassfish.jersey.internal.util.collection.ClassTypePair;
@@ -33,36 +33,36 @@ import org.glassfish.jersey.internal.util.collection.LazyValue;
 import org.glassfish.jersey.client.internal.LocalizationMessages;
 import org.glassfish.jersey.model.Parameter;
 import org.glassfish.jersey.internal.inject.PrimitiveMapper;
-import org.glassfish.jersey.client.inject.ParameterInserter;
-import org.glassfish.jersey.client.inject.ParameterInserterProvider;
+import org.glassfish.jersey.client.inject.ParameterUpdater;
+import org.glassfish.jersey.client.inject.ParameterUpdaterProvider;
 
 /**
- * Implementation of {@link ParameterInserterProvider}. For each
+ * Implementation of {@link ParameterUpdaterProvider}. For each
  * parameter, the implementation obtains a
  * {@link ParamConverter param converter} instance via
  * {@link ParamConverterFactory} and creates the proper
- * {@link ParameterInserter parameter inserter}.
+ * {@link ParameterUpdater parameter updater}.
  *
  * @author Paul Sandoz
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
  */
 @Singleton
-final class ParameterInserterFactory implements ParameterInserterProvider {
+final class ParameterUpdaterFactory implements ParameterUpdaterProvider {
 
     private final LazyValue<ParamConverterFactory> paramConverterFactory;
 
     /**
-     * Create new parameter inserter factory.
+     * Create new parameter updater factory.
      *
      * @param paramConverterFactory string readers factory.
      */
-    public ParameterInserterFactory(LazyValue<ParamConverterFactory> paramConverterFactory) {
+    public ParameterUpdaterFactory(LazyValue<ParamConverterFactory> paramConverterFactory) {
         this.paramConverterFactory = paramConverterFactory;
     }
 
     @Override
-    public ParameterInserter<?, ?> get(final Parameter p) {
+    public ParameterUpdater<?, ?> get(final Parameter p) {
         return process(
                 paramConverterFactory.get(),
                 p.getDefaultValue(),
@@ -73,7 +73,7 @@ final class ParameterInserterFactory implements ParameterInserterProvider {
     }
 
     @SuppressWarnings("unchecked")
-    private ParameterInserter<?, ?> process(
+    private ParameterUpdater<?, ?> process(
             final ParamConverterFactory paramConverterFactory,
             final String defaultValue,
             final Class<?> rawType,
@@ -86,8 +86,8 @@ final class ParameterInserterFactory implements ParameterInserterProvider {
         ParamConverter<?> converter = paramConverterFactory.getConverter(rawType, type, annotations);
         if (converter != null) {
             try {
-                return new SingleValueInserter(converter, parameterName, defaultValue);
-            } catch (final InserterException e) {
+                return new SingleValueUpdater(converter, parameterName, defaultValue);
+            } catch (final UpdaterException e) {
                 throw e;
             } catch (final Exception e) {
                 throw new ProcessingException(LocalizationMessages.ERROR_PARAMETER_TYPE_PROCESSING(rawType), e);
@@ -109,8 +109,8 @@ final class ParameterInserterFactory implements ParameterInserterProvider {
             }
             if (converter != null) {
                 try {
-                    return CollectionInserter.getInstance(rawType, converter, parameterName, defaultValue);
-                } catch (final InserterException e) {
+                    return CollectionUpdater.getInstance(rawType, converter, parameterName, defaultValue);
+                } catch (final UpdaterException e) {
                     throw e;
                 } catch (final Exception e) {
                     throw new ProcessingException(LocalizationMessages.ERROR_PARAMETER_TYPE_PROCESSING(rawType), e);
@@ -120,9 +120,9 @@ final class ParameterInserterFactory implements ParameterInserterProvider {
 
         // Check primitive types.
         if (rawType == String.class) {
-            return new SingleStringValueInserter(parameterName, defaultValue);
+            return new SingleStringValueUpdater(parameterName, defaultValue);
         } else if (rawType == Character.class) {
-            return new PrimitiveCharacterInserter(parameterName,
+            return new PrimitiveCharacterUpdater(parameterName,
                     defaultValue,
                     PrimitiveMapper.primitiveToDefaultValueMap.get(rawType));
         } else if (rawType.isPrimitive()) {
@@ -134,12 +134,12 @@ final class ParameterInserterFactory implements ParameterInserterProvider {
             }
 
             if (wrappedRaw == Character.class) {
-                return new PrimitiveCharacterInserter(parameterName,
+                return new PrimitiveCharacterUpdater(parameterName,
                         defaultValue,
                         PrimitiveMapper.primitiveToDefaultValueMap.get(wrappedRaw));
             }
 
-            return new PrimitiveValueOfInserter(
+            return new PrimitiveValueOfUpdater(
                     parameterName,
                     defaultValue,
                     PrimitiveMapper.primitiveToDefaultValueMap.get(wrappedRaw));

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/PrimitiveCharacterUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/PrimitiveCharacterUpdater.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2019 Payara Foundation and/or its affiliates.
+ * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,35 +17,22 @@
 
 package org.glassfish.jersey.client.internal.inject;
 
-import org.glassfish.jersey.client.inject.ParameterInserter;
+import org.glassfish.jersey.client.inject.ParameterUpdater;
 
 /**
- * Insert String value using {@code toString()} methods
- * on the primitive Java type wrapper classes.
+ * Value updater for {@link java.lang.Character} and {@code char} parameters.
  *
- * @author Paul Sandoz
- * @author Marek Potociar (marek.potociar at oracle.com)
+ * @author Pavel Bucek (pavel.bucek at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
- * @author Patrik Dudits
  *
  */
-final class PrimitiveValueOfInserter implements ParameterInserter<Object, String> {
+class PrimitiveCharacterUpdater implements ParameterUpdater<Character, String> {
 
     private final String parameter;
     private final String defaultValue;
     private final Object defaultPrimitiveTypeValue;
 
-    /**
-     * Create new primitive parameter value inserter.
-     *
-     * @param valueOf {@code valueOf()} method handler.
-     * @param parameter string parameter value.
-     * @param defaultValue default string value.
-     * @param defaultPrimitiveTypeValue default primitive type value.
-     */
-    public PrimitiveValueOfInserter(String parameter,
-            String defaultValue,
-            Object defaultPrimitiveTypeValue) {
+    public PrimitiveCharacterUpdater(String parameter, String defaultValue, Object defaultPrimitiveTypeValue) {
         this.parameter = parameter;
         this.defaultValue = defaultValue;
         this.defaultPrimitiveTypeValue = defaultPrimitiveTypeValue;
@@ -62,7 +49,7 @@ final class PrimitiveValueOfInserter implements ParameterInserter<Object, String
     }
 
     @Override
-    public String insert(Object value) {
+    public String update(Character value) {
         if (value != null) {
             return value.toString();
         } else if (defaultValue != null) {

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/PrimitiveCharacterUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/PrimitiveCharacterUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/PrimitiveValueOfUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/PrimitiveValueOfUpdater.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 Payara Foundation and/or its affiliates.
+ * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,22 +17,35 @@
 
 package org.glassfish.jersey.client.internal.inject;
 
-import org.glassfish.jersey.client.inject.ParameterInserter;
+import org.glassfish.jersey.client.inject.ParameterUpdater;
 
 /**
- * Value inserter for {@link java.lang.Character} and {@code char} parameters.
+ * Update String value using {@code toString()} methods
+ * on the primitive Java type wrapper classes.
  *
- * @author Pavel Bucek (pavel.bucek at oracle.com)
+ * @author Paul Sandoz
+ * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
+ * @author Patrik Dudits
  *
  */
-class PrimitiveCharacterInserter implements ParameterInserter<Character, String> {
+final class PrimitiveValueOfUpdater implements ParameterUpdater<Object, String> {
 
     private final String parameter;
     private final String defaultValue;
     private final Object defaultPrimitiveTypeValue;
 
-    public PrimitiveCharacterInserter(String parameter, String defaultValue, Object defaultPrimitiveTypeValue) {
+    /**
+     * Create new primitive parameter value updater.
+     *
+     * @param valueOf {@code valueOf()} method handler.
+     * @param parameter string parameter value.
+     * @param defaultValue default string value.
+     * @param defaultPrimitiveTypeValue default primitive type value.
+     */
+    public PrimitiveValueOfUpdater(String parameter,
+                                   String defaultValue,
+                                   Object defaultPrimitiveTypeValue) {
         this.parameter = parameter;
         this.defaultValue = defaultValue;
         this.defaultPrimitiveTypeValue = defaultPrimitiveTypeValue;
@@ -49,7 +62,7 @@ class PrimitiveCharacterInserter implements ParameterInserter<Character, String>
     }
 
     @Override
-    public String insert(Character value) {
+    public String update(Object value) {
         if (value != null) {
             return value.toString();
         } else if (defaultValue != null) {

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/PrimitiveValueOfUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/PrimitiveValueOfUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/SingleStringValueUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/SingleStringValueUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/SingleStringValueUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/SingleStringValueUpdater.java
@@ -17,30 +17,30 @@
 
 package org.glassfish.jersey.client.internal.inject;
 
-import org.glassfish.jersey.client.inject.ParameterInserter;
+import org.glassfish.jersey.client.inject.ParameterUpdater;
 
 /**
- * Insert value of the parameter by returning the first string parameter value
+ * Update value of the parameter by returning the first string parameter value
  * found in the list of string parameter values.
  * <p />
- * This class can be seen as a special, optimized, case of {@link SingleValueInserter}.
+ * This class can be seen as a special, optimized, case of {@link SingleValueUpdater}.
  *
  * @author Paul Sandoz
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
  */
-final class SingleStringValueInserter implements ParameterInserter<String, String> {
+final class SingleStringValueUpdater implements ParameterUpdater<String, String> {
 
     private final String paramName;
     private final String defaultValue;
 
     /**
-     * Create new single string value inserter.
+     * Create new single string value updater.
      *
      * @param parameterName string parameter name.
      * @param defaultValue  default value.
      */
-    public SingleStringValueInserter(String parameterName, String defaultValue) {
+    public SingleStringValueUpdater(String parameterName, String defaultValue) {
         this.paramName = parameterName;
         this.defaultValue = defaultValue;
     }
@@ -63,10 +63,10 @@ final class SingleStringValueInserter implements ParameterInserter<String, Strin
      * list will be ignored.
      *
      * @param parameters map of parameters.
-     * @return inserted single string parameter value.
+     * @return updated single string parameter value.
      */
     @Override
-    public String insert(String value) {
+    public String update(String value) {
         return (value != null) ? value : defaultValue;
     }
 }

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/SingleValueUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/SingleValueUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/SingleValueUpdater.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/inject/SingleValueUpdater.java
@@ -20,12 +20,12 @@ package org.glassfish.jersey.client.internal.inject;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.ext.ParamConverter;
-import org.glassfish.jersey.internal.inject.InserterException;
-import org.glassfish.jersey.client.inject.ParameterInserter;
+import org.glassfish.jersey.internal.inject.UpdaterException;
+import org.glassfish.jersey.client.inject.ParameterUpdater;
 
 
 /**
- * Insert value of the parameter using a single parameter value and the underlying
+ * Update value of the parameter using a single parameter value and the underlying
  * {@link ParamConverter param converter}.
  *
  * @param <T> custom Java type.
@@ -33,31 +33,31 @@ import org.glassfish.jersey.client.inject.ParameterInserter;
  * @author Marek Potociar (marek.potociar at oracle.com)
  * @author Gaurav Gupta (gaurav.gupta@payara.fish)
  */
-final class SingleValueInserter<T> extends AbstractParamValueInserter<T> implements ParameterInserter<T, String> {
+final class SingleValueUpdater<T> extends AbstractParamValueUpdater<T> implements ParameterUpdater<T, String> {
 
     /**
-     * Create new single value inserter.
+     * Create new single value updater.
      *
      * @param converter          string value reader.
      * @param parameterName      string parameter name.
      * @param defaultValue       default value.
      */
-    public SingleValueInserter(final ParamConverter<T> converter, final String parameterName, final String defaultValue) {
+    public SingleValueUpdater(final ParamConverter<T> converter, final String parameterName, final String defaultValue) {
         super(converter, parameterName, defaultValue);
     }
 
     /**
      * {@inheritDoc}
      * <p/>
-     * This implementation inserts the value of the parameter applying the underlying
+     * This implementation updates the value of the parameter applying the underlying
      * {@link ParamConverter param converter} to the first value found in the list of potential multiple
      * parameter values. Any other values in the multi-value list will be ignored.
      *
      * @param parameters map of parameters.
-     * @return inserted single parameter value.
+     * @return updated single parameter value.
      */
     @Override
-    public String insert(final T value){
+    public String update(final T value){
         try {
             if (value == null && isDefaultValueRegistered()) {
                 return getDefaultValueString();
@@ -69,7 +69,7 @@ final class SingleValueInserter<T> extends AbstractParamValueInserter<T> impleme
         } catch (final IllegalArgumentException ex) {
             return defaultValue();
         } catch (final Exception ex) {
-            throw new InserterException(ex);
+            throw new UpdaterException(ex);
         }
     }
 }

--- a/core-client/src/main/resources/org/glassfish/jersey/client/internal/localization.properties
+++ b/core-client/src/main/resources/org/glassfish/jersey/client/internal/localization.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at

--- a/core-client/src/main/resources/org/glassfish/jersey/client/internal/localization.properties
+++ b/core-client/src/main/resources/org/glassfish/jersey/client/internal/localization.properties
@@ -33,7 +33,7 @@ client.target.link.null=Link to the newly created target must not be null.
 client.uri.template.null=URI template of the newly created target must not be null.
 client.uri.null=URI of the newly created target must not be null.
 client.uri.builder.null=URI builder of the newly created target must not be null.
-collection.inserter.type.unsupported=Unsupported collection type.
+collection.updater.type.unsupported=Unsupported collection type.
 digest.filter.qop.unsupported=The 'qop' (quality of protection) = {0} extension requested by the server is not supported by Jersey HttpDigestAuthFilter. Cannot authenticate against the server using Http Digest Authentication.
 error.closing.output.stream=Error when closing the output stream.
 error.committing.output.stream=Error while committing the request output stream.

--- a/core-common/src/main/java/org/glassfish/jersey/internal/inject/UpdaterException.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/inject/UpdaterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-common/src/main/java/org/glassfish/jersey/internal/inject/UpdaterException.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/inject/UpdaterException.java
@@ -28,7 +28,7 @@ import javax.ws.rs.WebApplicationException;
  * @author Gaurav Gupta
  *
  */
-public class InserterException extends ProcessingException {
+public class UpdaterException extends ProcessingException {
     private static final long serialVersionUID = -4918023257104413981L;
 
     /**
@@ -36,7 +36,7 @@ public class InserterException extends ProcessingException {
      *
      * @param message exception message.
      */
-    public InserterException(String message) {
+    public UpdaterException(String message) {
         super(message);
     }
 
@@ -46,7 +46,7 @@ public class InserterException extends ProcessingException {
      * @param message exception message.
      * @param cause   exception cause.
      */
-    public InserterException(String message, Throwable cause) {
+    public UpdaterException(String message, Throwable cause) {
         super(message, cause);
     }
 
@@ -55,7 +55,7 @@ public class InserterException extends ProcessingException {
      *
      * @param cause exception cause.
      */
-    public InserterException(Throwable cause) {
+    public UpdaterException(Throwable cause) {
         super(cause);
     }
 }

--- a/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/InterfaceModel.java
+++ b/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/InterfaceModel.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -41,8 +40,8 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.ext.AsyncInvocationInterceptor;
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
-import org.glassfish.jersey.client.inject.ParameterInserter;
-import org.glassfish.jersey.client.inject.ParameterInserterProvider;
+import org.glassfish.jersey.client.inject.ParameterUpdater;
+import org.glassfish.jersey.client.inject.ParameterUpdaterProvider;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.inject.Providers;
 import org.glassfish.jersey.model.Parameter;
@@ -223,13 +222,13 @@ class InterfaceModel {
      * @return converted value of argument
      */
     Object resolveParamValue(Object arg, Parameter parameter) {
-        final Iterable<ParameterInserterProvider> parameterInserterProviders
-                = Providers.getAllProviders(injectionManager, ParameterInserterProvider.class);
-        for (final ParameterInserterProvider parameterInserterProvider : parameterInserterProviders) {
-            if (parameterInserterProvider != null) {
-                ParameterInserter<Object, Object> inserter =
-                        (ParameterInserter<Object, Object>) parameterInserterProvider.get(parameter);
-                return inserter.insert(arg);
+        final Iterable<ParameterUpdaterProvider> parameterUpdaterProviders
+                = Providers.getAllProviders(injectionManager, ParameterUpdaterProvider.class);
+        for (final ParameterUpdaterProvider parameterUpdaterProvider : parameterUpdaterProviders) {
+            if (parameterUpdaterProvider != null) {
+                ParameterUpdater<Object, Object> updater =
+                        (ParameterUpdater<Object, Object>) parameterUpdaterProvider.get(parameter);
+                return updater.update(arg);
             }
         }
         return arg;


### PR DESCRIPTION
While the classes are used for changing the value of parameters, the name updater seems to better fit the provided functionality

Signed-off-by: Jan Supol <jan.supol@oracle.com>