### PR TITLE
 CDI duplicate lookup fix

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/inject/Providers.java
@@ -179,15 +179,16 @@ public final class Providers {
      * @return iterable of all available ranked service providers for the contract. Return value is never {@code null}.
      */
     public static <T> Iterable<RankedProvider<T>> getAllRankedProviders(InjectionManager injectionManager, Class<T> contract) {
-        List<ServiceHolder<T>> providers = getServiceHolders(injectionManager, contract, CustomAnnotationLiteral.INSTANCE);
+        final List<ServiceHolder<T>> providers = getServiceHolders(injectionManager, contract, CustomAnnotationLiteral.INSTANCE);
         providers.addAll(getServiceHolders(injectionManager, contract));
 
-        LinkedHashMap<ServiceHolder<T>, RankedProvider<T>> providerMap = new LinkedHashMap<>();
+        final LinkedHashMap<Class<T>, RankedProvider<T>> providerMap = new LinkedHashMap<>();
 
-        for (ServiceHolder<T> provider : providers) {
-            if (!providerMap.containsKey(provider)) {
+        for (final ServiceHolder<T> provider : providers) {
+            final Class<T> implClass = getImplementationClass(contract, provider);
+            if (!providerMap.containsKey(implClass)) {
                 Set<Type> contracts = isProxyGenerated(contract, provider) ? provider.getContractTypes() : null;
-                providerMap.put(provider, new RankedProvider<>(provider.getInstance(), provider.getRank(), contracts));
+                providerMap.put(implClass, new RankedProvider<>(provider.getInstance(), provider.getRank(), contracts));
             }
         }
 
@@ -281,14 +282,16 @@ public final class Providers {
                                                              CustomAnnotationLiteral.INSTANCE);
         providers.addAll(getServiceHolders(injectionManager, contract));
 
-        LinkedHashSet<ServiceHolder<T>> providersSet = new LinkedHashSet<>();
-        for (ServiceHolder<T> provider : providers) {
-            if (!providersSet.contains(provider)) {
-                providersSet.add(provider);
+        final LinkedHashMap<Class<T>, ServiceHolder<T>> providerMap = new LinkedHashMap<>();
+
+        for (final ServiceHolder<T> provider : providers) {
+            final Class<T> implClass = getImplementationClass(contract, provider);
+            if (!providerMap.containsKey(implClass)) {
+                providerMap.put(implClass, provider);
             }
         }
 
-        return providersSet;
+        return providerMap.values();
     }
 
     private static <T> List<ServiceHolder<T>> getServiceHolders(

--- a/tests/integration/cdi-test-webapp/src/main/java/org/glassfish/jersey/tests/cdi/resources/MainApplication.java
+++ b/tests/integration/cdi-test-webapp/src/main/java/org/glassfish/jersey/tests/cdi/resources/MainApplication.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,6 +37,7 @@ import javax.ws.rs.core.Application;
  * JAX-RS application to configure resources.
  *
  * @author Jonathan Benoit (jonathan.benoit at oracle.com)
+ * @author Patrik Dudits
  */
 @ApplicationPath("main")
 @ApplicationScoped
@@ -66,6 +68,7 @@ public class MainApplication extends Application {
         classes.add(ConstructorInjectedResource.class);
         classes.add(ProducerResource.class);
         classes.add(FirstNonJaxRsBeanInjectedResource.class);
+        classes.add(ResponseFilter.class);
         return classes;
     }
 

--- a/tests/integration/cdi-test-webapp/src/main/java/org/glassfish/jersey/tests/cdi/resources/ResponseFilter.java
+++ b/tests/integration/cdi-test-webapp/src/main/java/org/glassfish/jersey/tests/cdi/resources/ResponseFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.tests.cdi.resources;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * CDI Managed response filter that should add single HTTP header.
+ * @author Patrik Dudits
+ */
+public class ResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().add("Filter-Invoked", UUID.randomUUID().toString());
+    }
+}

--- a/tests/integration/cdi-test-webapp/src/test/java/org/glassfish/jersey/tests/cdi/resources/PerRequestBeanTest.java
+++ b/tests/integration/cdi-test-webapp/src/test/java/org/glassfish/jersey/tests/cdi/resources/PerRequestBeanTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,17 +21,22 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 /**
  * Test for the request scoped resource.
  *
  * @author Jakub Podlesak (jakub.podlesak at oracle.com)
+ * @author Patrik Dudits
  */
 @RunWith(Parameterized.class)
 public class PerRequestBeanTest extends CdiTest {
@@ -66,4 +72,18 @@ public class PerRequestBeanTest extends CdiTest {
         assertThat(s, containsString(target.getUri().toString()));
         assertThat(s, containsString(String.format("queryParam=%s", x)));
     }
+
+    @Test
+    public void testSingleResponseFilterInvocation() {
+
+        final WebTarget target = target().path("jcdibean/per-request").queryParam("x", x);
+
+        Response response = target.request().get();
+
+        List<Object> invocationIds = response.getHeaders().get("Filter-Invoked");
+
+        assertNotNull("Filter-Invoked header should be set by ResponseFilter", invocationIds);
+        assertEquals("ResponseFilter should be invoked only once", 1, invocationIds.size());
+    }
+
 }


### PR DESCRIPTION
fixes #4157 and improves components distinguishing  - custom VS jersey's internal - in case of CDI component provider.  