### PR TITLE
Fixed: Various bugs in Helloworld CDI SE Example

### DIFF
--- a/examples/helloworld-cdi2-se/README.MD
+++ b/examples/helloworld-cdi2-se/README.MD
@@ -1,4 +1,4 @@
-[//]: # " Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved. "
+[//]: # " Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved. "
 [//]: # " "
 [//]: # " This program and the accompanying materials are made available under the "
 [//]: # " terms of the Eclipse Distribution License v. 1.0, which is available at "

--- a/examples/helloworld-cdi2-se/README.MD
+++ b/examples/helloworld-cdi2-se/README.MD
@@ -31,4 +31,4 @@ Run the example as follows:
 
 This deploys the example using [Grizzly](http://grizzly.java.net/) container.
 
--   <http://localhost:8080/helloworld>
+-   <http://localhost:8080/helloworld/Some%20Name>

--- a/examples/helloworld-cdi2-se/pom.xml
+++ b/examples/helloworld-cdi2-se/pom.xml
@@ -63,7 +63,7 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <configuration>
-                    <mainClass>java.org.glassfish.jersey.examples.helloworld.cdi2se.App</mainClass>
+                    <mainClass>org.glassfish.jersey.examples.helloworld.cdi2se.App</mainClass>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/helloworld-cdi2-se/src/main/java/org/glassfish/jersey/examples/helloworld/cdi2se/App.java
+++ b/examples/helloworld-cdi2-se/src/main/java/org/glassfish/jersey/examples/helloworld/cdi2se/App.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/examples/helloworld-cdi2-se/src/main/java/org/glassfish/jersey/examples/helloworld/cdi2se/App.java
+++ b/examples/helloworld-cdi2-se/src/main/java/org/glassfish/jersey/examples/helloworld/cdi2se/App.java
@@ -25,7 +25,7 @@ import org.glassfish.grizzly.http.server.HttpServer;
  */
 public class App {
 
-    private static final URI BASE_URI = URI.create("http://localhost:8080/base/");
+    private static final URI BASE_URI = URI.create("http://localhost:8080/");
     public static final String ROOT_HELLO_PATH = "helloworld";
     public static final String ROOT_COUNTER_PATH = "counter";
 

--- a/examples/helloworld-cdi2-se/src/main/java/org/glassfish/jersey/examples/helloworld/cdi2se/App.java
+++ b/examples/helloworld-cdi2-se/src/main/java/org/glassfish/jersey/examples/helloworld/cdi2se/App.java
@@ -40,7 +40,7 @@ public class App {
             server.start();
 
             System.out.println("Application started.\nTry out");
-            System.out.println(String.format("%s%s", BASE_URI, ROOT_HELLO_PATH));
+            System.out.println(String.format("%s%s%s", BASE_URI, ROOT_HELLO_PATH, "/Some%Name"));
             System.out.println(String.format("%s%s%s", BASE_URI, ROOT_COUNTER_PATH, "/request"));
             System.out.println(String.format("%s%s%s", BASE_URI, ROOT_COUNTER_PATH, "/application"));
             System.out.println("Stop the application using CTRL+C");


### PR DESCRIPTION
This PR fixes *various bugs* of the **Helloworld CDI SE** example.

1. README.MD - Sample link misses mandatory parameter
2. pom.xml - Surplus prefix for main class
3. App.java - Surplus base path for root url