### PR TITLE
Remove openjdk8 option from Travis build matrix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ services:
 
 jdk:
   - oraclejdk8
-  - oraclejdk11
-  - openjdk8
+  - openjdk11
 
 cache:
   directories:


### PR DESCRIPTION
Replace oraclejdk11 with openjdk11