### PR TITLE
Issue 3753 - CDI2 doesn't work with BeanValidation

### DIFF
--- a/examples/helloworld-cdi2-se/pom.xml
+++ b/examples/helloworld-cdi2-se/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>jersey-cdi2-se</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-bean-validation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>

--- a/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/bean/SupplierBeanBridge.java
+++ b/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/bean/SupplierBeanBridge.java
@@ -143,4 +143,9 @@ class SupplierBeanBridge extends JerseyBean<Object> {
     public Class<? extends Annotation> getScope() {
         return binding.getScope() == null ? Dependent.class : transformScope(binding.getScope());
     }
+
+    @Override
+    public Class<?> getBeanClass() {
+        return (Class<?>) this.binding.getContracts().iterator().next();
+    }
 }


### PR DESCRIPTION
Caused by SuplierBeanBridge returning the same bean ID for all bindings.

Updated getBeanClass to return the contract class, making the bean ID
to relate to the actual type.

Signed-off-by: pa314159 <pa314159@users.noreply.github.com>