### PR TITLE
Issue 3753 - CDI2 doesn't work with BeanValidation

### DIFF
--- a/examples/helloworld-cdi2-se/pom.xml
+++ b/examples/helloworld-cdi2-se/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>jersey-cdi2-se</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-bean-validation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>

--- a/examples/helloworld-cdi2-se/src/main/java/org/glassfish/jersey/examples/helloworld/cdi2se/HelloWorldResource.java
+++ b/examples/helloworld-cdi2-se/src/main/java/org/glassfish/jersey/examples/helloworld/cdi2se/HelloWorldResource.java
@@ -10,13 +10,19 @@
 
 package org.glassfish.jersey.examples.helloworld.cdi2se;
 
+import java.security.Principal;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import static java.util.Optional.ofNullable;
 
 /**
  * Singleton-scoped resource.
@@ -33,7 +39,17 @@ public class HelloWorldResource {
     @GET
     @Path("{name}")
     @Produces("text/plain")
-    public String getHello(@PathParam("name") String name) {
-        return helloBean.hello(name);
+    public String getHello(@PathParam("name") @NotNull String name, @Context SecurityContext sc) {
+        final StringBuilder sb = new StringBuilder(this.helloBean.hello(name));
+
+        ofNullable(sc.getUserPrincipal())
+                .map(Principal::getName)
+                .ifPresent(p -> {
+                    sb.append("(");
+                    sb.append(p);
+                    sb.append(")");
+                });
+
+        return sb.toString();
     }
 }

--- a/ext/bean-validation/src/main/java/org/glassfish/jersey/server/validation/internal/InjectingConstraintValidatorFactory.java
+++ b/ext/bean-validation/src/main/java/org/glassfish/jersey/server/validation/internal/InjectingConstraintValidatorFactory.java
@@ -17,8 +17,6 @@
 package org.glassfish.jersey.server.validation.internal;
 
 import javax.ws.rs.container.ResourceContext;
-import javax.ws.rs.core.Context;
-
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorFactory;
 
@@ -27,10 +25,13 @@ import javax.validation.ConstraintValidatorFactory;
  *
  * @author Michal Gajdos
  */
-public class InjectingConstraintValidatorFactory implements ConstraintValidatorFactory {
+final class InjectingConstraintValidatorFactory implements ConstraintValidatorFactory {
 
-    @Context
-    private ResourceContext resourceContext;
+    private final ResourceContext resourceContext;
+
+    InjectingConstraintValidatorFactory(ResourceContext resourceContext) {
+        this.resourceContext = resourceContext;
+    }
 
     @Override
     public <T extends ConstraintValidator<?, ?>> T getInstance(final Class<T> key) {

--- a/ext/bean-validation/src/main/java/org/glassfish/jersey/server/validation/internal/ValidationBinder.java
+++ b/ext/bean-validation/src/main/java/org/glassfish/jersey/server/validation/internal/ValidationBinder.java
@@ -257,7 +257,7 @@ public final class ValidationBinder extends AbstractBinder {
             final ValidatorContext context = factory.usingContext();
 
             // Default Configuration.
-            context.constraintValidatorFactory(resourceContext.getResource(InjectingConstraintValidatorFactory.class));
+            context.constraintValidatorFactory(new InjectingConstraintValidatorFactory(resourceContext));
 
             // Traversable Resolver.
             context.traversableResolver(getTraversableResolver(factory.getTraversableResolver(), handler));

--- a/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/bean/SupplierBeanBridge.java
+++ b/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/bean/SupplierBeanBridge.java
@@ -143,4 +143,9 @@ class SupplierBeanBridge extends JerseyBean<Object> {
     public Class<? extends Annotation> getScope() {
         return binding.getScope() == null ? Dependent.class : transformScope(binding.getScope());
     }
+
+    @Override
+    public Class<?> getBeanClass() {
+        return (Class<?>) this.binding.getContracts().iterator().next();
+    }
 }


### PR DESCRIPTION
Caused by SuplierBeanBridge returning the same bean ID for all bindings.

Updated getBeanClass to return the contract class, making the bean ID
to relate to the actual type.

Signed-off-by: pa314159 <pa314159@users.noreply.github.com>