### PR TITLE
Fix NettyInputStream ByteBuf leak

### DIFF
--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
@@ -68,9 +68,11 @@ public class NettyInputStream extends InputStream {
         this.isList = isList;
     }
 
-    @Override
-    public int read(byte[] b, int off, int len) throws IOException {
+    private interface ISReader {
+        int readFrom(InputStream take) throws IOException;
+    }
 
+    private int readInternal(ISReader takeRead) throws IOException {
         if (end) {
             return -1;
         }
@@ -83,7 +85,7 @@ public class NettyInputStream extends InputStream {
                 return -1;
             }
 
-            int read = take.read(b, off, len);
+            int read = takeRead.readFrom(take);
 
             if (take.available() > 0) {
                 isList.addFirst(take);
@@ -98,29 +100,13 @@ public class NettyInputStream extends InputStream {
     }
 
     @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return readInternal(take -> take.read(b, off, len));
+    }
+
+    @Override
     public int read() throws IOException {
-
-        if (end) {
-            return -1;
-        }
-
-        try {
-            InputStream take = isList.take();
-
-            if (checkEndOfInput(take)) {
-                return -1;
-            }
-
-            int read = take.read();
-
-            if (take.available() > 0) {
-                isList.addFirst(take);
-            }
-
-            return read;
-        } catch (InterruptedException e) {
-            throw new IOException("Interrupted.", e);
-        }
+        return readInternal(InputStream::read);
     }
 
     @Override

--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
@@ -87,6 +87,8 @@ public class NettyInputStream extends InputStream {
 
             if (take.available() > 0) {
                 isList.addFirst(take);
+            } else {
+                take.close();
             }
 
             return read;

--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
@@ -72,7 +72,7 @@ public class NettyInputStream extends InputStream {
         int readFrom(InputStream take) throws IOException;
     }
 
-    private int readInternal(ISReader takeRead) throws IOException {
+    private int readInternal(ISReader isReader) throws IOException {
         if (end) {
             return -1;
         }
@@ -85,7 +85,7 @@ public class NettyInputStream extends InputStream {
                 return -1;
             }
 
-            int read = takeRead.readFrom(take);
+            int read = isReader.readFrom(take);
 
             if (take.available() > 0) {
                 isList.addFirst(take);

--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyHttp2ServerHandler.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyHttp2ServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyHttp2ServerHandler.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyHttp2ServerHandler.java
@@ -88,7 +88,7 @@ class JerseyHttp2ServerHandler extends ChannelDuplexHandler {
      * Process incoming data.
      */
     private void onDataRead(ChannelHandlerContext ctx, Http2DataFrame data) throws Exception {
-        isList.add(new ByteBufInputStream(data.content()));
+        isList.add(new ByteBufInputStream(data.content(), true));
         if (data.isEndStream()) {
             isList.add(NettyInputStream.END_OF_INPUT);
         }

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
@@ -100,7 +100,7 @@ class JerseyServerHandler extends ChannelInboundHandlerAdapter {
             ByteBuf content = httpContent.content();
 
             if (content.isReadable()) {
-                isList.add(new ByteBufInputStream(content));
+                isList.add(new ByteBufInputStream(content, true));
             }
 
             if (msg instanceof LastHttpContent) {

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/JerseyServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
If not closed here `take` goes unreferenced leading to a leak of the underlying ByteBuf.
`LEAK: ByteBuf.release() was not called before it's garbage-collected. See http://netty.io/wiki/reference-counted-objects.html for more information.`

