### PR TITLE
Allow HK2 2.5.0 for OSGi

### DIFF
--- a/bundles/jaxrs-ri/pom.xml
+++ b/bundles/jaxrs-ri/pom.xml
@@ -285,6 +285,7 @@
                             javax.persistence.*;resolution:=optional,
                             javax.validation.*;resolution:=optional;version="${range;[==,3);${javax.validation.api.version}}",
                             sun.misc.*;resolution:=optional,
+                            ${hk2.osgi.version},
                             *
                         ]]></Import-Package>
                         <Private-Package>

--- a/containers/glassfish/jersey-gf-ejb/pom.xml
+++ b/containers/glassfish/jersey-gf-ejb/pom.xml
@@ -119,6 +119,7 @@
                             ${javax.annotation.osgi.version},
                             org.glassfish.ejb.*;version="[4.0,6)",
                             org.glassfish.internal.*;version="[4.0,6)",
+                            ${hk2.osgi.version},
                             *
                         </Import-Package>
                     </instructions>

--- a/ext/cdi/jersey-cdi1x/pom.xml
+++ b/ext/cdi/jersey-cdi1x/pom.xml
@@ -83,7 +83,11 @@
                             org.glassfish.jersey.ext.cdi1x.spi,org.glassfish.jersey.ext.cdi1x.internal,
                             org.glassfish.jersey.ext.cdi1x.internal.spi
                         </Export-Package>
-                        <Import-Package>${javax.annotation.osgi.version},*</Import-Package>
+                        <Import-Package>
+                            ${javax.annotation.osgi.version},
+                            ${hk2.osgi.version},
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/inject/hk2/pom.xml
+++ b/inject/hk2/pom.xml
@@ -88,6 +88,8 @@
                         <Import-Package>
                             sun.misc.*;resolution:=optional,
                             ${javax.annotation.osgi.version},
+                            ${hk2.jvnet.osgi.version},
+                            ${hk2.osgi.version},
                             *
                         </Import-Package>
                     </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -2077,6 +2077,8 @@
         <helidon.version>1.0.3</helidon.version>
         <xmlunit.version>1.6</xmlunit.version>
         <hk2.version>2.6.1</hk2.version>
+        <hk2.osgi.version>org.glassfish.hk2.*;version="[2.5,3)"</hk2.osgi.version>
+        <hk2.jvnet.osgi.version>org.jvnet.hk2.*;version="[2.5,3)"</hk2.jvnet.osgi.version>
         <hk2.config.version>5.1.0</hk2.config.version>
         <httpclient.version>4.5.9</httpclient.version>
         <istack.commons.runtime.version>3.0.8</istack.commons.runtime.version>


### PR DESCRIPTION
Signed-off-by: Jan Supol <jan.supol@oracle.com>