### PR TITLE
Do not handle already handled requests on Jetty

### DIFF
--- a/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
+++ b/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
@@ -137,6 +137,10 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     public void handle(final String target, final Request request, final HttpServletRequest httpServletRequest,
                        final HttpServletResponse httpServletResponse) throws IOException, ServletException {
 
+        if (request.isHandled()) {
+            return;
+        }
+
         final Response response = request.getResponse();
         final ResponseWriter responseWriter = new ResponseWriter(request, response, configSetStatusOverSendError);
         final URI baseUri = getBaseUri(request);


### PR DESCRIPTION
Prevents EOFException if JettyHttpContainer is in a HandlerCollection and is downstream of another handler that successfully handled a request.

Resubmission of #4269 since adding "Signed-Off" to commit message blew up the commit history.