### PR TITLE
JsonBindingProvider provides JSON-B (not Jackson)

### DIFF
--- a/media/json-binding/pom.xml
+++ b/media/json-binding/pom.xml
@@ -53,7 +53,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>org.glassfish.jersey.jackson.*</Export-Package>
+                        <Export-Package>org.glassfish.jersey.jsonb.*</Export-Package>
                         <Import-Package>${javax.annotation.osgi.version},*</Import-Package>
                     </instructions>
                     <unpackBundle>true</unpackBundle>

--- a/media/json-binding/src/main/java/org/glassfish/jersey/jsonb/JsonBindingFeature.java
+++ b/media/json-binding/src/main/java/org/glassfish/jersey/jsonb/JsonBindingFeature.java
@@ -27,7 +27,7 @@ import org.glassfish.jersey.jsonb.internal.JsonBindingAutoDiscoverable;
 import org.glassfish.jersey.jsonb.internal.JsonBindingProvider;
 
 /**
- * Feature used to register Jackson JSON providers.
+ * Feature used to register JSON-B providers.
  * <p>
  * The Feature is automatically enabled when {@link JsonBindingAutoDiscoverable} is on classpath.
  * Default JSON-B configuration obtained by calling {@code JsonbBuilder.create()} is used.


### PR DESCRIPTION
This provider claimed to provide Jackson, but actually it does provide JSON-B.
