### PR TITLE
Throwing NoContentException when InputStream is empty

### DIFF
--- a/media/json-binding/src/main/java/org/glassfish/jersey/jsonb/internal/JsonBindingProvider.java
+++ b/media/json-binding/src/main/java/org/glassfish/jersey/jsonb/internal/JsonBindingProvider.java
@@ -75,14 +75,14 @@ public class JsonBindingProvider extends AbstractMessageReaderWriterProvider<Obj
         if (entityStream.markSupported()) {
             entityStream.mark(1);
             if (entityStream.read() == -1) {
-                throw new NoContentException("JSON-B cannot process empty input stream");
+                throw new NoContentException(LocalizationMessages.ERROR_JSONB_EMPTYSTREAM());
             }
             entityStream.reset();
         } else {
             final PushbackInputStream buffer = new PushbackInputStream(entityStream);
             final int firstByte = buffer.read();
             if (firstByte == -1) {
-                throw new NoContentException("JSON-B cannot process empty input stream");
+                throw new NoContentException(LocalizationMessages.ERROR_JSONB_EMPTYSTREAM());
             }
             buffer.unread(firstByte);
             entityStream = buffer;

--- a/media/json-binding/src/main/resources/org/glassfish/jersey/jsonb/localization.properties
+++ b/media/json-binding/src/main/resources/org/glassfish/jersey/jsonb/localization.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,3 +16,4 @@
 
 error.jsonb.serialization=Error writing JSON-B serialized object.
 error.jsonb.deserialization=Error deserializing object from entity stream.
+error.jsonb.emptystream=JSON-B cannot parse empty input stream.

--- a/media/json-binding/src/test/java/org/glassfish/jersey/jsonb/internal/JsonBindingProviderTest.java
+++ b/media/json-binding/src/test/java/org/glassfish/jersey/jsonb/internal/JsonBindingProviderTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2020 Markus KARG
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.jsonb.internal;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NoContentException;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Providers;
+
+import org.junit.Test;
+
+/**
+ * Unit Test for {@link JsonBindingProvider}.
+ *
+ * @author Markus KARG (markus@headcrashing.eu)
+ */
+public final class JsonBindingProviderTest {
+
+    @Test(expected = NoContentException.class)
+    public final void shouldThrowNoContentException() throws IOException {
+        // given
+        final Providers providers = new EmptyProviders();
+        final MessageBodyReader<Foo> mbr = (MessageBodyReader) new JsonBindingProvider(providers);
+
+        // when
+        mbr.readFrom(Foo.class, Foo.class, new Annotation[0], APPLICATION_JSON_TYPE,
+                new EmptyMultivaluedMap<String, String>(), new ByteArrayInputStream(new byte[0]));
+
+        // then
+        // should throw NoContentException
+    }
+
+    private static final class Foo {
+        // no members
+    }
+
+    private static final class EmptyProviders implements Providers {
+
+        @Override
+        public final <T> MessageBodyReader<T> getMessageBodyReader(final Class<T> type, final Type genericType,
+                final Annotation[] annotations, final MediaType mediaType) {
+            return null;
+        }
+
+        @Override
+        public final <T> MessageBodyWriter<T> getMessageBodyWriter(final Class<T> type, final Type genericType,
+                final Annotation[] annotations, final MediaType mediaType) {
+            return null;
+        }
+
+        @Override
+        public final <T extends Throwable> ExceptionMapper<T> getExceptionMapper(final Class<T> type) {
+            return null;
+        }
+
+        @Override
+        public final <T> ContextResolver<T> getContextResolver(final Class<T> contextType, final MediaType mediaType) {
+            return null;
+        }
+
+    }
+
+    private static final class EmptyMultivaluedMap<K, V> implements MultivaluedMap<K, V> {
+
+        @Override
+        public final int size() {
+            return 0;
+        }
+
+        @Override
+        public final boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public final boolean containsKey(final Object key) {
+            return false;
+        }
+
+        @Override
+        public final boolean containsValue(final Object value) {
+            return false;
+        }
+
+        @Override
+        public final List<V> get(final Object key) {
+            return null;
+        }
+
+        @Override
+        public final List<V> put(final K key, final List<V> value) {
+            return null;
+        }
+
+        @Override
+        public final List<V> remove(final Object key) {
+            return null;
+        }
+
+        @Override
+        public final void putAll(final Map<? extends K, ? extends List<V>> m) {
+        }
+
+        @Override
+        public final void clear() {
+        }
+
+        @Override
+        public final Set<K> keySet() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public final Collection<List<V>> values() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public final Set<Entry<K, List<V>>> entrySet() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public final void putSingle(final K key, final V value) {
+        }
+
+        @Override
+        public final void add(final K key, final V value) {
+        }
+
+        @Override
+        public final V getFirst(final K key) {
+            return null;
+        }
+
+        @Override
+        public final void addAll(final K key, final V... newValues) {
+        }
+
+        @Override
+        public final void addAll(final K key, final List<V> valueList) {
+        }
+
+        @Override
+        public final void addFirst(final K key, final V value) {
+        }
+
+        @Override
+        public final boolean equalsIgnoreValueOrder(final MultivaluedMap<K, V> otherMap) {
+            return false;
+        }
+
+    }
+
+}

--- a/media/json-binding/src/test/java/org/glassfish/jersey/jsonb/internal/JsonBindingProviderTest.java
+++ b/media/json-binding/src/test/java/org/glassfish/jersey/jsonb/internal/JsonBindingProviderTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NoContentException;
 import javax.ws.rs.ext.ContextResolver;
@@ -54,7 +55,7 @@ public final class JsonBindingProviderTest {
 
         // when
         mbr.readFrom(Foo.class, Foo.class, new Annotation[0], APPLICATION_JSON_TYPE,
-                new EmptyMultivaluedMap<String, String>(), new ByteArrayInputStream(new byte[0]));
+                new MultivaluedHashMap<>(), new ByteArrayInputStream(new byte[0]));
 
         // then
         // should throw NoContentException
@@ -86,98 +87,6 @@ public final class JsonBindingProviderTest {
         @Override
         public final <T> ContextResolver<T> getContextResolver(final Class<T> contextType, final MediaType mediaType) {
             return null;
-        }
-
-    }
-
-    private static final class EmptyMultivaluedMap<K, V> implements MultivaluedMap<K, V> {
-
-        @Override
-        public final int size() {
-            return 0;
-        }
-
-        @Override
-        public final boolean isEmpty() {
-            return true;
-        }
-
-        @Override
-        public final boolean containsKey(final Object key) {
-            return false;
-        }
-
-        @Override
-        public final boolean containsValue(final Object value) {
-            return false;
-        }
-
-        @Override
-        public final List<V> get(final Object key) {
-            return null;
-        }
-
-        @Override
-        public final List<V> put(final K key, final List<V> value) {
-            return null;
-        }
-
-        @Override
-        public final List<V> remove(final Object key) {
-            return null;
-        }
-
-        @Override
-        public final void putAll(final Map<? extends K, ? extends List<V>> m) {
-        }
-
-        @Override
-        public final void clear() {
-        }
-
-        @Override
-        public final Set<K> keySet() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public final Collection<List<V>> values() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public final Set<Entry<K, List<V>>> entrySet() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public final void putSingle(final K key, final V value) {
-        }
-
-        @Override
-        public final void add(final K key, final V value) {
-        }
-
-        @Override
-        public final V getFirst(final K key) {
-            return null;
-        }
-
-        @Override
-        public final void addAll(final K key, final V... newValues) {
-        }
-
-        @Override
-        public final void addAll(final K key, final List<V> valueList) {
-        }
-
-        @Override
-        public final void addFirst(final K key, final V value) {
-        }
-
-        @Override
-        public final boolean equalsIgnoreValueOrder(final MultivaluedMap<K, V> otherMap) {
-            return false;
         }
 
     }


### PR DESCRIPTION
Since JAX-RS 2.1 an MBR must react upon an empty stream either with an empty instance or with NoContentException, but Jersey's JSON-B MBR does neither - it simply throws ProcessingException:

_"In case the entity input stream is empty, the reader is expected to either return a Java representation of a zero-length entity or throw a javax.ws.rs.core.NoContentException in case no zero-length entity representation is defined for the supported Java type."_