### PR TITLE
HK2 to skip fields injected by CDI in non bean-defining-annotated beans

### DIFF
--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
@@ -826,7 +826,7 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
         int skippedElements = methodsToSkip.size() + fieldsToSkip.size();
 
         ClassAnalyzer customizedClassAnalyzer = skippedElements > 0
-                ? new InjecteeSkippingAnalyzer(defaultClassAnalyzer, methodsToSkip, fieldsToSkip)
+                ? new InjecteeSkippingAnalyzer(defaultClassAnalyzer, methodsToSkip, fieldsToSkip, beanManager)
                 : defaultClassAnalyzer;
 
         Binder binder = new AbstractBinder() {

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/InjecteeSkippingAnalyzer.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/InjecteeSkippingAnalyzer.java
@@ -108,7 +108,7 @@ public final class InjecteeSkippingAnalyzer implements ClassAnalyzer {
 
     private void addCdiInjectedFieldsToSkip(Set<Field> skippedFields, Set<Field> originalFields) {
         for (Field field : originalFields) {
-            if (field.getAnnotation(Inject.class) != null && !beanManager.getBeans(field.getType()).isEmpty()) {
+            if (field.getAnnotation(Inject.class) != null) {
                 skippedFields.add(field);
             }
         }

--- a/tests/integration/cdi-integration/cdi-manually-bound/pom.xml
+++ b/tests/integration/cdi-integration/cdi-manually-bound/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>cdi-integration-project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration.cdi</groupId>
+        <version>2.30-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cdi-manually-bound</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>3.0.3.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-util</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-bundle</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext.cdi</groupId>
+            <artifactId>jersey-weld2-se</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.enterprise</groupId>
+                    <artifactId>cdi-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+
+</project>

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiService.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+public interface CdiService<T> {
+    void doService(T t);
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiServiceExtension.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiServiceExtension.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import java.io.IOException;
+
+public class CdiServiceExtension implements Extension {
+    public void observe(@Observes AfterBeanDiscovery event, BeanManager beanManager) throws IOException, ClassNotFoundException {
+        event.addBean()
+                .addType(CdiService.class)
+                .beanClass(CdiService.class)
+                .scope(ApplicationScoped.class)
+                .createWith(context -> new CdiServiceImpl());
+    }
+
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiServiceExtension.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiServiceExtension.java
@@ -19,12 +19,11 @@ package org.glassfish.jersey.tests.cdi.manuallybound;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
-import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 import java.io.IOException;
 
 public class CdiServiceExtension implements Extension {
-    public void observe(@Observes AfterBeanDiscovery event, BeanManager beanManager) throws IOException, ClassNotFoundException {
+    public void observe(@Observes AfterBeanDiscovery event) throws IOException, ClassNotFoundException {
         event.addBean()
                 .addType(CdiService.class)
                 .beanClass(CdiService.class)

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiServiceImpl.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+public class CdiServiceImpl implements CdiService<StringBuilder> {
+
+    @Override
+    public void doService(StringBuilder sb) {
+        sb.append(getClass().getSimpleName());
+    }
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/NoBeanDefiningAnnotationContainerFilter.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/NoBeanDefiningAnnotationContainerFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+import java.util.Collections;
+
+public class NoBeanDefiningAnnotationContainerFilter implements ContainerResponseFilter {
+
+    @Inject
+    CdiService service;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        if (service != null) {
+            StringBuilder sb = new StringBuilder();
+            service.doService(sb);
+            responseContext.getHeaders().put(
+                    NoBeanDefiningAnnotationContainerFilter.class.getSimpleName(),
+                    Collections.singletonList(sb.toString())
+            );
+        }
+    }
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/Resource.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/Resource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/")
+public class Resource {
+    @GET
+    public String get() {
+        return Resource.class.getSimpleName();
+    }
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/resources/META-INF/beans.xml
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+
+<beans
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+        http://java.sun.com/xml/ns/javaee/beans_1_0.xsd" bean-discovery-mode="none">
+</beans>

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.glassfish.jersey.tests.cdi.manuallybound.CdiServiceExtension

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/webapp/WEB-INF/web.xml
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+</web-app>

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/test/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiServiceInjectTest.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/test/java/org/glassfish/jersey/tests/cdi/manuallybound/CdiServiceInjectTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+import org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.external.ExternalTestContainerFactory;
+import org.jboss.weld.environment.se.Weld;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+public class CdiServiceInjectTest extends JerseyTest {
+    private Weld weld;
+
+    @Before
+    public void setup() {
+        Assume.assumeTrue(Hk2InjectionManagerFactory.isImmediateStrategy());
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        if (Hk2InjectionManagerFactory.isImmediateStrategy()) {
+            if (!ExternalTestContainerFactory.class.isAssignableFrom(getTestContainerFactory().getClass())) {
+                weld = new Weld();
+                weld.initialize();
+            }
+            super.setUp();
+        }
+    }
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(NoBeanDefiningAnnotationContainerFilter.class, Resource.class);
+    }
+
+    @Test
+    public void testServiceIsInjected() {
+        try (Response response = target().request().get()) {
+            String header = response.getStringHeaders().getFirst(NoBeanDefiningAnnotationContainerFilter.class.getSimpleName());
+            Assert.assertEquals(CdiServiceImpl.class.getSimpleName(), header);
+        }
+    }
+}

--- a/tests/integration/cdi-integration/pom.xml
+++ b/tests/integration/cdi-integration/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <version>2.30-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.glassfish.jersey.tests.integration.cdi</groupId>
+    <artifactId>cdi-integration-project</artifactId>
+    <name>cdi-integration-project</name>
+    <modules>
+        <module>cdi-manually-bound</module>
+    </modules>
+    <packaging>pom</packaging>
+
+</project>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -38,6 +38,7 @@
         <module>cdi-beanvalidation-webapp</module>
         <module>cdi-ejb-test-webapp</module>
         <module>cdi-iface-with-non-jaxrs-impl-test-webapp</module>
+        <module>cdi-integration</module>
         <module>cdi-log-check</module>
         <module>cdi-multimodule</module>
         <module>ejb-multimodule-reload</module>


### PR DESCRIPTION
Signed-off-by: Jan Supol <jan.supol@oracle.com>