### PR TITLE
Assure that exception in async interceptor doesn't prevent completion

### DIFF
--- a/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/MethodModel.java
+++ b/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/MethodModel.java
@@ -278,7 +278,15 @@ class MethodModel {
                 result.completeExceptionally(e);
             }
         }).exceptionally(throwable -> {
-            asyncInterceptors.forEach(AsyncInvocationInterceptor::removeContext);
+            // Since it could have been the removeContext method causing exception, we need to be more careful
+            // to assure, that the future completes
+            asyncInterceptors.forEach(interceptor -> {
+                try {
+                    interceptor.removeContext();
+                } catch (Throwable e) {
+                    throwable.addSuppressed(e);
+                }
+            });
             result.completeExceptionally(throwable);
             return null;
         });


### PR DESCRIPTION
I accidentally run Jersey REST Client against TCK version 1.1, which isn't binary comatible.

`AsyncMethodTest` hung with it, because `AsyncInvocationInterceptor` didn't yet have method `removeContext`, and therefore this invocation

https://github.com/eclipse-ee4j/jersey/blob/959b4e799721796668f0e185ea3eb9a67ac442c7/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/MethodModel.java#L267

was throwing `AbstractMethodError`. This again happened in `exceptionally` callback, causing resulting `CompletableFuture` to never complete.

The change will propagate any AsyncInvocationInterceptor failure to completion result.