### PR TITLE
exclude javax.validation-api from hibernate dependency

### DIFF
--- a/ext/bean-validation/pom.xml
+++ b/ext/bean-validation/pom.xml
@@ -89,6 +89,12 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- java-el related dependencies are in scope "provided" in hibernate-validator -->


### PR DESCRIPTION
Fixes #4295 

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>