### PR TITLE
Take Hk2CustomBoundTypesProvider into an account

### DIFF
--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
@@ -728,6 +728,14 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
     }
 
     /**
+     * Get the types provided by HK2
+     * @return Types that HK2 is to inject
+     */
+    /* package */ boolean isHk2ProvidedType(Type type) {
+        return hk2ProvidedTypes.contains(type);
+    }
+
+    /**
      * Gets you fields to skip from a proxied instance.
      * <p/>
      * Note: Do NOT lower the visibility of this method. CDI proxies need at least this visibility.

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/InjecteeSkippingAnalyzer.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/InjecteeSkippingAnalyzer.java
@@ -45,6 +45,7 @@ public final class InjecteeSkippingAnalyzer implements ClassAnalyzer {
     private final Map<Class<?>, Set<Method>> methodsToSkip;
     private final Map<Class<?>, Set<Field>> fieldsToSkip;
     private final BeanManager beanManager;
+    private final CdiComponentProvider cdiComponentProvider;
 
     public InjecteeSkippingAnalyzer(ClassAnalyzer defaultAnalyzer,
                                     Map<Class<?>, Set<Method>> methodsToSkip,
@@ -54,6 +55,7 @@ public final class InjecteeSkippingAnalyzer implements ClassAnalyzer {
         this.methodsToSkip = methodsToSkip;
         this.fieldsToSkip = fieldsToSkip;
         this.beanManager = beanManager;
+        this.cdiComponentProvider = beanManager.getExtension(CdiComponentProvider.class);
     }
 
     @Override
@@ -108,7 +110,7 @@ public final class InjecteeSkippingAnalyzer implements ClassAnalyzer {
 
     private void addCdiInjectedFieldsToSkip(Set<Field> skippedFields, Set<Field> originalFields) {
         for (Field field : originalFields) {
-            if (field.getAnnotation(Inject.class) != null) {
+            if (field.getAnnotation(Inject.class) != null && !cdiComponentProvider.isHk2ProvidedType(field.getType())) {
                 skippedFields.add(field);
             }
         }

--- a/tests/integration/cdi-integration/cdi-manually-bound/pom.xml
+++ b/tests/integration/cdi-integration/cdi-manually-bound/pom.xml
@@ -32,12 +32,10 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.enterprise</groupId>
@@ -45,14 +43,19 @@
             <version>2.0</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.ext.cdi</groupId>
+            <artifactId>jersey-cdi1x</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
             <version>3.0.3.Final</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework</groupId>
             <artifactId>jersey-test-framework-util</artifactId>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2Binder.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2Binder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+
+import javax.inject.Singleton;
+
+public class HK2Binder extends AbstractBinder {
+    @Override
+    protected void configure() {
+        bindAsContract(HK2ServiceImpl.class).to(HK2Service.class).in(Singleton.class);
+    }
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2InjectedFilter.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2InjectedFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Configuration;
+import java.io.IOException;
+
+public class HK2InjectedFilter implements ContainerResponseFilter {
+    @Inject
+    HK2Service service;
+
+    @Inject
+    Configuration configuration;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        final StringBuilder stringBuilder = new StringBuilder();
+        if (service != null) {
+            service.service(stringBuilder);
+            responseContext.getHeaders().add(HK2InjectedFilter.class.getSimpleName(), stringBuilder.toString());
+        }
+    }
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2Service.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2Service.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+public interface HK2Service {
+    void service(StringBuilder stringBuilder);
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2ServiceExtension.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2ServiceExtension.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.literal.InjectLiteral;
+import javax.enterprise.inject.spi.AfterTypeDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
+
+/*
+ * Replaces bean-discovery-mode="annotated" + @ApplicationScoped on HK2InjectedFilter
+ */
+public class HK2ServiceExtension implements Extension {
+    public void observeAfterTypeDiscovery(@Observes AfterTypeDiscovery event, BeanManager beanManager) {
+        event.addAnnotatedType(HK2InjectedFilter.class, "test-hk2service");
+    }
+
+    public void decorateAnnotatedType(@Observes ProcessAnnotatedType<HK2InjectedFilter> pat, BeanManager beanManager) {
+        AnnotatedTypeConfigurator<HK2InjectedFilter> annotatedTypeConfigurator = pat.configureAnnotatedType();
+
+        annotatedTypeConfigurator.filterFields(service -> service.getBaseType() == HK2Service.class).findFirst().get()
+                .remove(a -> a.equals(InjectLiteral.INSTANCE));
+    }
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2ServiceImpl.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2ServiceImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+public class HK2ServiceImpl implements HK2Service {
+    @Override
+    public void service(StringBuilder stringBuilder) {
+        stringBuilder.append(HK2ServiceImpl.class.getSimpleName());
+    }
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/Hk2CustomTypesProvider.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/java/org/glassfish/jersey/tests/cdi/manuallybound/Hk2CustomTypesProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.cdi.manuallybound;
+
+import org.glassfish.jersey.ext.cdi1x.spi.Hk2CustomBoundTypesProvider;
+
+import javax.ws.rs.core.Configuration;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Hk2CustomTypesProvider implements Hk2CustomBoundTypesProvider {
+
+    @Override
+    public Set<Type> getHk2Types(){
+        Set<Type> set = new HashSet<>();
+        set.add(Configuration.class);
+        set.add(HK2Service.class);
+        return set;
+    }
+}

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,1 +1,2 @@
 org.glassfish.jersey.tests.cdi.manuallybound.CdiServiceExtension
+org.glassfish.jersey.tests.cdi.manuallybound.HK2ServiceExtension

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/main/resources/META-INF/services/org.glassfish.jersey.ext.cdi1x.spi.Hk2CustomBoundTypesProvider
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/main/resources/META-INF/services/org.glassfish.jersey.ext.cdi1x.spi.Hk2CustomBoundTypesProvider
@@ -1,0 +1,1 @@
+org.glassfish.jersey.tests.cdi.manuallybound.Hk2CustomTypesProvider

--- a/tests/integration/cdi-integration/cdi-manually-bound/src/test/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2ServiceInjectTest.java
+++ b/tests/integration/cdi-integration/cdi-manually-bound/src/test/java/org/glassfish/jersey/tests/cdi/manuallybound/HK2ServiceInjectTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
-public class CdiServiceInjectTest extends JerseyTest {
+public class HK2ServiceInjectTest extends JerseyTest {
     private Weld weld;
 
     @Before
@@ -56,14 +56,14 @@ public class CdiServiceInjectTest extends JerseyTest {
 
     @Override
     protected Application configure() {
-        return new ResourceConfig(NoBeanDefiningAnnotationContainerFilter.class, Resource.class);
+        return new ResourceConfig(Resource.class, HK2InjectedFilter.class).register(new HK2Binder());
     }
 
     @Test
-    public void testCdiServiceIsInjected() {
+    public void testHK2ServiceIsInjected() {
         try (Response response = target().request().get()) {
-            String header = response.getStringHeaders().getFirst(NoBeanDefiningAnnotationContainerFilter.class.getSimpleName());
-            Assert.assertEquals(CdiServiceImpl.class.getSimpleName(), header);
+            String header = response.getStringHeaders().getFirst(HK2InjectedFilter.class.getSimpleName());
+            Assert.assertEquals(HK2ServiceImpl.class.getSimpleName(), header);
         }
     }
 }


### PR DESCRIPTION
when skipping @Inject annotated fields for HK2

Signed-off-by: Jan Supol <jan.supol@oracle.com>