### PR TITLE
Automatically serialize/deserialize Java 8 datatype

### DIFF
--- a/media/json-jackson/pom.xml
+++ b/media/json-jackson/pom.xml
@@ -117,6 +117,10 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/jackson/jaxrs/json/JsonMapperConfigurator.java
+++ b/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/jackson/jaxrs/json/JsonMapperConfigurator.java
@@ -2,6 +2,7 @@ package org.glassfish.jersey.jackson.internal.jackson.jaxrs.json;
 
 import java.util.ArrayList;
 
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.cfg.Annotations;
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.cfg.MapperConfiguratorBase;
 
@@ -44,6 +45,8 @@ public class JsonMapperConfigurator
     public synchronized ObjectMapper getDefaultMapper() {
         if (_defaultMapper == null) {
             _defaultMapper = new ObjectMapper();
+            // We can remove this once we move to Jackson 3.0
+            _defaultMapper.registerModule(new Jdk8Module());
             _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
         }
         return _defaultMapper;
@@ -65,6 +68,8 @@ public class JsonMapperConfigurator
     {
         if (_mapper == null) {
             _mapper = new ObjectMapper();
+            // We can remove this once we move to Jackson 3.0
+            _mapper.registerModule(new Jdk8Module());
             _setAnnotations(_mapper, _defaultAnnotationsToUse);
         }
         return _mapper;

--- a/pom.xml
+++ b/pom.xml
@@ -1722,6 +1722,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${jackson1.version}</version>

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -365,6 +365,11 @@
             <artifactId>jackson-xc</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
This patch adds support for automatically serializing and deserialzing for new "datatypes" introduced in Java 8 for jersey-media-json-jackson module.

Fixes #3637. 