### PR TITLE
Rewritten Netty Jersey implementation using direct ByteBuf consumption

### DIFF
--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/JerseyClientHandler.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/JerseyClientHandler.java
@@ -16,7 +16,6 @@
 
 package org.glassfish.jersey.netty.connector;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
@@ -31,6 +30,7 @@ import org.glassfish.jersey.client.spi.AsyncConnectorCallback;
 import org.glassfish.jersey.netty.connector.internal.NettyInputStream;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.HttpContent;
@@ -50,7 +50,7 @@ import io.netty.util.concurrent.GenericFutureListener;
 class JerseyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
 
     private final NettyConnector connector;
-    private final LinkedBlockingDeque<InputStream> isList = new LinkedBlockingDeque<>();
+    private final LinkedBlockingDeque<ByteBuf> isList = new LinkedBlockingDeque<>();
 
     private final AsyncConnectorCallback asyncConnectorCallback;
     private final ClientRequest jerseyRequest;
@@ -89,7 +89,7 @@ class JerseyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
             for (Map.Entry<String, String> entry : response.headers().entries()) {
                 jerseyResponse.getHeaders().add(entry.getKey(), entry.getValue());
             }
-
+            isList.clear(); // clearing the content - possible leftover from previous request processing.
             // request entity handling.
             if ((response.headers().contains(HttpHeaderNames.CONTENT_LENGTH) && HttpUtil.getContentLength(response) > 0)
                     || HttpUtil.isTransferEncodingChunked(response)) {
@@ -97,7 +97,7 @@ class JerseyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
                 ctx.channel().closeFuture().addListener(new GenericFutureListener<Future<? super Void>>() {
                     @Override
                     public void operationComplete(Future<? super Void> future) throws Exception {
-                        isList.add(NettyInputStream.END_OF_INPUT_ERROR);
+                        isList.add(Unpooled.EMPTY_BUFFER);
                     }
                 });
 
@@ -123,21 +123,16 @@ class JerseyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
 
         }
         if (msg instanceof HttpContent) {
-
             HttpContent httpContent = (HttpContent) msg;
 
             ByteBuf content = httpContent.content();
-
             if (content.isReadable()) {
-                // copy bytes - when netty reads last chunk, it automatically closes the channel, which invalidates all
-                // relates ByteBuffs.
-                byte[] bytes = new byte[content.readableBytes()];
-                content.getBytes(content.readerIndex(), bytes);
-                isList.add(new ByteArrayInputStream(bytes));
+                content.retain();
+                isList.add(content);
             }
 
             if (msg instanceof LastHttpContent) {
-                isList.add(NettyInputStream.END_OF_INPUT);
+                isList.add(Unpooled.EMPTY_BUFFER);
             }
         }
     }
@@ -153,6 +148,6 @@ class JerseyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
             });
         }
         future.completeExceptionally(cause);
-        isList.add(NettyInputStream.END_OF_INPUT_ERROR);
+        ctx.close();
     }
 }

--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/JerseyChunkedInput.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/JerseyChunkedInput.java
@@ -42,10 +42,9 @@ import io.netty.handler.stream.ChunkedInput;
 public class JerseyChunkedInput extends OutputStream implements ChunkedInput<ByteBuf>, ChannelFutureListener {
 
     private static final ByteBuffer VOID = ByteBuffer.allocate(0);
-    private static final int CAPACITY = 8;
-    // TODO this needs to be configurable, see JERSEY-3228
-    private static final int WRITE_TIMEOUT = 10000;
-    private static final int READ_TIMEOUT = 10000;
+    private static final int CAPACITY = Integer.getInteger("jersey.ci.capacity", 8);
+    private static final int WRITE_TIMEOUT = Integer.getInteger("jersey.ci.read.timeout", 10000);
+    private static final int READ_TIMEOUT = Integer.getInteger("jersey.ci.write.timeout", 10000);
 
     private final LinkedBlockingDeque<ByteBuffer> queue = new LinkedBlockingDeque<>(CAPACITY);
     private final Channel ctx;

--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/NettyInputStream.java
@@ -20,77 +20,47 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.LinkedBlockingDeque;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
 /**
  * Input stream which servers as Request entity input.
  * <p>
- * Converts Netty NIO buffers to an input streams and stores them in the queue,
- * waiting for Jersey to process it.
- *
- * @author Pavel Bucek
+ * Consumes a list of pending {@link ByteBuf}s and processes them on request by Jersey
  */
 public class NettyInputStream extends InputStream {
 
-    private volatile boolean end = false;
+    private final LinkedBlockingDeque<ByteBuf> isList;
 
-    /**
-     * End of input.
-     */
-    public static final InputStream END_OF_INPUT = new InputStream() {
-        @Override
-        public int read() throws IOException {
-            return 0;
-        }
-
-        @Override
-        public String toString() {
-            return "END_OF_INPUT " + super.toString();
-        }
-    };
-
-    /**
-     * Unexpected end of input.
-     */
-    public static final InputStream END_OF_INPUT_ERROR = new InputStream() {
-        @Override
-        public int read() throws IOException {
-            return 0;
-        }
-
-        @Override
-        public String toString() {
-            return "END_OF_INPUT_ERROR " + super.toString();
-        }
-    };
-
-    private final LinkedBlockingDeque<InputStream> isList;
-
-    public NettyInputStream(LinkedBlockingDeque<InputStream> isList) {
+    public NettyInputStream(LinkedBlockingDeque<ByteBuf> isList) {
         this.isList = isList;
     }
 
-    private interface ISReader {
-        int readFrom(InputStream take) throws IOException;
-    }
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
 
-    private int readInternal(ISReader isReader) throws IOException {
-        if (end) {
-            return -1;
-        }
-
-        InputStream take;
+        ByteBuf take;
         try {
             take = isList.take();
-
-            if (checkEndOfInput(take)) {
+            boolean isReadable = take.isReadable();
+            int read = -1;
+            if (checkEndOfInputOrError(take)) {
+                take.release();
                 return -1;
             }
 
-            int read = isReader.readFrom(take);
-
-            if (take.available() > 0) {
-                isList.addFirst(take);
+            if (isReadable) {
+                int readableBytes = take.readableBytes();
+                read = Math.min(readableBytes, len);
+                take.readBytes(b, off, read);
+                if (read < len) {
+                    take.release();
+                } else {
+                    isList.addFirst(take);
+                }
             } else {
-                take.close();
+                read = 0;
+                take.release(); //We don't need `0`
             }
 
             return read;
@@ -100,33 +70,53 @@ public class NettyInputStream extends InputStream {
     }
 
     @Override
-    public int read(byte[] b, int off, int len) throws IOException {
-        return readInternal(take -> take.read(b, off, len));
+    public int read() throws IOException {
+
+        ByteBuf take;
+        try {
+            take = isList.take();
+            boolean isReadable = take.isReadable();
+            if (checkEndOfInputOrError(take)) {
+                take.release();
+                return -1;
+            }
+
+            if (isReadable) {
+                return take.readInt();
+            } else {
+                take.release(); //We don't need `0`
+            }
+
+            return 0;
+        } catch (InterruptedException e) {
+            throw new IOException("Interrupted.", e);
+        }
     }
 
     @Override
-    public int read() throws IOException {
-        return readInternal(InputStream::read);
+    public void close() throws IOException {
+        if (isList != null) {
+            while (!isList.isEmpty()) {
+                try {
+                    isList.take().release();
+                } catch (InterruptedException e) {
+                    throw new IOException("Interrupted. Potential ByteBuf Leak.", e);
+                }
+            }
+        }
+        super.close();
     }
 
     @Override
     public int available() throws IOException {
-        InputStream peek = isList.peek();
-        if (peek != null) {
-            return peek.available();
+        ByteBuf peek = isList.peek();
+        if (peek != null && peek.isReadable()) {
+            return peek.readableBytes();
         }
-
         return 0;
     }
 
-    private boolean checkEndOfInput(InputStream take) throws IOException {
-        if (take == END_OF_INPUT) {
-            end = true;
-            return true;
-        } else if (take == END_OF_INPUT_ERROR) {
-            end = true;
-            throw new IOException("Connection was closed prematurely.");
-        }
-        return false;
+    private boolean checkEndOfInputOrError(ByteBuf take) throws IOException {
+        return take == Unpooled.EMPTY_BUFFER;
     }
 }

--- a/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/NettyResponseWriter.java
+++ b/containers/netty-http/src/main/java/org/glassfish/jersey/netty/httpserver/NettyResponseWriter.java
@@ -46,7 +46,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 /**
  * Netty implementation of {@link ContainerResponseWriter}.
  *
- * @author Pavel Bucek
+ * @author Pavel Bucek (pavel.bucek at oracle.com)
  */
 class NettyResponseWriter implements ContainerResponseWriter {
 
@@ -119,7 +119,11 @@ class NettyResponseWriter implements ContainerResponseWriter {
 
             JerseyChunkedInput jerseyChunkedInput = new JerseyChunkedInput(ctx.channel());
 
-            ctx.write(new HttpChunkedInput(jerseyChunkedInput)).addListener(FLUSH_FUTURE);
+            if (HttpUtil.isTransferEncodingChunked(response)) {
+                ctx.writeAndFlush(new HttpChunkedInput(jerseyChunkedInput));
+            } else {
+                ctx.write(new HttpChunkedInput(jerseyChunkedInput)).addListener(FLUSH_FUTURE);
+            }
             return jerseyChunkedInput;
 
         } else {


### PR DESCRIPTION
This commit contains a rewritten implementation of Netty Jersey server and client with the following major changes:
1) Consume `ByteBuf`s from `HttpContent` as-is for processing, reduces a lot of overhead.
2) Fixes a bug on reading 0-byte or 1-byte JSON content
3) Add three new configurable `ChunkedInput` buffer properties through `jersey.ci.capacity`, `jersey.ci.read.timeout` and `jersey.ci.write.timeout`
4) Add configurable payload size through `jersey.max.http.request.entitySizeMb` , defaults to 50 Mb

This change should fix some of the long pending bug reports in eclipse-ee4j#3500 , eclipse-ee4j#3568 and eclipse-ee4j#4286 . This may also resolve eclipse-ee4j#4285

Signed-off-by: Venkat Ganesh <010gvr@gmail.com>