### PR TITLE
Override HK2 dependency versions with versions used in Jersey

### DIFF
--- a/inject/hk2/pom.xml
+++ b/inject/hk2/pom.xml
@@ -42,6 +42,22 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-locator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>${javassist.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Signed-off-by: Jan Supol <jan.supol@oracle.com>
