### PR TITLE
Close SseEventSink at the end of the example

### DIFF
--- a/examples/server-sent-events-jaxrs/src/test/java/org/glassfish/jersey/examples/sse/jaxrs/ServerSentEventsTest.java
+++ b/examples/server-sent-events-jaxrs/src/test/java/org/glassfish/jersey/examples/sse/jaxrs/ServerSentEventsTest.java
@@ -86,12 +86,13 @@ public class ServerSentEventsTest extends JerseyTest {
         });
 
         eventSource.open();
-        target().path(App.ROOT_PATH).request().post(Entity.text("message"));
+        target().path(App.ROOT_PATH).request().post(Entity.text("message")).close();
 
         try {
             assertTrue("Waiting for message to be delivered has timed out.",
                     latch.await(5 * getAsyncTimeoutMultiplier(), TimeUnit.SECONDS));
         } finally {
+            target().path(App.ROOT_PATH).request().delete().close();
             eventSource.close();
         }
         assertThat("Unexpected SSE event data value.", message.get(), equalTo("message"));


### PR DESCRIPTION
Signed-off-by: Jan Supol <jan.supol@oracle.com>