### PR TITLE
Set Apache Connector behaviour for Apache Http Client prior 4.5.1 to …

### DIFF
--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
@@ -156,6 +156,41 @@ public final class ApacheClientProperties {
      */
     public static final String KEEPALIVE_STRATEGY = "jersey.config.apache.client.keepAliveStrategy";
 
+
+    /**
+     * Strategy that defines the way the Apache connection releases resources. Apache enables closing the content stream
+     * and the response. This strategy settings allows for choosing the order.
+     * <pre>
+     *     The difference between closing the content stream and closing the response is that
+     *     the former will attempt to keep the underlying connection alive by consuming the
+     *     entity content while the latter immediately shuts down and discards the connection.
+     * </pre>
+     * While for using the Apache features it is better to close the entity stream first, and Apache response later,
+     * this order can cause the thread to hang, waiting for more data to be read from the socket. Using the
+     * {@link org.glassfish.jersey.client.ClientProperties#READ_TIMEOUT} property can prevent this hanging forever.
+     * <p/>
+     * The default is to close the apache response and entity stream after ({@link ResponseClosingStrategy#RESPONSE_STREAM})
+     * for Apache HttpClient 4.5 or earlier, unless {@link org.glassfish.jersey.client.ClientProperties#READ_TIMEOUT} is defined.
+     * For Apache HttpClient 4.5.1 or later, the default is to close entity stream and Apache response after
+     * (@link {@link ResponseClosingStrategy#STREAM_RESPONSE}. Since Apache Http 4.5.1 the way Apache closes the connection
+     * changed, and it does not work when using chunk transfer encoding, and {@code MalformedChunkCodingException} is thrown.
+     *
+     * @see ResponseClosingStrategy
+     * @since 2.30
+     */
+    public static final String RESPONSE_CLOSING_STRATEGY = "jersey.config.apache.client.responseClosingStrategy";
+
+    /**
+     * The strategy that defined the way the Response has been closed.
+     * {@link #STREAM_RESPONSE} was the default in 2.29,
+     * {@link #RESPONSE_STREAM} was the default pre 2.29.
+     * @see #RESPONSE_CLOSING_STRATEGY
+     */
+    public enum ResponseClosingStrategy {
+        STREAM_RESPONSE,
+        RESPONSE_STREAM;
+    }
+
     /**
      * Get the value of the specified property.
      *

--- a/tests/integration/jersey-4321/pom.xml
+++ b/tests/integration/jersey-4321/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Christian Kaltepoth. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <version>2.30-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jersey-4321</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-grizzly2-http</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <!-- Do not change the version, this is backward compatibility test that is to pass on 4.5 -->
+            <version>4.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tests/integration/jersey-4321/src/test/java/org/glassfish/jersey/tests/integration/jersey4321/StreamingTest.java
+++ b/tests/integration/jersey-4321/src/test/java/org/glassfish/jersey/tests/integration/jersey4321/StreamingTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.jersey4321;
+
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.server.ChunkedOutput;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Brought over from Apache connector module, Jersey 2.28 style
+ * @author Petr Janouch
+ */
+public class StreamingTest extends JerseyTest {
+
+    /**
+     * Test that a data stream can be terminated from the client side.
+     * Using pre Jersey 2.29 strategy
+     */
+    @Test
+    public void clientCloseCloseResponseFirstTest() throws IOException {
+        // start streaming
+
+        InputStream inputStream = target().path("/streamingEndpoint").request().get(InputStream.class);
+
+        WebTarget sendTarget = target().path("/streamingEndpoint/send");
+        // trigger sending 'A' to the stream; OK is sent if everything on the server was OK
+        assertEquals("OK", sendTarget.request().get().readEntity(String.class));
+        // check 'A' has been sent
+        assertEquals('A', inputStream.read());
+        // closing the stream should tear down the connection
+        inputStream.close();
+        // trigger sending another 'A' to the stream; it should fail
+        // (indicating that the streaming has been terminated on the server)
+        assertEquals("NOK", sendTarget.request().get().readEntity(String.class));
+    }
+
+
+    @Override
+    protected void configureClient(ClientConfig config) {
+        config.connectorProvider(new ApacheConnectorProvider());
+    }
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(StreamingEndpoint.class);
+    }
+
+    @Singleton
+    @Path("streamingEndpoint")
+    public static class StreamingEndpoint {
+
+        private final ChunkedOutput<String> output = new ChunkedOutput<>(String.class);
+
+        @GET
+        @Path("send")
+        public String sendEvent() {
+            try {
+                output.write("A");
+            } catch (IOException e) {
+                return "NOK";
+            }
+
+            return "OK";
+        }
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public ChunkedOutput<String> get() {
+            return output;
+        }
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -83,6 +83,7 @@
         <module>jersey-3670</module>
         <module>jersey-3992</module>
         <module>jersey-4099</module>
+        <module>jersey-4321</module>
         <module>portability-jersey-1</module>
         <module>portability-jersey-2</module>
         <module>property-check</module>


### PR DESCRIPTION
…behaviour in Jersey 2.28

Keep behaviour of Jersey 2.29 for Apache HttpClient 4.5.1+

Signed-off-by: Jan Supol <jan.supol@oracle.com>