### PR TITLE
Allow to use additional properties with security manager/4323

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ nb-configuration.xml
 .settings/*
 .project
 .classpath
-bin/
 
 # Maven plugins noise
 dependency-reduced-pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ nb-configuration.xml
 .settings/*
 .project
 .classpath
+bin/
 
 # Maven plugins noise
 dependency-reduced-pom.xml

--- a/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
@@ -160,7 +160,10 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
             if (Modifier.isStatic(field.getModifiers()) && field.getType().isAssignableFrom(String.class)) {
                 final String propertyValue = getPropertyNameByField(field);
                 if (propertyValue != null) {
-                    properties.put(propertyValue, PropertiesHelper.getSystemProperty(propertyValue));
+                    String value = getSystemProperty(propertyValue);
+                    if (value != null) {
+                        properties.put(propertyValue, value);
+                    }
                 }
             }
         }

--- a/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
@@ -47,7 +47,6 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
             "org.glassfish.jersey.server.ServerProperties",
             "org.glassfish.jersey.client.ClientProperties",
             "org.glassfish.jersey.servlet.ServletProperties",
-            "org.glassfish.jersey.internal.InternalProperties",
             "org.glassfish.jersey.message.MessageProperties",
             "org.glassfish.jersey.server.internal.InternalServerProperties",
             "org.glassfish.jersey.apache.connector.ApacheClientProperties",

--- a/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
@@ -133,7 +133,7 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
     }
 
     private Map<String, Object> getExpectedSystemProperties() {
-        final Map<String, Object> result = new HashMap<>();        
+        final Map<String, Object> result = new HashMap<>();
         mapFieldsToProperties(result, CommonProperties.class);
         for (String propertyClass : PROPERTY_CLASSES) {
             mapFieldsToProperties(result,

--- a/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
@@ -16,29 +16,44 @@
 
 package org.glassfish.jersey.internal.config;
 
-import org.glassfish.jersey.CommonProperties;
-import org.glassfish.jersey.internal.LocalizationMessages;
-import org.glassfish.jersey.internal.util.PropertiesHelper;
-import org.glassfish.jersey.internal.util.ReflectionHelper;
-import org.glassfish.jersey.spi.ExternalConfigurationModel;
-
-import javax.ws.rs.RuntimeType;
-import javax.ws.rs.core.Feature;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Logger;
 
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.Feature;
+
+import org.glassfish.jersey.CommonProperties;
+import org.glassfish.jersey.internal.LocalizationMessages;
+import org.glassfish.jersey.internal.util.PropertiesHelper;
+import org.glassfish.jersey.internal.util.ReflectionHelper;
+import org.glassfish.jersey.spi.ExternalConfigurationModel;
+
 
 class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<Void> {
 
     private static final Logger log = Logger.getLogger(SystemPropertiesConfigurationModel.class.getName());
+    static final List<String> PROPERTY_CLASSES = Arrays.asList(
+            "org.glassfish.jersey.server.ServerProperties", 
+            "org.glassfish.jersey.client.ClientProperties",
+            "org.glassfish.jersey.servlet.ServletProperties",
+            "org.glassfish.jersey.internal.InternalProperties",
+            "org.glassfish.jersey.message.MessageProperties",
+            "org.glassfish.jersey.server.internal.InternalServerProperties",
+            "org.glassfish.jersey.apache.connector.ApacheClientProperties",
+            "org.glassfish.jersey.jdk.connector.JdkConnectorProperties",
+            "org.glassfish.jersey.jetty.connector.JettyClientProperties",
+            "org.glassfish.jersey.media.multipart.MultiPartProperties",
+            "org.glassfish.jersey.server.oauth1.OAuth1ServerProperties");
 
 
     private static final Map<Class, Function> converters = new HashMap<>();
@@ -118,26 +133,16 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
     }
 
     private Map<String, Object> getExpectedSystemProperties() {
-
-
         final Map<String, Object> result = new HashMap<>();
-
+        
         mapFieldsToProperties(result, CommonProperties.class);
-
-
-
-        mapFieldsToProperties(result,
-                AccessController.doPrivileged(
-                        ReflectionHelper.classForNamePA("org.glassfish.jersey.server.ServerProperties")
-                )
-        );
-
-        mapFieldsToProperties(result,
-                AccessController.doPrivileged(
-                        ReflectionHelper.classForNamePA("org.glassfish.jersey.client.ClientProperties")
-                )
-        );
-
+        for(String propertyClass : PROPERTY_CLASSES) {
+            mapFieldsToProperties(result,
+                    AccessController.doPrivileged(
+                            ReflectionHelper.classForNamePA(propertyClass)
+                    )
+            );
+        }
 
         return  result;
     }

--- a/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
@@ -17,6 +17,7 @@
 package org.glassfish.jersey.internal.config;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -156,7 +157,7 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
         );
 
         for (final Field field : fields) {
-            if (field.getType().isAssignableFrom(String.class)) {
+            if (Modifier.isStatic(field.getModifiers()) && field.getType().isAssignableFrom(String.class)) {
                 final String propertyValue = getPropertyNameByField(field);
                 properties.put(propertyValue, PropertiesHelper.getSystemProperty(propertyValue));
             }

--- a/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
@@ -159,7 +159,9 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
         for (final Field field : fields) {
             if (Modifier.isStatic(field.getModifiers()) && field.getType().isAssignableFrom(String.class)) {
                 final String propertyValue = getPropertyNameByField(field);
-                properties.put(propertyValue, PropertiesHelper.getSystemProperty(propertyValue));
+                if (propertyValue != null) {
+                    properties.put(propertyValue, PropertiesHelper.getSystemProperty(propertyValue));
+                }
             }
         }
     }

--- a/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
@@ -43,7 +43,7 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
 
     private static final Logger log = Logger.getLogger(SystemPropertiesConfigurationModel.class.getName());
     static final List<String> PROPERTY_CLASSES = Arrays.asList(
-            "org.glassfish.jersey.server.ServerProperties", 
+            "org.glassfish.jersey.server.ServerProperties",
             "org.glassfish.jersey.client.ClientProperties",
             "org.glassfish.jersey.servlet.ServletProperties",
             "org.glassfish.jersey.internal.InternalProperties",
@@ -133,10 +133,9 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
     }
 
     private Map<String, Object> getExpectedSystemProperties() {
-        final Map<String, Object> result = new HashMap<>();
-        
+        final Map<String, Object> result = new HashMap<>();        
         mapFieldsToProperties(result, CommonProperties.class);
-        for(String propertyClass : PROPERTY_CLASSES) {
+        for (String propertyClass : PROPERTY_CLASSES) {
             mapFieldsToProperties(result,
                     AccessController.doPrivileged(
                             ReflectionHelper.classForNamePA(propertyClass)

--- a/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModel.java
@@ -48,7 +48,6 @@ class SystemPropertiesConfigurationModel implements ExternalConfigurationModel<V
             "org.glassfish.jersey.client.ClientProperties",
             "org.glassfish.jersey.servlet.ServletProperties",
             "org.glassfish.jersey.message.MessageProperties",
-            "org.glassfish.jersey.server.internal.InternalServerProperties",
             "org.glassfish.jersey.apache.connector.ApacheClientProperties",
             "org.glassfish.jersey.jdk.connector.JdkConnectorProperties",
             "org.glassfish.jersey.jetty.connector.JettyClientProperties",

--- a/tests/integration/property-check/pom.xml
+++ b/tests/integration/property-check/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/integration/property-check/pom.xml
+++ b/tests/integration/property-check/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>jersey-media-sse</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/integration/property-check/pom.xml
+++ b/tests/integration/property-check/pom.xml
@@ -94,11 +94,6 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 package org.glassfish.jersey.internal.config;
 
 import static org.junit.Assert.assertEquals;

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -77,10 +77,12 @@ public class SystemPropertiesConfigurationModelTest {
 
     @Test
     public void propertyLoadedWhenSecurityException() {
+        final String APP_NAME = "propertyLoadedWhenSecurityException";
         SecurityManager sm = System.getSecurityManager();
         String policy = System.getProperty("java.security.policy");
         try {
-            System.setProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER, "true");
+            System.setProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER, Boolean.TRUE.toString());
+            System.setProperty(ServerProperties.APPLICATION_NAME, APP_NAME);
             SystemPropertiesConfigurationModel model = new SystemPropertiesConfigurationModel();
             assertTrue(model.as(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER, Boolean.class));
             String securityPolicy = SystemPropertiesConfigurationModelTest.class.getResource("/server.policy").getFile();
@@ -88,16 +90,17 @@ public class SystemPropertiesConfigurationModelTest {
             SecurityManager manager = new SecurityManager();
             System.setSecurityManager(manager);
             Map<String, Object> properties = model.getProperties();
-            assertTrue(properties.get(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE) != null);
-            assertTrue(properties.get(ServerProperties.APPLICATION_NAME) != null);
-            assertTrue(properties.get(ClientProperties.ASYNC_THREADPOOL_SIZE) != null);
-            assertTrue(properties.get(ServletProperties.FILTER_CONTEXT_PATH) != null);
-            assertTrue(properties.get(InternalProperties.JSON_FEATURE) != null);
-            assertTrue(properties.get(MessageProperties.DEFLATE_WITHOUT_ZLIB) != null);
-            assertTrue(properties.get(ApacheClientProperties.CONNECTION_MANAGER) != null);
-            assertTrue(properties.get(JettyClientProperties.DISABLE_COOKIES) != null);
-            assertTrue(properties.get(MultiPartProperties.BUFFER_THRESHOLD) != null);
-            assertTrue(properties.get(OAuth1ServerProperties.ACCESS_TOKEN_URI) != null);
+            assertEquals(APP_NAME, properties.get(ServerProperties.APPLICATION_NAME));
+            assertEquals(Boolean.TRUE.toString(), properties.get(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER));
+            assertFalse(properties.containsKey(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE));
+            assertFalse(properties.containsKey(ClientProperties.ASYNC_THREADPOOL_SIZE));
+            assertFalse(properties.containsKey(ServletProperties.FILTER_CONTEXT_PATH));
+            assertFalse(properties.containsKey(InternalProperties.JSON_FEATURE));
+            assertFalse(properties.containsKey(MessageProperties.DEFLATE_WITHOUT_ZLIB));
+            assertFalse(properties.containsKey(ApacheClientProperties.CONNECTION_MANAGER));
+            assertFalse(properties.containsKey(JettyClientProperties.DISABLE_COOKIES));
+            assertFalse(properties.containsKey(MultiPartProperties.BUFFER_THRESHOLD));
+            assertFalse(properties.containsKey(OAuth1ServerProperties.ACCESS_TOKEN_URI));
         } finally {
             if (policy != null) {
                 System.setProperty("java.security.policy", policy);

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -39,7 +39,8 @@ public class SystemPropertiesConfigurationModelTest {
             try {
                 return Class.forName(classInfo.getName());
             } catch (ClassNotFoundException e) {
-                return null;
+                // Ignore it
+                return Void.class;
             }
         });
         for (Predicate<Class<?>> predicate : predicates) {

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -20,30 +20,32 @@ public class SystemPropertiesConfigurationModelTest {
 
     @Test
     public void allPropertyClassLoaded() throws IOException {
-        Predicate<Class<?>> containsAnnotation = clazz -> clazz.getAnnotation(PropertiesClass.class) != null || clazz.getAnnotation(Property.class) != null;
+        Predicate<Class<?>> containsAnnotation = clazz -> clazz.getAnnotation(PropertiesClass.class) != null
+                || clazz.getAnnotation(Property.class) != null;
         Predicate<Class<?>> notCommon = clazz -> clazz != CommonProperties.class;
         Predicate<Class<?>> notTestProperties = clazz -> clazz != TestProperties.class;
-        List<String> propertyClasses = getClassesWithPredicate("org.glassfish.jersey", notCommon, notTestProperties, containsAnnotation).stream()
-                .map(Class::getName).collect(Collectors.toList());
+        List<String> propertyClasses = getClassesWithPredicate("org.glassfish.jersey", notCommon, notTestProperties,
+                containsAnnotation).stream().map(Class::getName).collect(Collectors.toList());
         propertyClasses.removeAll(SystemPropertiesConfigurationModel.PROPERTY_CLASSES);
         assertEquals("New properties have been found. "
-                + "Make sure you add next classes in SystemPropertiesConfigurationModel.PROPERTY_CLASSES: "+propertyClasses, 0, propertyClasses.size());
+                + "Make sure you add next classes in SystemPropertiesConfigurationModel.PROPERTY_CLASSES: "
+                + propertyClasses, 0, propertyClasses.size());
     }
-    
-    private List<Class<?>> getClassesWithPredicate(String packageRoot, Predicate<Class<?>> ... predicates) throws IOException{
+
+    private List<Class<?>> getClassesWithPredicate(String packageRoot, Predicate<Class<?>>... predicates)
+            throws IOException {
         ClassPath classpath = ClassPath.from(Thread.currentThread().getContextClassLoader());
-        Stream<Class<?>> steam = classpath.getTopLevelClassesRecursive(packageRoot)
-                .stream().map(classInfo -> {
-                    try {
-                        return Class.forName(classInfo.getName());
-                    } catch (ClassNotFoundException e) {
-                        return null;
-                    }
-                });
+        Stream<Class<?>> steam = classpath.getTopLevelClassesRecursive(packageRoot).stream().map(classInfo -> {
+            try {
+                return Class.forName(classInfo.getName());
+            } catch (ClassNotFoundException e) {
+                return null;
+            }
+        });
         for (Predicate<Class<?>> predicate : predicates) {
             steam = steam.filter(predicate);
         }
         return steam.collect(Collectors.toList());
     }
-    
+
 }

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -77,12 +77,20 @@ public class SystemPropertiesConfigurationModelTest {
 
     @Test
     public void propertyLoadedWhenSecurityException() {
-        final String APP_NAME = "propertyLoadedWhenSecurityException";
+        final String TEST_STRING = "test";
         SecurityManager sm = System.getSecurityManager();
         String policy = System.getProperty("java.security.policy");
         try {
             System.setProperty(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER, Boolean.TRUE.toString());
-            System.setProperty(ServerProperties.APPLICATION_NAME, APP_NAME);
+            System.setProperty(ServerProperties.APPLICATION_NAME, TEST_STRING);
+            System.setProperty(ClientProperties.BACKGROUND_SCHEDULER_THREADPOOL_SIZE, TEST_STRING);
+            System.setProperty(ServletProperties.JAXRS_APPLICATION_CLASS, TEST_STRING);
+            System.setProperty(InternalProperties.JSON_FEATURE_CLIENT, TEST_STRING);
+            System.setProperty(MessageProperties.IO_BUFFER_SIZE, TEST_STRING);
+            System.setProperty(ApacheClientProperties.DISABLE_COOKIES, TEST_STRING);
+            System.setProperty(JettyClientProperties.ENABLE_SSL_HOSTNAME_VERIFICATION, TEST_STRING);
+            System.setProperty(MultiPartProperties.TEMP_DIRECTORY, TEST_STRING);
+            System.setProperty(OAuth1ServerProperties.REALM, TEST_STRING);
             SystemPropertiesConfigurationModel model = new SystemPropertiesConfigurationModel();
             assertTrue(model.as(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER, Boolean.class));
             String securityPolicy = SystemPropertiesConfigurationModelTest.class.getResource("/server.policy").getFile();
@@ -90,16 +98,24 @@ public class SystemPropertiesConfigurationModelTest {
             SecurityManager manager = new SecurityManager();
             System.setSecurityManager(manager);
             Map<String, Object> properties = model.getProperties();
-            assertEquals(APP_NAME, properties.get(ServerProperties.APPLICATION_NAME));
+            assertEquals(TEST_STRING, properties.get(ServerProperties.APPLICATION_NAME));
             assertEquals(Boolean.TRUE.toString(), properties.get(CommonProperties.ALLOW_SYSTEM_PROPERTIES_PROVIDER));
             assertFalse(properties.containsKey(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE));
+            assertEquals(TEST_STRING, properties.get(ClientProperties.BACKGROUND_SCHEDULER_THREADPOOL_SIZE));
             assertFalse(properties.containsKey(ClientProperties.ASYNC_THREADPOOL_SIZE));
+            assertEquals(TEST_STRING, properties.get(ServletProperties.JAXRS_APPLICATION_CLASS));
             assertFalse(properties.containsKey(ServletProperties.FILTER_CONTEXT_PATH));
+            assertEquals(TEST_STRING, properties.get(InternalProperties.JSON_FEATURE_CLIENT));
             assertFalse(properties.containsKey(InternalProperties.JSON_FEATURE));
+            assertEquals(TEST_STRING, properties.get(MessageProperties.IO_BUFFER_SIZE));
             assertFalse(properties.containsKey(MessageProperties.DEFLATE_WITHOUT_ZLIB));
+            assertEquals(TEST_STRING, properties.get(ApacheClientProperties.DISABLE_COOKIES));
             assertFalse(properties.containsKey(ApacheClientProperties.CONNECTION_MANAGER));
+            assertEquals(TEST_STRING, properties.get(JettyClientProperties.ENABLE_SSL_HOSTNAME_VERIFICATION));
             assertFalse(properties.containsKey(JettyClientProperties.DISABLE_COOKIES));
+            assertEquals(TEST_STRING, properties.get(MultiPartProperties.TEMP_DIRECTORY));
             assertFalse(properties.containsKey(MultiPartProperties.BUFFER_THRESHOLD));
+            assertEquals(TEST_STRING, properties.get(OAuth1ServerProperties.REALM));
             assertFalse(properties.containsKey(OAuth1ServerProperties.ACCESS_TOKEN_URI));
         } finally {
             if (policy != null) {

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -38,7 +38,7 @@ public class SystemPropertiesConfigurationModelTest {
             throws IOException {
         ClassPath classpath = ClassPath.from(Thread.currentThread().getContextClassLoader());
         Stream<Class<?>> steam = classpath.getTopLevelClassesRecursive(packageRoot).stream()
-                .filter(classInfo -> classInfo.getName().startsWith(packageRoot)).map(classInfo -> {
+                .map(classInfo -> {
                     try {
                         return Class.forName(classInfo.getName());
                     } catch (ClassNotFoundException e) {

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -40,7 +40,7 @@ public class SystemPropertiesConfigurationModelTest {
                         return null;
                     }
                 });
-        for(Predicate<Class<?>> predicate : predicates) {
+        for (Predicate<Class<?>> predicate : predicates) {
             steam = steam.filter(predicate);
         }
         return steam.collect(Collectors.toList());

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -41,7 +41,6 @@ import org.glassfish.jersey.jetty.connector.JettyClientProperties;
 import org.glassfish.jersey.media.multipart.MultiPartProperties;
 import org.glassfish.jersey.message.MessageProperties;
 import org.glassfish.jersey.server.ServerProperties;
-import org.glassfish.jersey.server.internal.InternalServerProperties;
 import org.glassfish.jersey.server.oauth1.OAuth1ServerProperties;
 import org.glassfish.jersey.servlet.ServletProperties;
 import org.glassfish.jersey.test.TestProperties;
@@ -52,7 +51,8 @@ public class SystemPropertiesConfigurationModelTest {
     private static final String ROOT_PACKAGE = "org.glassfish.jersey";
     private static final List<String> BLACK_LIST_CLASSES = Arrays.asList("org.glassfish.jersey.internal.OsgiRegistry",
         "org.glassfish.jersey.internal.jsr166.SubmissionPublisher", "org.glassfish.jersey.internal.jsr166.Flow",
-        "org.glassfish.jersey.internal.InternalProperties");
+        "org.glassfish.jersey.internal.InternalProperties",
+        "org.glassfish.jersey.server.internal.InternalServerProperties");
 
     @Test
     public void allPropertyClassLoaded() throws IOException {

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -1,0 +1,49 @@
+package org.glassfish.jersey.internal.config;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.reflect.ClassPath;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.glassfish.jersey.CommonProperties;
+import org.glassfish.jersey.internal.util.PropertiesClass;
+import org.glassfish.jersey.internal.util.Property;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+public class SystemPropertiesConfigurationModelTest {
+
+    @Test
+    public void allPropertyClassLoaded() throws IOException {
+        Predicate<Class<?>> containsAnnotation = clazz -> clazz.getAnnotation(PropertiesClass.class) != null || clazz.getAnnotation(Property.class) != null;
+        Predicate<Class<?>> notCommon = clazz -> clazz != CommonProperties.class;
+        Predicate<Class<?>> notTestProperties = clazz -> clazz != TestProperties.class;
+        List<String> propertyClasses = getClassesWithPredicate("org.glassfish.jersey", notCommon, notTestProperties, containsAnnotation).stream()
+                .map(Class::getName).collect(Collectors.toList());
+        propertyClasses.removeAll(SystemPropertiesConfigurationModel.PROPERTY_CLASSES);
+        assertEquals("New properties have been found. "
+                + "Make sure you add next classes in SystemPropertiesConfigurationModel.PROPERTY_CLASSES: "+propertyClasses, 0, propertyClasses.size());
+    }
+    
+    private List<Class<?>> getClassesWithPredicate(String packageRoot, Predicate<Class<?>> ... predicates) throws IOException{
+        ClassPath classpath = ClassPath.from(Thread.currentThread().getContextClassLoader());
+        Stream<Class<?>> steam = classpath.getTopLevelClassesRecursive(packageRoot)
+                .stream().map(classInfo -> {
+                    try {
+                        return Class.forName(classInfo.getName());
+                    } catch (ClassNotFoundException e) {
+                        return null;
+                    }
+                });
+        for(Predicate<Class<?>> predicate : predicates) {
+            steam = steam.filter(predicate);
+        }
+        return steam.collect(Collectors.toList());
+    }
+    
+}

--- a/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
+++ b/tests/integration/property-check/src/test/java/org/glassfish/jersey/internal/config/SystemPropertiesConfigurationModelTest.java
@@ -51,7 +51,8 @@ public class SystemPropertiesConfigurationModelTest {
 
     private static final String ROOT_PACKAGE = "org.glassfish.jersey";
     private static final List<String> BLACK_LIST_CLASSES = Arrays.asList("org.glassfish.jersey.internal.OsgiRegistry",
-        "org.glassfish.jersey.internal.jsr166.SubmissionPublisher", "org.glassfish.jersey.internal.jsr166.Flow");
+        "org.glassfish.jersey.internal.jsr166.SubmissionPublisher", "org.glassfish.jersey.internal.jsr166.Flow",
+        "org.glassfish.jersey.internal.InternalProperties");
 
     @Test
     public void allPropertyClassLoaded() throws IOException {
@@ -85,7 +86,6 @@ public class SystemPropertiesConfigurationModelTest {
             System.setProperty(ServerProperties.APPLICATION_NAME, TEST_STRING);
             System.setProperty(ClientProperties.BACKGROUND_SCHEDULER_THREADPOOL_SIZE, TEST_STRING);
             System.setProperty(ServletProperties.JAXRS_APPLICATION_CLASS, TEST_STRING);
-            System.setProperty(InternalProperties.JSON_FEATURE_CLIENT, TEST_STRING);
             System.setProperty(MessageProperties.IO_BUFFER_SIZE, TEST_STRING);
             System.setProperty(ApacheClientProperties.DISABLE_COOKIES, TEST_STRING);
             System.setProperty(JettyClientProperties.ENABLE_SSL_HOSTNAME_VERIFICATION, TEST_STRING);
@@ -105,7 +105,6 @@ public class SystemPropertiesConfigurationModelTest {
             assertFalse(properties.containsKey(ClientProperties.ASYNC_THREADPOOL_SIZE));
             assertEquals(TEST_STRING, properties.get(ServletProperties.JAXRS_APPLICATION_CLASS));
             assertFalse(properties.containsKey(ServletProperties.FILTER_CONTEXT_PATH));
-            assertEquals(TEST_STRING, properties.get(InternalProperties.JSON_FEATURE_CLIENT));
             assertFalse(properties.containsKey(InternalProperties.JSON_FEATURE));
             assertEquals(TEST_STRING, properties.get(MessageProperties.IO_BUFFER_SIZE));
             assertFalse(properties.containsKey(MessageProperties.DEFLATE_WITHOUT_ZLIB));

--- a/tests/integration/property-check/src/test/resources/server.policy
+++ b/tests/integration/property-check/src/test/resources/server.policy
@@ -17,9 +17,9 @@
 
 grant {
 	permission java.util.PropertyPermission "jersey.config.allowSystemPropertiesProvider", "read";
-    permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
-    permission java.lang.reflect.ReflectPermission "*";
-  	permission java.lang.RuntimePermission "*";
-  	permission java.net.NetPermission "specifyStreamHandler";
+	permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+	permission java.lang.reflect.ReflectPermission "*";
+	permission java.lang.RuntimePermission "*";
+	permission java.net.NetPermission "specifyStreamHandler";
 	permission java.net.SocketPermission "*", "accept,listen,connect,resolve";
 };

--- a/tests/integration/property-check/src/test/resources/server.policy
+++ b/tests/integration/property-check/src/test/resources/server.policy
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+
+grant {
+	permission java.util.PropertyPermission "jersey.config.allowSystemPropertiesProvider", "read";
+    permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+    permission java.lang.reflect.ReflectPermission "*";
+  	permission java.lang.RuntimePermission "*";
+  	permission java.net.NetPermission "specifyStreamHandler";
+	permission java.net.SocketPermission "*", "accept,listen,connect,resolve";
+};

--- a/tests/integration/property-check/src/test/resources/server.policy
+++ b/tests/integration/property-check/src/test/resources/server.policy
@@ -16,7 +16,7 @@
 
 
 grant {
-	permission java.util.PropertyPermission "jersey.config.allowSystemPropertiesProvider", "read";
+	permission java.util.PropertyPermission "*", "read";
 	permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
 	permission java.lang.reflect.ReflectPermission "*";
 	permission java.lang.RuntimePermission "*";


### PR DESCRIPTION
This pull request is related to this issue:
https://github.com/eclipse-ee4j/jersey/issues/4323

The properties are not loaded by reflection, they are explicitly set in a list. The reason I didn't use reflection is we only want to load jersey properties, so we already know them.

In case we create a new property class and we forget to add it in the list, there is a new test that should fail.