### PR TITLE
HttpUrlConnector relies on DefaultSSLSocketFactory value which is not…

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java
@@ -299,11 +299,34 @@ public class HttpUrlConnector implements Connector {
                 suc.setHostnameVerifier(verifier);
             }
 
-            if (HttpsURLConnection.getDefaultSSLSocketFactory() == suc.getSSLSocketFactory()) {
+            if (isDefaultSSLSocketFactory(suc)) {
                 // indicates that the custom socket factory was not set
                 suc.setSSLSocketFactory(sslSocketFactory.get());
             }
         }
+    }
+
+    static boolean isDefaultSSLSocketFactory(HttpsURLConnection suc) {
+        final boolean fastCheck = HttpsURLConnection.getDefaultSSLSocketFactory() == suc.getSSLSocketFactory();
+        if (fastCheck) {
+            return true;
+        }
+        final Object defaultContext = getContextObject(HttpsURLConnection.getDefaultSSLSocketFactory());
+        if (defaultContext == null) {
+            return false;
+        }
+        final Object sucContext = getContextObject(suc.getSSLSocketFactory());
+        return defaultContext == sucContext;
+    }
+
+    static Object getContextObject(SSLSocketFactory sslSocketFactory) {
+        try {
+            final Field contextField = sslSocketFactory.getClass().getDeclaredField("context");
+            contextField.setAccessible(true);
+            return contextField.get(sslSocketFactory);
+        } catch (NoSuchFieldException | IllegalAccessException ignore) {
+        }
+        return null;
     }
 
     private ClientResponse _apply(final ClientRequest request) throws IOException {

--- a/core-client/src/test/java/org/glassfish/jersey/client/internal/HttpUrlConnectorInternalTest.java
+++ b/core-client/src/test/java/org/glassfish/jersey/client/internal/HttpUrlConnectorInternalTest.java
@@ -1,0 +1,33 @@
+package org.glassfish.jersey.client.internal;
+
+import org.junit.Test;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class HttpUrlConnectorInternalTest {
+
+    @Test
+    public void testBasicDefaultSocketFactoryDetection() throws IOException {
+        HttpsURLConnection httpsURLConnection = (HttpsURLConnection) new URL("https://example.org").openConnection();
+
+        assertTrue(HttpUrlConnector.isDefaultSSLSocketFactory(httpsURLConnection));
+    }
+
+    @Test
+    public void testContextFieldExtraction() throws IOException {
+        HttpsURLConnection httpsURLConnection = (HttpsURLConnection) new URL("https://example.org").openConnection();
+
+        final Object contextObject = HttpUrlConnector.getContextObject(httpsURLConnection.getSSLSocketFactory());
+        final Object defaultContextObject = HttpUrlConnector.getContextObject(HttpsURLConnection.getDefaultSSLSocketFactory());
+        assertNotNull(contextObject);
+        assertNotNull(defaultContextObject);
+        assertSame(defaultContextObject, contextObject);
+    }
+
+}


### PR DESCRIPTION
A proposal to fix https://github.com/eclipse-ee4j/jersey/issues/4332
Despite the fact that `HttpsURLConnection.getDefaultSSLSocketFactory()` result is not always unique, all default `SSLSocketFactory` share the same `SSLContextImpl`:

```
public final class SSLSocketFactoryImpl extends SSLSocketFactory {
    private final SSLContextImpl context;

    public SSLSocketFactoryImpl() throws Exception {
        this.context = DefaultSSLContext.getDefaultImpl();
    }
```

This is a proposed solution to use this additional check.