### PR TITLE
Add initial implementation of JUnit Jupiter Extension (#3662)

### DIFF
--- a/test-framework/jupiter-extension/pom.xml
+++ b/test-framework/jupiter-extension/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.jersey.test-framework</groupId>
+        <artifactId>project</artifactId>
+        <version>2.30-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jersey-test-framework-jupiter-extension</artifactId>
+    <packaging>jar</packaging>
+    <name>jersey-test-framework-jupiter-extension</name>
+
+    <description>Jersey Test Framework JUnit Jupiter Extension</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.14.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-framework/jupiter-extension/src/main/java/org/glassfish/jersey/test/jupiter/JerseyExtension.java
+++ b/test-framework/jupiter-extension/src/main/java/org/glassfish/jersey/test/jupiter/JerseyExtension.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.test.jupiter;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import static org.junit.jupiter.api.extension.ExtensionContext.Store;
+
+public class JerseyExtension implements TestInstancePostProcessor, BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private static final Namespace NAMESPACE = Namespace.create(JerseyExtension.class);
+
+    private final Supplier<Application> applicationSupplier;
+
+    @SuppressWarnings("WeakerAccess")
+    public JerseyExtension(Supplier<Application> applicationSupplier) {
+        this.applicationSupplier = applicationSupplier;
+    }
+
+    @SuppressWarnings("unused")
+    public JerseyExtension() {
+        applicationSupplier = null;
+    }
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext extensionContext) {
+        // TODO: validate predonditions
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        Object testInstance = extensionContext.getRequiredTestInstance();
+
+        JerseyTestImpl jerseyTest = new JerseyTestImpl(findApplication(testInstance));
+        jerseyTest.setUp();
+
+        injectFields(testInstance, jerseyTest);
+
+        Store store = store(extensionContext);
+        store.put(JerseyTestImpl.class, jerseyTest);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        store(extensionContext).remove(JerseyTestImpl.class, JerseyTestImpl.class).tearDown();
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return supportsInjectable(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        JerseyTestImpl jerseyTest = store(extensionContext).get(JerseyTestImpl.class, JerseyTestImpl.class);
+        return resolveInjectable(parameterContext.getParameter().getType(), jerseyTest);
+    }
+
+    private Application findApplication(Object testInstance) throws Exception {
+        if (applicationSupplier != null) {
+            return applicationSupplier.get();
+        }
+        for (Method method : testInstance.getClass().getDeclaredMethods()) {
+            if (Application.class.isAssignableFrom(method.getReturnType()) && method.getParameterCount() == 0) {
+                method.setAccessible(true);
+                return (Application) method.invoke(testInstance);
+            }
+        }
+        throw new IllegalStateException("Couldn't find a way to configure Application");
+    }
+
+    private static void injectFields(Object testInstance, JerseyTestImpl jerseyTest) throws IllegalAccessException {
+        for (Field field : testInstance.getClass().getDeclaredFields()) {
+            if (supportsInjectable(field.getType())) {
+                field.setAccessible(true);
+                field.set(testInstance, resolveInjectable(field.getType(), jerseyTest));
+            }
+        }
+    }
+
+    private static boolean supportsInjectable(Class<?> type) {
+        return type == WebTarget.class
+                || type == Client.class
+                || type == URI.class;
+    }
+
+    private static Object resolveInjectable(Class<?> type, JerseyTestImpl jerseyTest) {
+        if (type == WebTarget.class) {
+            return jerseyTest.target();
+        }
+        if (type == Client.class) {
+            return jerseyTest.client();
+        }
+        if (type == URI.class) {
+            return jerseyTest.baseUri();
+        }
+        throw new IllegalArgumentException("Unsupported injectable type " + type);
+    }
+
+    private static Store store(ExtensionContext extensionContext) {
+        return extensionContext.getStore(NAMESPACE);
+    }
+
+    private static class JerseyTestImpl extends org.glassfish.jersey.test.JerseyTest {
+
+        JerseyTestImpl(Application application) {
+            super(application);
+        }
+
+        URI baseUri() {
+            return getBaseUri();
+        }
+    }
+}

--- a/test-framework/jupiter-extension/src/main/java/org/glassfish/jersey/test/jupiter/JerseyTest.java
+++ b/test-framework/jupiter-extension/src/main/java/org/glassfish/jersey/test/jupiter/JerseyTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.test.jupiter;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(JerseyExtension.class)
+public @interface JerseyTest {
+}

--- a/test-framework/jupiter-extension/src/test/java/org/glassfish/jersey/test/jupiter/JerseyExtensionTest.java
+++ b/test-framework/jupiter-extension/src/test/java/org/glassfish/jersey/test/jupiter/JerseyExtensionTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.test.jupiter;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JerseyExtension should")
+class JerseyExtensionTest {
+
+    @Nested
+    @DisplayName("when registered programmatically")
+    class RegisteredProgrammatically implements BasicTestCases {
+
+        @RegisterExtension
+        JerseyExtension jerseyExtension = new JerseyExtension(this::application);
+
+        @SuppressWarnings("unused")
+        private WebTarget target;
+        @SuppressWarnings("unused")
+        private Client client;
+        @SuppressWarnings("unused")
+        private URI uri;
+
+        @Override
+        public WebTarget injectedTarget() {
+            return target;
+        }
+
+        @Override
+        public Client injectedClient() {
+            return client;
+        }
+
+        @Override
+        public URI injectedURI() {
+            return uri;
+        }
+
+        private Application application() {
+            return new ResourceConfig(SimpleResource.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("when registered by @JerseyTest")
+    @JerseyTest
+    class RegisteredByJerseyTest implements BasicTestCases {
+
+        @SuppressWarnings("unused")
+        private WebTarget target;
+        @SuppressWarnings("unused")
+        private Client client;
+        @SuppressWarnings("unused")
+        private URI uri;
+
+        @Override
+        public WebTarget injectedTarget() {
+            return target;
+        }
+
+        @Override
+        public Client injectedClient() {
+            return client;
+        }
+
+        @Override
+        public URI injectedURI() {
+            return uri;
+        }
+
+        @SuppressWarnings("unused")
+        private Application application() {
+            return new ResourceConfig().register(new SimpleResource());
+        }
+    }
+
+    interface BasicTestCases {
+
+        WebTarget injectedTarget();
+
+        Client injectedClient();
+
+        URI injectedURI();
+
+        @Test
+        @DisplayName("inject a WebTarget parameter")
+        default void injectsWebTargetParameter(WebTarget target) {
+            assertThat(target).isNotNull();
+        }
+
+        @Test
+        @DisplayName("access the resource through WebTarget parameter")
+        default void accessesResourceThroughWebTargetParameter(WebTarget target) {
+            assertThat(target.path("simple").request().get(String.class)).isEqualTo(SimpleResource.RESULT);
+        }
+
+        @Test
+        @DisplayName("inject a Client parameter")
+        default void injectsClientParameter(Client client) {
+            assertThat(client).isNotNull();
+        }
+
+        @Test
+        @DisplayName("inject a URI parameter")
+        default void injectsURIParameter(URI uri) {
+            assertThat(uri).isNotNull();
+        }
+
+        @Test
+        @DisplayName("access the resource through Client and URI parameters")
+        default void accessesResourceThroughClientAndURIParameters(Client client, URI baseUri) {
+            assertThat(client.target(baseUri).path("simple").request().get(String.class)).isEqualTo(SimpleResource.RESULT);
+        }
+
+        @Test
+        @DisplayName("inject a WebTarget field")
+        default void injectsWebTargetField() {
+            assertThat(injectedTarget()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("access the resource through WebTarget field")
+        default void accessesResourceThroughWebTargetField() {
+            assertThat(injectedTarget().path("simple").request().get(String.class)).isEqualTo(SimpleResource.RESULT);
+        }
+
+        @Test
+        @DisplayName("inject a Client field")
+        default void injectsClientParameter() {
+            assertThat(injectedClient()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("inject a URI field")
+        default void injectsURIParameter() {
+            assertThat(injectedURI()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("access the resource through Client and URI fields")
+        default void accessesResourceThroughClientAndURIParameters() {
+            assertThat(injectedClient().target(injectedURI()).path("simple").request().get(String.class))
+                    .isEqualTo(SimpleResource.RESULT);
+        }
+    }
+}

--- a/test-framework/jupiter-extension/src/test/java/org/glassfish/jersey/test/jupiter/SimpleResource.java
+++ b/test-framework/jupiter-extension/src/test/java/org/glassfish/jersey/test/jupiter/SimpleResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.test.jupiter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("simple")
+public class SimpleResource {
+
+    static final String RESULT = "OK";
+
+    @GET
+    public String get() {
+        return RESULT;
+    }
+}

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -38,6 +38,7 @@
         <module>util</module>
         <module>maven</module>
         <module>memleak-test-common</module>
+        <module>jupiter-extension</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
Fix #3662 

We are using this initial implementation in our internal projects successfully with JUnit Jupiter 5.2+. It provides a JUnit Jupiter Extension (and annotation) that sets up and configures the Jersey Test Framework and is able to inject Client, WebTarget and URI instances into fields and/or test method parameters.

ECA is signed.

Signed-off-by: Sascha Volkenandt <sascha@akv-soft.de>