### PR TITLE
OSGI groupId fix

### DIFF
--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/JaxRsRiBundleTest.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/JaxRsRiBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,7 +61,7 @@ public class JaxRsRiBundleTest {
 
                 mavenBundle().groupId("org.glassfish.jersey.bundles").artifactId("jaxrs-ri").versionAsInProject(),
 
-                mavenBundle().groupId("org.mortbay.jetty").artifactId("servlet-api-2.5").versionAsInProject(),
+                mavenBundle().groupId("jakarta.servlet").artifactId("jakarta.servlet-api").versionAsInProject(),
                 mavenBundle().groupId("org.glassfish.grizzly").artifactId("grizzly-http-servlet").versionAsInProject()
         ));
 


### PR DESCRIPTION
Fixes mounts for OSGI bundles.

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>