### PR TITLE
Fix check style

### DIFF
--- a/ext/wadl-doclet/src/main/java8_11/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
+++ b/ext/wadl-doclet/src/main/java8_11/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/wadl-doclet/src/main/java8_11/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
+++ b/ext/wadl-doclet/src/main/java8_11/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
@@ -388,7 +388,6 @@ public class ResourceDoclet {
 
         /* Get referenced example bean
          */
-        
         final ClassDoc containingClass = referencedMember.containingClass();
         return DocletUtils.getLinkClass(containingClass.qualifiedName(), referencedMember.name());
     }


### PR DESCRIPTION
[ERROR] src/main/java8_11/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java[391] (regexp) RegexpSinglelineJava: File contains trailing whitespace.