### PR TITLE
Multi release sources

### DIFF
--- a/ext/wadl-doclet/pom.xml
+++ b/ext/wadl-doclet/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/wadl-doclet/pom.xml
+++ b/ext/wadl-doclet/pom.xml
@@ -182,7 +182,7 @@
                         <executions>
                             <execution>
                                 <id>copy-jdk12-sources</id>
-                                <phase>verify</phase>
+                                <phase>package</phase>
                                 <configuration>
                                     <target>
                                     	<property name="sources-jar" value="${java8_11.build.outputDirectory}/${project.artifactId}-${project.version}-sources.jar"/>


### PR DESCRIPTION
Jenkins creates the multirelease with java 12+ running install, and then with java 8_12 with package.

Package is not triggering the plugin that adds the sources.