### PR TITLE
[#3802] Link in exception mapping example README is wrong

### DIFF
--- a/examples/exception-mapping/README.MD
+++ b/examples/exception-mapping/README.MD
@@ -13,7 +13,7 @@ This example demonstrates how to create a custom exception mapping. There are de
 `WebApplicationException`, custom exceptions and an exception mapper inheritance.
 
 The full description how to handle exception and map them to Response object can be found in Jersey User Guide, chapter
-[WebApplicationException and Mapping Exceptions to Responses](https://jersey.java.net/documentation/latest/representations.html#d0e6567).
+[WebApplicationException and Mapping Exceptions to Responses](https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/representations.html#d0e6355).
 
 Contents
 --------


### PR DESCRIPTION
Signed-off-by: Miguel Serra <Miguel.Serra@criticaltechworks.com>