### PR TITLE
Fix #4380 - Jersey 2.30 does not work on JDK 11

### DIFF
--- a/core-common/pom.xml
+++ b/core-common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -336,7 +336,7 @@
                                     <target>
                                         <mkdir dir="${java11.build.outputDirectory}" />
                                         <javac srcdir="${java11.sourceDirectory}" destdir="${java11.build.outputDirectory}"
-                                               classpath="${project.build.outputDirectory}" includeantruntime="false" />
+                                               classpath="${project.build.outputDirectory}" includeantruntime="false" release="11" />
                                     </target>
                                 </configuration>
                                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -772,6 +772,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.8</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.ant</groupId>
+                            <artifactId>ant</artifactId>
+                            <version>1.10.7</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.fortasoft</groupId>


### PR DESCRIPTION
Signed-off-by: tvallin <thibault.vallin@oracle.com>