### PR TITLE
Fix #3433 - Multiple cookies with same name are not supported

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/CookiesParser.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/CookiesParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -70,10 +70,7 @@ public class CookiesParser {
                 value = value.substring(1, value.length() - 1);
             }
             if (!name.startsWith("$")) {
-                if (cookie != null) {
-                    cookies.put(cookie.name, cookie.getImmutableCookie());
-                }
-
+                checkSimilarCookieName(cookies, cookie);
                 cookie = new MutableCookie(name, value);
                 cookie.version = version;
             } else if (name.startsWith("$Version")) {
@@ -84,10 +81,26 @@ public class CookiesParser {
                 cookie.domain = value;
             }
         }
-        if (cookie != null) {
-            cookies.put(cookie.name, cookie.getImmutableCookie());
-        }
+        checkSimilarCookieName(cookies, cookie);
         return cookies;
+    }
+
+    /**
+     * Check if a cookie with identical name had been parsed.
+     * If yes, the one with the longest string will be kept
+     * @param cookies : Map of cookies
+     * @param cookie : Cookie to be checked
+     */
+    private static void checkSimilarCookieName(Map<String, Cookie> cookies, MutableCookie cookie) {
+        if (cookie != null) {
+            if (cookies.containsKey(cookie.name)){
+                if (cookie.value.length() > cookies.get(cookie.name).getValue().length()){
+                    cookies.put(cookie.name, cookie.getImmutableCookie());
+                }
+            } else {
+                cookies.put(cookie.name, cookie.getImmutableCookie());
+            }
+        }
     }
 
     public static Cookie parseCookie(String header) {
@@ -148,8 +161,6 @@ public class CookiesParser {
                     cookie.secure = true;
                 } else if (param.startsWith("version")) {
                     cookie.version = Integer.parseInt(value);
-                } else if (param.startsWith("domain")) {
-                    cookie.domain = value;
                 } else if (param.startsWith("httponly")) {
                     cookie.httpOnly = true;
                 }  else if (param.startsWith("expires")) {

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
@@ -301,23 +301,6 @@ public final class HeaderUtils {
     }
 
     /**
-     * Compare two objects according to comparator
-     *
-     * @param first first object to be compared
-     * @param second second object to be compared
-     * @param comparator criteria
-     * @return the preferred object according to comparator
-     */
-    public static <T> T compareNullable(T first, T second, Comparator<T> comparator) {
-        if (first == null) {
-            return second;
-        } else if (second == null) {
-            return first;
-        }
-        return comparator.compare(first, second) > 0 ? first : second;
-    }
-
-    /**
      * Compare two NewCookies having the same name. See documentation RFC.
      *
      * @param first    NewCookie to be compared.
@@ -336,9 +319,9 @@ public final class HeaderUtils {
         }
 
         if (first.getMaxAge() != second.getMaxAge()){
-            return compareNullable(first, second, Comparator.comparing(NewCookie::getMaxAge));
+            return Comparator.comparing(NewCookie::getMaxAge).compare(first, second) > 0 ? first : second;
         } else if (first.getExpiry() != null && second.getExpiry() != null && !first.getExpiry().equals(second.getExpiry())) {
-            return compareNullable(first, second, Comparator.comparing(NewCookie::getExpiry));
+            return Comparator.comparing(NewCookie::getExpiry).compare(first, second) > 0 ? first : second;
         } else {
             return first.getPath().length() > second.getPath().length() ? first : second;
         }

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
@@ -17,6 +17,7 @@
 package org.glassfish.jersey.message.internal;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -300,20 +301,40 @@ public final class HeaderUtils {
     }
 
     /**
+     * Compare two objects according to comparator
+     *
+     * @param first first object to be compared
+     * @param second second object to be compared
+     * @param comparator criteria
+     * @return the preferred object according to comparator
+     */
+    public static <T> T compareNullable(T first, T second, Comparator<T> comparator) {
+        if (first == null) {
+            return second;
+        } else if (second == null) {
+            return first;
+        }
+        return comparator.compare(first, second) <= 0 ? first : second;
+    }
+
+    /**
      * Compare two NewCookies having the same name. See documentation RFC.
      *
-     * @param one    NewCookie to be compared.
+     * @param first    NewCookie to be compared.
      * @param second NewCookie to be compared.
      * @return the preferred NewCookie according to rules :
      *              - the latest maxAge.
-     *              - if same maxAge, the longest path.
+     *              - if equal, compare the expiry date
+     *              - if equal, compare name length
      */
-    public static NewCookie getPreferredCookie(NewCookie one, NewCookie second) {
+    public static NewCookie getPreferredCookie(NewCookie first, NewCookie second) {
 
-        if (one.getMaxAge() != second.getMaxAge()){
-            return one.getMaxAge() > second.getMaxAge() ?  one : second;
+        if (first.getMaxAge() != second.getMaxAge()){
+            return compareNullable(first, second, Comparator.comparing(NewCookie::getMaxAge));
+        } else if (first.getExpiry() != null && second.getExpiry() != null && !first.getExpiry().equals(second.getExpiry())) {
+            return compareNullable(first, second, Comparator.comparing(NewCookie::getExpiry));
         } else {
-            return one.getPath().length() > second.getPath().length() ?  one : second;
+            return first.getPath().length() > second.getPath().length() ? first : second;
         }
     }
 

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
@@ -314,7 +314,7 @@ public final class HeaderUtils {
         } else if (second == null) {
             return first;
         }
-        return comparator.compare(first, second) <= 0 ? first : second;
+        return comparator.compare(first, second) > 0 ? first : second;
     }
 
     /**
@@ -328,6 +328,12 @@ public final class HeaderUtils {
      *              - if equal, compare name length
      */
     public static NewCookie getPreferredCookie(NewCookie first, NewCookie second) {
+
+        if (first == null) {
+            return second;
+        } else if (second == null) {
+            return first;
+        }
 
         if (first.getMaxAge() != second.getMaxAge()){
             return compareNullable(first, second, Comparator.comparing(NewCookie::getMaxAge));

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.AbstractMultivaluedMap;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.ext.RuntimeDelegate;
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 
@@ -295,6 +296,24 @@ public final class HeaderUtils {
                             changedHeaderNames.toString()));
                 }
             }
+        }
+    }
+
+    /**
+     * Compare two NewCookies having the same name. See documentation RFC.
+     *
+     * @param one    NewCookie to be compared.
+     * @param second NewCookie to be compared.
+     * @return the prefered NewCookie according to rules :
+     *              - the latest expiration date.
+     *              - if same expiration date, the longest path.
+     */
+    public static NewCookie getPreferedNewCookie(NewCookie one, NewCookie second) {
+
+        if (!one.getExpiry().equals(second.getExpiry())){
+            return one.getExpiry().after(second.getExpiry()) ?  one : second;
+        } else {
+            return one.getPath().length() > second.getPath().length() ?  one : second;
         }
     }
 

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/HeaderUtils.java
@@ -304,14 +304,14 @@ public final class HeaderUtils {
      *
      * @param one    NewCookie to be compared.
      * @param second NewCookie to be compared.
-     * @return the prefered NewCookie according to rules :
-     *              - the latest expiration date.
-     *              - if same expiration date, the longest path.
+     * @return the preferred NewCookie according to rules :
+     *              - the latest maxAge.
+     *              - if same maxAge, the longest path.
      */
-    public static NewCookie getPreferedNewCookie(NewCookie one, NewCookie second) {
+    public static NewCookie getPreferredCookie(NewCookie one, NewCookie second) {
 
-        if (!one.getExpiry().equals(second.getExpiry())){
-            return one.getExpiry().after(second.getExpiry()) ?  one : second;
+        if (one.getMaxAge() != second.getMaxAge()){
+            return one.getMaxAge() > second.getMaxAge() ?  one : second;
         } else {
             return one.getPath().length() > second.getPath().length() ?  one : second;
         }

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/InboundMessageContext.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/InboundMessageContext.java
@@ -589,7 +589,7 @@ public abstract class InboundMessageContext {
                 NewCookie newCookie = HttpHeaderReader.readNewCookie(cookie);
                 String cookieName = newCookie.getName();
                 if (result.containsKey(cookieName)) {
-                    result.put(cookieName, HeaderUtils.getPreferedNewCookie(result.get(cookieName), newCookie));
+                    result.put(cookieName, HeaderUtils.getPreferredCookie(result.get(cookieName), newCookie));
                 } else {
                     result.put(cookieName, newCookie);
                 }

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/InboundMessageContext.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/InboundMessageContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -587,7 +587,12 @@ public abstract class InboundMessageContext {
         for (String cookie : cookies) {
             if (cookie != null) {
                 NewCookie newCookie = HttpHeaderReader.readNewCookie(cookie);
-                result.put(newCookie.getName(), newCookie);
+                String cookieName = newCookie.getName();
+                if (result.containsKey(cookieName)) {
+                    result.put(cookieName, HeaderUtils.getPreferedNewCookie(result.get(cookieName), newCookie));
+                } else {
+                    result.put(cookieName, newCookie);
+                }
             }
         }
         return result;

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/OutboundMessageContext.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/OutboundMessageContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -456,7 +456,12 @@ public class OutboundMessageContext {
         for (String cookie : HeaderUtils.asStringList(cookies, configuration)) {
             if (cookie != null) {
                 NewCookie newCookie = HttpHeaderReader.readNewCookie(cookie);
-                result.put(newCookie.getName(), newCookie);
+                String cookieName = newCookie.getName();
+                if (result.containsKey(cookieName)) {
+                    result.put(cookieName, HeaderUtils.getPreferedNewCookie(result.get(cookieName), newCookie));
+                } else {
+                    result.put(cookieName, newCookie);
+                }
             }
         }
         return result;

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/OutboundMessageContext.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/OutboundMessageContext.java
@@ -458,7 +458,7 @@ public class OutboundMessageContext {
                 NewCookie newCookie = HttpHeaderReader.readNewCookie(cookie);
                 String cookieName = newCookie.getName();
                 if (result.containsKey(cookieName)) {
-                    result.put(cookieName, HeaderUtils.getPreferedNewCookie(result.get(cookieName), newCookie));
+                    result.put(cookieName, HeaderUtils.getPreferredCookie(result.get(cookieName), newCookie));
                 } else {
                     result.put(cookieName, newCookie);
                 }

--- a/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/message/internal/HeaderUtilsTest.java
+++ b/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/message/internal/HeaderUtilsTest.java
@@ -188,9 +188,9 @@ public class HeaderUtilsTest {
     public void testgetPreferredCookie(){
 
         Calendar calendar = Calendar.getInstance();
-        calendar.set(2000, Calendar.JANUARY, Calendar.MONDAY);
+        calendar.set(2000, Calendar.JANUARY, 1);
         Date earlyDate = calendar.getTime();
-        calendar.set(2000, Calendar.JANUARY, Calendar.TUESDAY);
+        calendar.set(2000, Calendar.JANUARY, 2);
         Date laterDate = calendar.getTime();
 
         NewCookie earlyCookie = new NewCookie("fred", "valuestring", "pathstring", "domainstring",

--- a/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/message/internal/HeaderUtilsTest.java
+++ b/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/message/internal/HeaderUtilsTest.java
@@ -17,10 +17,8 @@
 package org.glassfish.jersey.tests.e2e.common.message.internal;
 
 import java.net.URI;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -30,7 +28,6 @@ import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.ext.RuntimeDelegate;
 
 import org.glassfish.jersey.message.internal.HeaderUtils;
-import org.glassfish.jersey.message.internal.HttpDateFormat;
 import org.glassfish.jersey.tests.e2e.common.TestRuntimeDelegate;
 
 import org.junit.Test;
@@ -186,94 +183,32 @@ public class HeaderUtilsTest {
     }
 
     @Test
-    public void testgetPreferedNewCookie(){
+    public void testgetPreferredCookie(){
 
-        Date earliestDate;
-        Date latestDate;
+        NewCookie one = new NewCookie("fred", "valuestring", "pathstring", "domainstring",
+                0, "commentstring", 100, null, false, false);
+        NewCookie second = new NewCookie("fred", "valuestring", "pathstring", "domainstring",
+                0, "commentstring", 10, null, false, false);
 
-        try {
-            earliestDate = HttpDateFormat.readDate("Fri, 1 Jan 2020 00:00:00 GMT");
-            latestDate =  HttpDateFormat.readDate("Fri, 1 Jan 2020 01:00:00 GMT");
-        } catch (ParseException e) {
-            e.printStackTrace();
-            earliestDate = new Date(10);
-            latestDate =  new Date(100);
-        }
+        assertEquals(one, HeaderUtils.getPreferredCookie(one, second));
 
-        NewCookie one = new NewCookie(
-                "fred",
-                "valuestring",
-                "pathstring",
-                "domainstring",
-                0,
-                "commentstring",
-                0,
-                latestDate,
-                false,
-                false);
-        NewCookie second = new NewCookie(
-                "fred",
-                "valuestring",
-                "pathstring",
-                "domainstring",
-                0,
-                "commentstring",
-                0,
-                earliestDate,
-                false,
-                false);
+        NewCookie longPathNewCookie = new NewCookie("fred", "valuestring", "longestpathstring",
+                "domainstring", 0, "commentstring", 0, null,
+                false, false);
+        NewCookie shortPathNewCookie = new NewCookie("fred", "valuestring", "shortestpath",
+                "domainstring", 0, "commentstring", 0, null,
+                false, false);
 
-        assertEquals(one, HeaderUtils.getPreferedNewCookie(one, second));
+        assertEquals(longPathNewCookie, HeaderUtils.getPreferredCookie(longPathNewCookie, shortPathNewCookie));
 
-        NewCookie longPathNewCookie = new NewCookie(
-                "fred",
-                "valuestring",
-                "longestpathstring",
-                "domainstring",
-                0,
-                "commentstring",
-                0,
-                latestDate,
-                false,
-                false);
-        NewCookie shortPathNewCookie = new NewCookie(
-                "fred",
-                "valuestring",
-                "shortestpath",
-                "domainstring",
-                0,
-                "commentstring",
-                0,
-                latestDate,
-                false,
-                false);
+        NewCookie identicalNewCookie = new NewCookie("fred", "valuestring", "pathstring",
+                "domainstring", 0, "commentstring", 0, null,
+                false, false);
+        NewCookie identicalNewCookie1 = new NewCookie("fred", "valuestring", "pathstring",
+                "domainstring", 0, "commentstring", 0, null,
+                false, false);
 
-        assertEquals(longPathNewCookie, HeaderUtils.getPreferedNewCookie(longPathNewCookie, shortPathNewCookie));
-
-        NewCookie identicalNewCookie = new NewCookie(
-                "fred",
-                "valuestring",
-                "pathstring",
-                "domainstring",
-                0,
-                "commentstring",
-                0,
-                latestDate,
-                false,
-                false);
-        NewCookie identicalNewCookie1 = new NewCookie(
-                "fred",
-                "valuestring",
-                "pathstring",
-                "domainstring",
-                0,
-                "commentstring",
-                0,
-                latestDate,
-                false,
-                false);
-
-        assertEquals(identicalNewCookie, HeaderUtils.getPreferedNewCookie(identicalNewCookie, identicalNewCookie1));
+        assertEquals(identicalNewCookie, HeaderUtils.getPreferredCookie(identicalNewCookie, identicalNewCookie1));
 
     }
 

--- a/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/message/internal/HeaderUtilsTest.java
+++ b/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/message/internal/HeaderUtilsTest.java
@@ -18,7 +18,9 @@ package org.glassfish.jersey.tests.e2e.common.message.internal;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -184,6 +186,19 @@ public class HeaderUtilsTest {
 
     @Test
     public void testgetPreferredCookie(){
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2000, Calendar.JANUARY, Calendar.MONDAY);
+        Date earlyDate = calendar.getTime();
+        calendar.set(2000, Calendar.JANUARY, Calendar.TUESDAY);
+        Date laterDate = calendar.getTime();
+
+        NewCookie earlyCookie = new NewCookie("fred", "valuestring", "pathstring", "domainstring",
+                0, "commentstring", 0, earlyDate, false, false);
+        NewCookie laterCookie = new NewCookie("fred", "valuestring", "pathstring", "domainstring",
+                0, "commentstring", 0, laterDate, false, false);
+
+        assertEquals(laterCookie, HeaderUtils.getPreferredCookie(earlyCookie, laterCookie));
 
         NewCookie one = new NewCookie("fred", "valuestring", "pathstring", "domainstring",
                 0, "commentstring", 100, null, false, false);

--- a/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/message/internal/HeaderUtilsTest.java
+++ b/tests/e2e-core-common/src/test/java/org/glassfish/jersey/tests/e2e/common/message/internal/HeaderUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,16 +17,20 @@
 package org.glassfish.jersey.tests.e2e.common.message.internal;
 
 import java.net.URI;
+import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
 import javax.ws.rs.core.AbstractMultivaluedMap;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.ext.RuntimeDelegate;
 
 import org.glassfish.jersey.message.internal.HeaderUtils;
+import org.glassfish.jersey.message.internal.HttpDateFormat;
 import org.glassfish.jersey.tests.e2e.common.TestRuntimeDelegate;
 
 import org.junit.Test;
@@ -180,4 +184,97 @@ public class HeaderUtilsTest {
         final String result = HeaderUtils.asHeaderString(values, null);
         assertEquals("value,[null]," + uri.toASCIIString(), result);
     }
+
+    @Test
+    public void testgetPreferedNewCookie(){
+
+        Date earliestDate;
+        Date latestDate;
+
+        try {
+            earliestDate = HttpDateFormat.readDate("Fri, 1 Jan 2020 00:00:00 GMT");
+            latestDate =  HttpDateFormat.readDate("Fri, 1 Jan 2020 01:00:00 GMT");
+        } catch (ParseException e) {
+            e.printStackTrace();
+            earliestDate = new Date(10);
+            latestDate =  new Date(100);
+        }
+
+        NewCookie one = new NewCookie(
+                "fred",
+                "valuestring",
+                "pathstring",
+                "domainstring",
+                0,
+                "commentstring",
+                0,
+                latestDate,
+                false,
+                false);
+        NewCookie second = new NewCookie(
+                "fred",
+                "valuestring",
+                "pathstring",
+                "domainstring",
+                0,
+                "commentstring",
+                0,
+                earliestDate,
+                false,
+                false);
+
+        assertEquals(one, HeaderUtils.getPreferedNewCookie(one, second));
+
+        NewCookie longPathNewCookie = new NewCookie(
+                "fred",
+                "valuestring",
+                "longestpathstring",
+                "domainstring",
+                0,
+                "commentstring",
+                0,
+                latestDate,
+                false,
+                false);
+        NewCookie shortPathNewCookie = new NewCookie(
+                "fred",
+                "valuestring",
+                "shortestpath",
+                "domainstring",
+                0,
+                "commentstring",
+                0,
+                latestDate,
+                false,
+                false);
+
+        assertEquals(longPathNewCookie, HeaderUtils.getPreferedNewCookie(longPathNewCookie, shortPathNewCookie));
+
+        NewCookie identicalNewCookie = new NewCookie(
+                "fred",
+                "valuestring",
+                "pathstring",
+                "domainstring",
+                0,
+                "commentstring",
+                0,
+                latestDate,
+                false,
+                false);
+        NewCookie identicalNewCookie1 = new NewCookie(
+                "fred",
+                "valuestring",
+                "pathstring",
+                "domainstring",
+                0,
+                "commentstring",
+                0,
+                latestDate,
+                false,
+                false);
+
+        assertEquals(identicalNewCookie, HeaderUtils.getPreferedNewCookie(identicalNewCookie, identicalNewCookie1));
+
+    }
+
 }

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/api/CookieImplTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/api/CookieImplTest.java
@@ -159,7 +159,7 @@ public class CookieImplTest {
         assertEquals("kobe", c.getName());
         assertEquals("longeststring", c.getValue());
 
-        cookieHeader = "bryant=longeststring; bryant=shortstring ; fred=shortstring ; fred=longeststring ; $Path=/path ; $Domain=.sun.com";
+        cookieHeader = "bryant=longeststring; bryant=shortstring; fred=shortstring ;fred=longeststring;$Path=/path";
         cookies = HttpHeaderReader.readCookies(cookieHeader);
         assertEquals(cookies.size(), 2);
         c = cookies.get("bryant");
@@ -171,7 +171,6 @@ public class CookieImplTest {
         assertEquals("fred", c.getName());
         assertEquals("longeststring", c.getValue());
         assertEquals("/path", c.getPath());
-        assertEquals(".sun.com", c.getDomain());
 
     }
 

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/api/CookieImplTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/api/CookieImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -146,6 +146,33 @@ public class CookieImplTest {
         assertTrue("barney".equals(c.getName()));
         assertTrue("rubble".equals(c.getValue()));
         assertTrue(".sun.com".equals(c.getDomain()));
+    }
+
+    @Test
+    public void testMultipleCookiesWithSameName(){
+
+        String cookieHeader = "kobe=longeststring; kobe=shortstring";
+        Map<String, Cookie> cookies = HttpHeaderReader.readCookies(cookieHeader);
+        assertEquals(cookies.size(), 1);
+        Cookie c = cookies.get("kobe");
+        assertEquals(c.getVersion(), 0);
+        assertEquals("kobe", c.getName());
+        assertEquals("longeststring", c.getValue());
+
+        cookieHeader = "bryant=longeststring; bryant=shortstring ; fred=shortstring ; fred=longeststring ; $Path=/path ; $Domain=.sun.com";
+        cookies = HttpHeaderReader.readCookies(cookieHeader);
+        assertEquals(cookies.size(), 2);
+        c = cookies.get("bryant");
+        assertEquals(c.getVersion(), 0);
+        assertEquals("bryant", c.getName());
+        assertEquals("longeststring", c.getValue());
+        c = cookies.get("fred");
+        assertEquals(c.getVersion(), 0);
+        assertEquals("fred", c.getName());
+        assertEquals("longeststring", c.getValue());
+        assertEquals("/path", c.getPath());
+        assertEquals(".sun.com", c.getDomain());
+
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: tvallin <thibault.vallin@oracle.com>

NewCookie :
     - pick the latest expiration date
     - if same date, take the longest path string

Cookie : 
     - pick the longest string