### PR TITLE
Query parameters were not included in netty URI

### DIFF
--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyConnector.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -285,7 +285,7 @@ class NettyConnector implements Connector {
 
     private String buildPathWithQueryParameters(URI requestUri) {
         if (requestUri.getRawQuery() != null) {
-            return new StringBuilder(requestUri.getRawPath()).append("?").append(requestUri.getRawQuery()).toString();
+            return String.format("%s?%s", requestUri.getRawPath(), requestUri.getRawQuery());
         } else {
             return requestUri.getRawPath();
         }

--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyConnector.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyConnector.java
@@ -205,15 +205,16 @@ class NettyConnector implements Connector {
             ch.closeFuture().addListener(closeListener);
 
             HttpRequest nettyRequest;
+            String pathWithQuery = buildPathWithQueryParameters(requestUri);
 
             if (jerseyRequest.hasEntity()) {
                 nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
                                                       HttpMethod.valueOf(jerseyRequest.getMethod()),
-                                                      requestUri.getRawPath());
+                                                      pathWithQuery);
             } else {
                 nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
                                                           HttpMethod.valueOf(jerseyRequest.getMethod()),
-                                                          requestUri.getRawPath());
+                                                          pathWithQuery);
             }
 
             // headers
@@ -280,6 +281,14 @@ class NettyConnector implements Connector {
         }
 
         return settableFuture;
+    }
+
+    private String buildPathWithQueryParameters(URI requestUri) {
+        if (requestUri.getRawQuery() != null) {
+            return new StringBuilder(requestUri.getRawPath()).append("?").append(requestUri.getRawQuery()).toString();
+        } else {
+            return requestUri.getRawPath();
+        }
     }
 
     @Override

--- a/examples/helloworld-netty/src/main/java/org/glassfish/jersey/examples/helloworld/netty/HelloWorldResource.java
+++ b/examples/helloworld-netty/src/main/java/org/glassfish/jersey/examples/helloworld/netty/HelloWorldResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,9 +10,13 @@
 
 package org.glassfish.jersey.examples.helloworld.netty;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 /**
  *
@@ -26,6 +30,23 @@ public class HelloWorldResource {
     @Produces("text/plain")
     public String getHello() {
         return CLICHED_MESSAGE;
+    }
+
+    @GET
+    @Path("query1")
+    @Produces("text/plain")
+    public String getQueryParameter(@DefaultValue("error1") @QueryParam(value = "test1") String test1,
+            @DefaultValue("error2") @QueryParam(value = "test2") String test2) {
+        return test1 + test2;
+    }
+
+    @POST
+    @Path("query2")
+    @Consumes("text/plain")
+    @Produces("text/plain")
+    public String postQueryParameter(@DefaultValue("error1") @QueryParam(value = "test1") String test1,
+            @DefaultValue("error2") @QueryParam(value = "test2") String test2, String entity) {
+        return entity + test1 + test2;
     }
 
 }

--- a/examples/helloworld-netty/src/test/java/org/glassfish/jersey/examples/helloworld/netty/HelloWorldTest.java
+++ b/examples/helloworld-netty/src/test/java/org/glassfish/jersey/examples/helloworld/netty/HelloWorldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
@@ -224,4 +225,22 @@ public class HelloWorldTest extends JerseyTest {
         assertEquals(1, CustomLoggingFilter.preFilterCalled);
         assertEquals(1, CustomLoggingFilter.postFilterCalled);
     }
+
+    @Test
+    @RunSeparately
+    public void testQueryParameterGet() {
+        String result = target().path(App.ROOT_PATH + "/query1").queryParam("test1", "expected1")
+                .queryParam("test2", "expected2").request().get(String.class);
+        assertEquals("expected1expected2", result);
+    }
+
+    @Test
+    @RunSeparately
+    public void testQueryParameterPost() {
+        String result = target().path(App.ROOT_PATH + "/query2").queryParam("test1", "expected1")
+                .queryParam("test2", "expected2").request("text/plain").post(Entity.entity("entity", "text/plain"))
+                .readEntity(String.class);
+        assertEquals("entityexpected1expected2", result);
+    }
+
 }


### PR DESCRIPTION
This is the issue:
https://github.com/eclipse-ee4j/jersey/issues/4369

I didn't find a better solution for this because the Netty HttpRequest doesn't have a method to add query parameters.