### PR TITLE
Add ExecutionStatisticsDynamicBean.getAttributes

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/monitoring/jmx/ExecutionStatisticsDynamicBean.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/monitoring/jmx/ExecutionStatisticsDynamicBean.java
@@ -173,8 +173,12 @@ public class ExecutionStatisticsDynamicBean implements DynamicMBean {
 
     @Override
     public AttributeList getAttributes(String[] attributes) {
-        // TODO: implement
-        return null;
+        AttributeList x = new AttributeList();
+        for (String k : attributes) {
+            Attribute a = new Attribute(k, attributeValues.get(k).get());
+            x.add(a);
+        }
+        return x;
     }
 
     @Override


### PR DESCRIPTION
Implementation was missing. Needed in order to use this bean with generic JMX collector from Prometheus: https://github.com/prometheus/jmx_exporter.