### PR TITLE
Additionally building on OpenJDK14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ jdk:
   - oraclejdk8
   - openjdk11
   - openjdk13
+  - openjdk14
 
 cache:
   directories:


### PR DESCRIPTION
Since JDK 14 was released, it makes sense to test buildability on OpenJDK14.