### PR TITLE
Support jersey-2031 integration test

### DIFF
--- a/tests/integration/jersey-2031/pom.xml
+++ b/tests/integration/jersey-2031/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29-SNAPSHOT</version>
+        <version>2.31-SNAPSHOT</version>
     </parent>
 
     <artifactId>jersey-2031</artifactId>

--- a/tests/integration/jersey-2031/src/main/webapp/WEB-INF/web.xml
+++ b/tests/integration/jersey-2031/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,12 +31,4 @@
         <filter-name>jersey2031</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
-    <jsp-config>
-        <taglib>
-            <taglib-uri>urn:org:glassfish:jersey:servlet:mvc</taglib-uri>
-            <taglib-location>
-                /WEB-INF/lib/jersey-mvc-jsp-2.29-SNAPSHOT.jar
-            </taglib-location>
-        </taglib>
-    </jsp-config>
 </web-app>

--- a/tests/integration/jersey-2031/src/main/webapp/org/glassfish/jersey/tests/integration/jersey2031/Issue2031Resource/index.jsp
+++ b/tests/integration/jersey-2031/src/main/webapp/org/glassfish/jersey/tests/integration/jersey2031/Issue2031Resource/index.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,8 +19,6 @@
 <%@page contentType="text/html"%>
 <%@page pageEncoding="UTF-8"%>
 
-<%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
-<%@taglib prefix="rbt" uri="urn:org:glassfish:jersey:servlet:mvc" %>
 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 
@@ -33,7 +31,7 @@
 
     ${model.index}
 
-    <rbt:include page="include.jsp"/>
+    <jersey-mvc-jsp:include page="include.jsp"/>
 
     </body>
 </html>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -53,7 +53,7 @@
         <module>jersey-1928</module>
         <module>jersey-1960</module>
         <module>jersey-1964</module>
-        <!--<module>jersey-2031</module>-->
+        <module>jersey-2031</module>
         <module>jersey-2136</module>
         <module>jersey-2137</module>
         <module>jersey-2154</module>


### PR DESCRIPTION
There is a problem trying to assign the prefix to the URI:
<%@taglib prefix="rbt" uri="urn:org:glassfish:jerseyservlet:mvc" %>

However the URI is correctly loaded, because you can use the default short name 'jersey-mvc-jsp' and it is working.

The issue seems to be related with Jetty, because it was working with previous plugin version without doing this change.

I think from Jersey point of view is okay to apply this fix.
