### PR TITLE
jersey-2031 excluded JDK11

### DIFF
--- a/tests/integration/jersey-2031/pom.xml
+++ b/tests/integration/jersey-2031/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29-SNAPSHOT</version>
+        <version>2.31-SNAPSHOT</version>
     </parent>
 
     <artifactId>jersey-2031</artifactId>
@@ -66,10 +66,42 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
+                <groupId>org.mortbay.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-osgi</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**ITCase.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -53,7 +53,7 @@
         <module>jersey-1928</module>
         <module>jersey-1960</module>
         <module>jersey-1964</module>
-        <!--<module>jersey-2031</module>-->
+        <module>jersey-2031</module>
         <module>jersey-2136</module>
         <module>jersey-2137</module>
         <module>jersey-2154</module>


### PR DESCRIPTION
jersey-2031 module was excluded because it doesn't work with Jetty 9.

It looks like the correct Jetty versions to run servlet 2.5 is the Jetty 6 or 7. But that old Jetty doesn't work with JDK11.

I think the only option is to use Jetty 6 or 7 and run it with JDK8 only.

Here is the table of compatibilities:
https://www.eclipse.org/jetty/documentation/9.4.27.v20200227/what-jetty-version.html