### PR TITLE
JerseyInvocation should override toString()

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/JerseyInvocation.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/JerseyInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -993,5 +993,10 @@ public class JerseyInvocation implements javax.ws.rs.client.Invocation {
      */
     ClientRequest request() {
         return requestContext;
+    }
+
+    @Override
+    public String toString() {
+        return "JerseyInvocation [" + request().getMethod() + ' ' + request().getUri() + "]";
     }
 }


### PR DESCRIPTION
Override toString() with a sensible implementation.
So if you log a given JerseyInvocation object at least the request method and
URI of the contained requestContext is printed.

See issue #4270