### PR TITLE
jersey-2031

### DIFF
--- a/tests/integration/jersey-2031/pom.xml
+++ b/tests/integration/jersey-2031/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,13 +17,15 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29-SNAPSHOT</version>
+        <version>2.31-SNAPSHOT</version>
     </parent>
 
     <artifactId>jersey-2031</artifactId>
@@ -41,13 +43,12 @@
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-mvc-jsp</artifactId>
         </dependency>
-
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <version>${servlet2.version}</version>
+            <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-external</artifactId>
@@ -68,6 +69,29 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
+            </plugin>
+            <!-- From Jetty 7 there is a problem trying to auto-load the tld from a jar file, so we copy it directly in the app. -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/ext/mvc-jsp/src/main/resources/META-INF</directory>
+                                    <includes>
+                                        <include>taglib.tld</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tests/integration/jersey-2031/src/main/webapp/WEB-INF/taglib.tld
+++ b/tests/integration/jersey-2031/src/main/webapp/WEB-INF/taglib.tld
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<taglib xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
+        version="2.1">
+
+    <description>The tag library contains tags that takes advantage of the request dispatching mechanism.</description>
+    <tlib-version>1.0</tlib-version>
+    <short-name>jersey-mvc-jsp</short-name>
+    <uri>urn:org:glassfish:jersey:servlet:mvc</uri>
+
+    <tag>
+        <name>include</name>
+        <tag-class>org.glassfish.jersey.server.mvc.jsp.Include</tag-class>
+        <body-content>empty</body-content>
+        <attribute>
+            <name>page</name>
+            <required>yes</required>
+            <rtexprvalue>yes</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>resource</name>
+            <required>no</required>
+            <rtexprvalue>yes</rtexprvalue>
+        </attribute>
+    </tag>
+</taglib>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/integration/jersey-2031/src/main/webapp/WEB-INF/web.xml
+++ b/tests/integration/jersey-2031/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,9 +34,7 @@
     <jsp-config>
         <taglib>
             <taglib-uri>urn:org:glassfish:jersey:servlet:mvc</taglib-uri>
-            <taglib-location>
-                /WEB-INF/lib/jersey-mvc-jsp-2.29-SNAPSHOT.jar
-            </taglib-location>
+            <taglib-location>WEB-INF/taglib.tld</taglib-location>
         </taglib>
     </jsp-config>
 </web-app>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -53,7 +53,7 @@
         <module>jersey-1928</module>
         <module>jersey-1960</module>
         <module>jersey-1964</module>
-        <!--<module>jersey-2031</module>-->
+        <module>jersey-2031</module>
         <module>jersey-2136</module>
         <module>jersey-2137</module>
         <module>jersey-2154</module>


### PR DESCRIPTION
Enabled this module for testing. 

The problem is that JDK11 doesn't work with Jetty 6, so we use now Jetty 9.

This brings another problem, for some reason the tld of jersey-mvc-jsp is not loaded. Not sure why, in theory Jetty scans the jar files by regular expression. I tried it and it didn't work anyway:
https://wiki.eclipse.org/Jetty/Howto/Configure_JSP#Using_JSTL_Taglibs_for_Jetty_7.x_and_8.x

Finally I did an ugly solution, which is copying the tld in the application, and specify the web.xml to load it.

Maybe Jetty 9 doesn't work totally fine with servlet 2.5.