### PR TITLE
jersey-2031

### DIFF
--- a/tests/integration/jersey-2031/pom.xml
+++ b/tests/integration/jersey-2031/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,13 +17,15 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.glassfish.jersey.tests.integration</groupId>
         <artifactId>project</artifactId>
-        <version>2.29-SNAPSHOT</version>
+        <version>2.31-SNAPSHOT</version>
     </parent>
 
     <artifactId>jersey-2031</artifactId>
@@ -41,13 +43,12 @@
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-mvc-jsp</artifactId>
         </dependency>
-
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <version>${servlet2.version}</version>
+            <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-external</artifactId>
@@ -68,6 +69,36 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-tld</id>
+                        <phase>test</phase>
+                        <configuration>
+                            <target>
+                                <copy file="../../../ext/mvc-jsp/src/main/resources/META-INF/taglib.tld" todir="src/main/webapp/WEB-INF"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>delete-tld</id>
+                        <phase>post-integration-test</phase>
+                        <configuration>
+                            <target>
+                                <delete file="src/main/webapp/WEB-INF/taglib.tld"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tests/integration/jersey-2031/src/main/webapp/WEB-INF/web.xml
+++ b/tests/integration/jersey-2031/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,12 +31,4 @@
         <filter-name>jersey2031</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
-    <jsp-config>
-        <taglib>
-            <taglib-uri>urn:org:glassfish:jersey:servlet:mvc</taglib-uri>
-            <taglib-location>
-                /WEB-INF/lib/jersey-mvc-jsp-2.29-SNAPSHOT.jar
-            </taglib-location>
-        </taglib>
-    </jsp-config>
 </web-app>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -53,7 +53,7 @@
         <module>jersey-1928</module>
         <module>jersey-1960</module>
         <module>jersey-1964</module>
-        <!--<module>jersey-2031</module>-->
+        <module>jersey-2031</module>
         <module>jersey-2136</module>
         <module>jersey-2137</module>
         <module>jersey-2154</module>


### PR DESCRIPTION
Enabled this module for testing.

The problem is that JDK11 doesn't work with Jetty 6, so we use now Jetty 9.

This brings another problem, for some reason the tld of jersey-mvc-jsp is not loaded. Not sure why, in theory Jetty scans the jar files by regular expression. I tried to add a new regular expression to find jersey-mvc-jsp-2.31-SNAPSHOT.jar but it didn't work:
https://wiki.eclipse.org/Jetty/Howto/Configure_JSP#Using_JSTL_Taglibs_for_Jetty_7.x_and_8.x

Finally I did an ugly solution that works, which is copying the tld in the application. And to make the things more ugly, it doesn't work when you copy the tld in ${project.build.directory}/${project.build.finalName}/WEB-INF. Doing that it includes the TLD in the war file but it is not loaded for some reason.

It needs to be added in src/main/webapp/WEB-INF/ and then removed. It seems Jetty is using as resource folder src/main/webapp


