### PR TITLE
Activate useSystemProperties into ApacheConnector (#4458)

### DIFF
--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -164,6 +164,20 @@ public final class ApacheClientProperties {
      * @since 2.30
      */
     public static final String CONNECTION_CLOSING_STRATEGY = "jersey.config.apache.client.connectionClosingStrategy";
+
+    /**
+     * A value of {@code false} indicates the client will use default ApacheConnector params. A value
+     * of {@code true} will cause the client to take into account the system properties
+     * {@code https.protocols}, {@code https.cipherSuites}, {@code http.keepAlive},
+     * {@code http.maxConnections}.
+     * <p/>
+     * The value MUST be an instance of {@link java.lang.Boolean}.
+     * <p/>
+     * The default value is {@code false}.
+     * <p/>
+     * The name of the configuration property is <tt>{@value}</tt>.
+     */
+    public static final String USE_SYSTEM_PROPERTIES = "jersey.config.apache.client.useSystemProperties";
 
     /**
      * Get the value of the specified property.

--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -357,12 +357,15 @@ class ApacheConnector implements Connector {
             }
         }
 
+        final boolean useSystemProperties =
+            PropertiesHelper.isProperty(config.getProperties(), ApacheClientProperties.USE_SYSTEM_PROPERTIES);
+
         // Create custom connection manager.
         return createConnectionManager(
                 client,
                 config,
                 sslContext,
-                false);
+            useSystemProperties);
     }
 
     private HttpClientConnectionManager createConnectionManager(


### PR DESCRIPTION
ApacheConnector force the useSystemProperties flag to false:

jersey/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java

Line 365 in f9a8431

 false); 
All the code is already done, but the switch to activate it is missing.