### PR TITLE
javadoc fix for helidon connector

### DIFF
--- a/connectors/helidon-connector/pom.xml
+++ b/connectors/helidon-connector/pom.xml
@@ -73,6 +73,13 @@
                     <target>11</target>
                 </configuration>
             </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-javadoc-plugin</artifactId>
+               <configuration>
+                    <source>8</source>
+               </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Due to error in javadoc plugin it's required to mark sources as for the JDK 8, just for javadoc generation

Signed-off-by: Maxim Nesen <maxim.nesen@oracle.com>