### PR TITLE
SSE Flow.Subscriber injectable as event sink

### DIFF
--- a/connectors/helidon-connector/src/test/java/org/glassfish/jersey/helidon/connector/sse/SseTest.java
+++ b/connectors/helidon-connector/src/test/java/org/glassfish/jersey/helidon/connector/sse/SseTest.java
@@ -110,8 +110,10 @@ public class SseTest extends JerseyTest {
         final StringBuilder sb = new StringBuilder();
         final CountDownLatch latch = new CountDownLatch(10);
         try (SseEventSource source = SseEventSource.target(target().path("simple")).build()) {
-            source.register((event) -> sb.append(event.readData()));
-            source.register((event) -> latch.countDown());
+            source.register((event) -> {
+                sb.append(event.readData());
+                latch.countDown();
+            });
             source.open();
 
             latch.await(WAIT_TIME, TimeUnit.MILLISECONDS);
@@ -158,9 +160,11 @@ public class SseTest extends JerseyTest {
 
         private void register() throws InterruptedException {
             final CountDownLatch latch = new CountDownLatch(1);
-            source.register((event) -> message.append(event.readData()));
-            source.register((event) -> latch.countDown());
-            source.register((event) -> messageLatch.countDown());
+            source.register((event) -> {
+                message.append(event.readData());
+                latch.countDown();
+                messageLatch.countDown();
+            });
             source.open();
 
             latch.await(WAIT_TIME, TimeUnit.MILLISECONDS);

--- a/core-common/src/main/java11/org/glassfish/jersey/internal/jsr166/JerseyFlowSubscriber.java
+++ b/core-common/src/main/java11/org/glassfish/jersey/internal/jsr166/JerseyFlowSubscriber.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.internal.jsr166;
+
+public interface JerseyFlowSubscriber<T> extends Flow.Subscriber<T>, java.util.concurrent.Flow.Subscriber<T> {
+    @Override
+    default void onSubscribe(java.util.concurrent.Flow.Subscription subscription) {
+        this.onSubscribe(new Flow.Subscription() {
+            @Override
+            public void request(final long n) {
+                subscription.request(n);
+            }
+
+            @Override
+            public void cancel() {
+                subscription.cancel();
+            }
+        });
+    }
+}

--- a/core-common/src/main/java8/org/glassfish/jersey/internal/jsr166/JerseyFlowSubscriber.java
+++ b/core-common/src/main/java8/org/glassfish/jersey/internal/jsr166/JerseyFlowSubscriber.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.internal.jsr166;
+
+public interface JerseyFlowSubscriber<T> extends Flow.Subscriber<T> {
+}

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -299,6 +299,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
             closed = true;
             // remember the exception (it will get rethrown from finally clause, once it does it's work)
             ex = e;
+            onClose(e);
         } finally {
             if (closed) {
                 try {
@@ -347,6 +348,14 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
      */
     public boolean isClosed() {
         return closed;
+    }
+
+    /**
+     * Executed only in case of close being triggered by client.
+     * @param e Exception causing the close
+     */
+    protected void onClose(Exception e){
+
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/IntrospectionModeller.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/IntrospectionModeller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,7 +40,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.sse.SseEventSink;
 
 import org.glassfish.jersey.internal.Errors;
 import org.glassfish.jersey.internal.util.Producer;
@@ -49,6 +48,7 @@ import org.glassfish.jersey.internal.util.Tokenizer;
 import org.glassfish.jersey.server.ManagedAsync;
 import org.glassfish.jersey.server.internal.LocalizationMessages;
 import org.glassfish.jersey.server.model.internal.ModelHelper;
+import org.glassfish.jersey.server.model.internal.SseTypeResolver;
 
 /**
  * Utility class for constructing resource model from JAX-RS annotated POJO.
@@ -298,7 +298,7 @@ final class IntrospectionModeller {
         }
 
         for (Class<?> paramType : am.getParameterTypes()) {
-            if (SseEventSink.class.equals(paramType)) {
+            if (SseTypeResolver.isSseSinkParam(paramType)) {
                 resourceMethodBuilder.sse();
             }
         }

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodValidator.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,11 +37,11 @@ import javax.ws.rs.MatrixParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.sse.SseEventSink;
 
 import org.glassfish.jersey.internal.Errors;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.internal.LocalizationMessages;
+import org.glassfish.jersey.server.model.internal.SseTypeResolver;
 import org.glassfish.jersey.server.spi.internal.ParameterValueHelper;
 import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
 
@@ -85,7 +85,7 @@ class ResourceMethodValidator extends AbstractResourceModelVisitor {
         if ("GET".equals(method.getHttpMethod())) {
             final long eventSinkCount = invocable.getParameters()
                     .stream()
-                    .filter(parameter -> SseEventSink.class.equals(parameter.getRawType()))
+                    .filter(parameter -> SseTypeResolver.isSseSinkParam(parameter.getRawType()))
                     .count();
 
             final boolean isSse = eventSinkCount > 0;
@@ -213,7 +213,8 @@ class ResourceMethodValidator extends AbstractResourceModelVisitor {
     }
 
     private boolean isSseInjected(final Invocable invocable) {
-        return invocable.getParameters().stream().anyMatch(parameter -> SseEventSink.class.equals(parameter.getRawType()));
+        return invocable.getParameters().stream()
+                .anyMatch(parameter -> SseTypeResolver.isSseSinkParam(parameter.getRawType()));
     }
 
     private static final Set<Class> PARAM_ANNOTATION_SET = createParamAnnotationSet();

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/internal/JavaResourceMethodDispatcherProvider.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/internal/JavaResourceMethodDispatcherProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,7 @@ class JavaResourceMethodDispatcherProvider implements ResourceMethodDispatcher.P
             // return type is void
             int i = 0;
             for (final Parameter parameter : resourceMethod.getParameters()) {
-                if (SseEventSink.class.equals(parameter.getRawType())) {
+                if (SseTypeResolver.isSseSinkParam(parameter.getRawType())) {
                     resourceMethodDispatcher =
                             new SseEventSinkInvoker(resourceMethod, invocationHandler, valueProviders, validator, i);
                     break;

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/internal/SseTypeResolver.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/internal/SseTypeResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.jersey.server.model.internal;
+
+import java.security.AccessController;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.glassfish.jersey.internal.util.ReflectionHelper;
+
+public final class SseTypeResolver {
+
+    private static final Set<Class<?>> SUPPORTED_SSE_SINK_TYPES;
+
+    private SseTypeResolver() {
+    }
+
+    static {
+        Set<Class<?>> set = new HashSet<>(8);
+
+        set.add(org.glassfish.jersey.internal.jsr166.Flow.Subscriber.class);
+        set.add(javax.ws.rs.sse.SseEventSink.class);
+        Class<?> clazz = AccessController
+                .doPrivileged(ReflectionHelper.classForNamePA("java.util.concurrent.Flow$Subscriber", null));
+
+        if (clazz != null) {
+            set.add(clazz);
+        }
+        SUPPORTED_SSE_SINK_TYPES = Collections.unmodifiableSet(set);
+    }
+
+    public static boolean isSseSinkParam(Class<?> type) {
+        return SUPPORTED_SSE_SINK_TYPES.contains(type);
+    }
+}

--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/internal/SseEventSinkValueParamProvider.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/internal/SseEventSinkValueParamProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,6 +29,7 @@ import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.internal.inject.AbstractValueParamProvider;
 import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractorProvider;
 import org.glassfish.jersey.server.model.Parameter;
+import org.glassfish.jersey.server.model.internal.SseTypeResolver;
 import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
 
 /**
@@ -59,7 +60,8 @@ public class SseEventSinkValueParamProvider extends AbstractValueParamProvider {
         }
 
         final Class<?> rawParameterType = parameter.getRawType();
-        if (rawParameterType == SseEventSink.class && parameter.isAnnotationPresent(Context.class)) {
+        if (SseTypeResolver.isSseSinkParam(rawParameterType)
+                && parameter.isAnnotationPresent(Context.class)) {
             return new SseEventSinkValueSupplier(asyncContextSupplier);
         }
         return null;

--- a/media/sse/src/main/resources/org/glassfish/jersey/media/sse/localization.properties
+++ b/media/sse/src/main/resources/org/glassfish/jersey/media/sse/localization.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,5 +34,6 @@ out.event.not.buildable=Cannot build outbound event. Either a comment or non-nul
 param.null="{0}" parameter is null.
 params.null=One or more of parameters is null.
 event.sink.close.failed=Closing EventSink failed. Could not close chunked output.
+event.sink.next.failed=Processing onNext signal failed.
 unsupported.webtarget.type=Argument {0} is not a valid JerseyWebTarget instance. SseEventSource does not support other \
   WebTarget implementations.

--- a/media/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseyEventSinkTest.java
+++ b/media/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseyEventSinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,7 @@
 
 package org.glassfish.jersey.media.sse.internal;
 
+import org.glassfish.jersey.media.sse.OutboundEvent;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -27,43 +28,6 @@ public class JerseyEventSinkTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-
-    @Test
-    public void onSubscribe() throws Exception {
-        JerseyEventSink eventSink = new JerseyEventSink(null);
-
-        eventSink.close();
-        thrown.expect(IllegalStateException.class);
-        eventSink.onSubscribe(null);
-    }
-
-    @Test
-    public void onNext() throws Exception {
-        JerseyEventSink eventSink = new JerseyEventSink(null);
-
-        eventSink.close();
-        thrown.expect(IllegalStateException.class);
-        eventSink.onNext(null);
-    }
-
-    @Test
-    public void onError() throws Exception {
-        JerseyEventSink eventSink = new JerseyEventSink(null);
-
-        eventSink.close();
-        thrown.expect(IllegalStateException.class);
-        eventSink.onError(null);
-    }
-
-    @Test
-    public void onComplete() throws Exception {
-        JerseyEventSink eventSink = new JerseyEventSink(null);
-
-        eventSink.close();
-        thrown.expect(IllegalStateException.class);
-        eventSink.onComplete();
-    }
 
     @Test
     public void test() throws Exception {

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -133,6 +133,7 @@
         <module>spring4</module>
         <module>spring5</module>
         <module>tracing-support</module>
+        <module>reactive-streams</module>
     </modules>
 
     <profiles>

--- a/tests/integration/reactive-streams/pom.xml
+++ b/tests/integration/reactive-streams/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <version>2.32.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <groupId>org.glassfish.jersey.tests.integration.reactive</groupId>
+    <artifactId>reactive-streams-integration-project</artifactId>
+    <name>reactive-streams-integration-project</name>
+    <modules>
+        <module>sse</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/reactive-streams/sse/pom.xml
+++ b/tests/integration/reactive-streams/sse/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>reactive-streams-integration-project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration.reactive</groupId>
+        <version>2.32.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sse-reactive-streams-tck</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-sse</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck</artifactId>
+            <version>1.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava2</groupId>
+            <artifactId>rxjava</artifactId>
+            <version>${rxjava2.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-binding</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-bundle</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>**/*TckTest.java</include>
+                    </includes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>3.0.0-M3</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/tests/integration/reactive-streams/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseyEventSinkBlackBoxSubscriberTckTest.java
+++ b/tests/integration/reactive-streams/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseyEventSinkBlackBoxSubscriberTckTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.media.sse.internal;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.tck.SubscriberBlackboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+
+public class JerseyEventSinkBlackBoxSubscriberTckTest extends SubscriberBlackboxVerification<Object> {
+
+    static final TestEnvironment env = new TestEnvironment(250);
+
+    public JerseyEventSinkBlackBoxSubscriberTckTest() {
+        super(env);
+    }
+
+    @Override
+    public Subscriber<Object> createSubscriber() {
+        JerseyEventSink jerseyEventSink = new JerseyEventSink(null);
+        return JerseyFlowAdapters.toSubscriber(jerseyEventSink);
+    }
+
+    @Override
+    public String createElement(final int i) {
+        return "test" + i;
+    }
+}

--- a/tests/integration/reactive-streams/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseyEventSinkWhiteBoxSubscriberTckTest.java
+++ b/tests/integration/reactive-streams/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseyEventSinkWhiteBoxSubscriberTckTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.media.sse.internal;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.Assert.fail;
+
+import org.glassfish.jersey.internal.jsr166.Flow;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.tck.SubscriberWhiteboxVerification;
+import org.reactivestreams.tck.TestEnvironment;
+import org.testng.TestException;
+import org.testng.annotations.Test;
+
+public class JerseyEventSinkWhiteBoxSubscriberTckTest extends SubscriberWhiteboxVerification<Object> {
+
+    static final TestEnvironment env = new TestEnvironment(250);
+
+    public JerseyEventSinkWhiteBoxSubscriberTckTest() {
+        super(env);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void noopOnNextAfterClose() throws InterruptedException {
+        WhiteboxTestStage stage = new WhiteboxTestStage(env, true);
+        SubscriberPuppet puppet = stage.puppet();
+        WhiteboxSubscriberProbe<Object> probe = stage.probe;
+        JerseyEventSink eventSink = (JerseyEventSink)
+                ((JerseyFlowAdapters.AdaptedSubscriber<Object>) stage.sub()).jerseySubscriber;
+        puppet.triggerRequest(2);
+        stage.expectRequest();
+        probe.expectNext(stage.signalNext());
+        probe.expectNext(stage.signalNext());
+
+        puppet.triggerRequest(3000);
+        eventSink.close();
+        stage.expectCancelling();
+        stage.signalNext();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void noopOnCompleteAfterClose() throws InterruptedException {
+        WhiteboxTestStage stage = new WhiteboxTestStage(env, true);
+        SubscriberPuppet puppet = stage.puppet();
+        WhiteboxSubscriberProbe<Object> probe = stage.probe;
+        JerseyEventSink eventSink = (JerseyEventSink)
+                ((JerseyFlowAdapters.AdaptedSubscriber<Object>) stage.sub()).jerseySubscriber;
+        puppet.triggerRequest(2);
+        stage.expectRequest();
+        probe.expectNext(stage.signalNext());
+        probe.expectNext(stage.signalNext());
+
+        puppet.triggerRequest(3000);
+        eventSink.close();
+        stage.sendCompletion();
+        probe.expectCompletion();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void noopOnErrorAfterClose() throws InterruptedException {
+        WhiteboxTestStage stage = new WhiteboxTestStage(env, true);
+        SubscriberPuppet puppet = stage.puppet();
+        WhiteboxSubscriberProbe<Object> probe = stage.probe;
+        JerseyEventSink eventSink = (JerseyEventSink)
+                ((JerseyFlowAdapters.AdaptedSubscriber<Object>) stage.sub()).jerseySubscriber;
+        puppet.triggerRequest(2);
+        stage.expectRequest();
+        probe.expectNext(stage.signalNext());
+        probe.expectNext(stage.signalNext());
+
+        puppet.triggerRequest(3000);
+        eventSink.close();
+
+        TestException testException = new TestException("BOOM JERSEY!");
+
+        stage.sendError(testException);
+        probe.expectError(testException);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void cancelSubscriptionAfterClose() throws InterruptedException {
+        WhiteboxTestStage stage = new WhiteboxTestStage(env, true);
+        SubscriberPuppet puppet = stage.puppet();
+        WhiteboxSubscriberProbe<Object> probe = stage.probe;
+        JerseyEventSink eventSink = (JerseyEventSink)
+                ((JerseyFlowAdapters.AdaptedSubscriber<Object>) stage.sub()).jerseySubscriber;
+        puppet.triggerRequest(2);
+        stage.expectRequest();
+        probe.expectNext(stage.signalNext());
+        probe.expectNext(stage.signalNext());
+
+        puppet.triggerRequest(3000);
+        eventSink.close();
+
+        stage.expectCancelling();
+
+        CompletableFuture<Void> cancelled2ndSubscription = new CompletableFuture<>();
+
+        eventSink.onSubscribe(new Flow.Subscription() {
+            @Override
+            public void request(final long n) {
+
+            }
+
+            @Override
+            public void cancel() {
+                cancelled2ndSubscription.complete(null);
+            }
+        });
+
+        try {
+            cancelled2ndSubscription.get(env.defaultTimeoutMillis(), TimeUnit.MILLISECONDS);
+        } catch (ExecutionException | TimeoutException e) {
+            fail("Cancel is expected on subscription on closed JerseyEventSink");
+        }
+    }
+
+    @Override
+    public Subscriber<Object> createSubscriber(final WhiteboxSubscriberProbe<Object> probe) {
+        JerseyEventSink jerseyEventSink = new JerseyEventSink(null) {
+            @Override
+            public void onSubscribe(final Flow.Subscription subscription) {
+                super.onSubscribe(subscription);
+                probe.registerOnSubscribe(new SubscriberPuppet() {
+                    @Override
+                    public void triggerRequest(final long elements) {
+                        subscription.request(elements);
+                    }
+
+                    @Override
+                    public void signalCancel() {
+                        subscription.cancel();
+                    }
+                });
+            }
+
+            @Override
+            public void onNext(final Object item) {
+                super.onNext(item);
+                probe.registerOnNext(item);
+            }
+
+            @Override
+            public void onError(final Throwable throwable) {
+                super.onError(throwable);
+                probe.registerOnError(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                super.onComplete();
+                probe.registerOnComplete();
+            }
+        };
+        return JerseyFlowAdapters.toSubscriber(jerseyEventSink);
+    }
+
+    @Override
+    public String createElement(final int i) {
+        return "test" + i;
+    }
+}

--- a/tests/integration/reactive-streams/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseyFlowAdapters.java
+++ b/tests/integration/reactive-streams/sse/src/test/java/org/glassfish/jersey/media/sse/internal/JerseyFlowAdapters.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.media.sse.internal;
+
+import org.glassfish.jersey.internal.jsr166.Flow;
+
+public class JerseyFlowAdapters {
+
+    /**
+     * Adapt {@link org.glassfish.jersey.internal.jsr166.Flow.Subscriber} to
+     * {@link org.reactivestreams.Subscriber}.
+     *
+     * @param jerseySubscriber Jersey's repackaged {@link org.glassfish.jersey.internal.jsr166.Flow.Subscriber}
+     * @param <T>              payload type
+     * @return Reactive Streams's {@link org.reactivestreams.Subscriber}
+     */
+    static <T> org.reactivestreams.Subscriber<T> toSubscriber(Flow.Subscriber<T> jerseySubscriber) {
+        return new AdaptedSubscriber<T>(jerseySubscriber);
+    }
+
+    public static class AdaptedSubscriber<T> implements org.reactivestreams.Subscriber<T> {
+
+        public final Flow.Subscriber<T> jerseySubscriber;
+
+        public AdaptedSubscriber(Flow.Subscriber<T> jerseySubscriber) {
+            this.jerseySubscriber = jerseySubscriber;
+        }
+
+        @Override
+        public void onSubscribe(final org.reactivestreams.Subscription subscription) {
+            jerseySubscriber.onSubscribe(new Flow.Subscription() {
+                @Override
+                public void request(final long n) {
+                    subscription.request(n);
+                }
+
+                @Override
+                public void cancel() {
+                    subscription.cancel();
+                }
+            });
+        }
+
+        @Override
+        public void onNext(final T t) {
+            jerseySubscriber.onNext(t);
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+            jerseySubscriber.onError(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            jerseySubscriber.onComplete();
+        }
+    }
+}

--- a/tests/integration/reactive-streams/sse/src/test/java/org/glassfish/jersey/media/sse/internal/SseSubscriberTest.java
+++ b/tests/integration/reactive-streams/sse/src/test/java/org/glassfish/jersey/media/sse/internal/SseSubscriberTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.media.sse.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import javax.inject.Singleton;
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObject;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.sse.SseEventSource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.reactivex.Flowable;
+import org.glassfish.jersey.internal.jsr166.Flow;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+/**
+ * @author Daniel Kec
+ */
+public class SseSubscriberTest extends JerseyTest {
+
+    private static final int NUMBER_OF_TEST_MESSAGES = 5;
+    private static final String TEST_MESSAGE = "Jersey";
+    private static final JsonBuilderFactory JSON_BUILDER = Json.createBuilderFactory(Collections.emptyMap());
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(SseEndpoint.class);
+    }
+
+    @Singleton
+    @Path("sse")
+    public static class SseEndpoint {
+
+        @GET
+        @Path("short")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseShort(@Context Flow.Subscriber<Short> subscriber) {
+            Flowable.interval(20, TimeUnit.MILLISECONDS)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .map(Long::shortValue)
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("double")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseDouble(@Context Flow.Subscriber<Double> subscriber) {
+            Flowable.interval(20, TimeUnit.MILLISECONDS)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .map(Long::doubleValue)
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("byte")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseByte(@Context Flow.Subscriber<Byte> subscriber) {
+            Flowable.interval(20, TimeUnit.MILLISECONDS)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .map(Long::byteValue)
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("integer")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseInteger(@Context Flow.Subscriber<Integer> subscriber) {
+            Flowable.interval(20, TimeUnit.MILLISECONDS)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .map(Long::intValue)
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("long")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseLong(@Context Flow.Subscriber<Long> subscriber) {
+            Flowable.just(0L, 1L, 2L, 3L, 4L)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("string")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseString(@Context Flow.Subscriber<String> subscriber) {
+            Flowable.interval(20, TimeUnit.MILLISECONDS)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .map(l -> TEST_MESSAGE + l)
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("boolean")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseBoolean(@Context Flow.Subscriber<Boolean> subscriber) {
+            Flowable.interval(20, TimeUnit.MILLISECONDS)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .map(l -> (l % 2) == 0)
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("char")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseChar(@Context Flow.Subscriber<Character> subscriber) {
+            Flowable.just("FRANK")
+                    .flatMap(s -> Flowable.fromArray(s.chars().mapToObj(ch -> (char) ch).toArray(Character[]::new)))
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("json-obj")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseJsonObj(@Context Flow.Subscriber<JsonObject> subscriber) {
+            Flowable.interval(20, TimeUnit.MILLISECONDS)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .map(l -> JSON_BUILDER.createObjectBuilder()
+                            .add("brand", TEST_MESSAGE)
+                            .add("model", "Model " + l)
+                            .build())
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+
+        @GET
+        @Path("json")
+        @Produces(MediaType.SERVER_SENT_EVENTS)
+        public void sseJson(@Context Flow.Subscriber<Car> subscriber) {
+            Flowable.interval(20, TimeUnit.MILLISECONDS)
+                    .take(NUMBER_OF_TEST_MESSAGES)
+                    .map(l -> new Car(TEST_MESSAGE, "Model " + l))
+                    .subscribe(JerseyFlowAdapters.toSubscriber(subscriber));
+        }
+    }
+
+
+    @Test
+    public void testShort() throws InterruptedException {
+        assertEquals(Arrays.asList((short) 0, (short) 1, (short) 2, (short) 3, (short) 4), receive(Short.class, "sse/short"));
+    }
+
+    @Test
+    public void testDouble() throws InterruptedException {
+        assertEquals(Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0), receive(Double.class, "sse/double"));
+    }
+
+    @Test
+    public void testByte() throws InterruptedException {
+        assertEquals(Arrays.asList((byte) 0, (byte) 1, (byte) 2, (byte) 3, (byte) 4), receive(Byte.class, "sse/byte"));
+    }
+
+    @Test
+    public void testInteger() throws InterruptedException {
+        assertEquals(Arrays.asList(0, 1, 2, 3, 4), receive(Integer.class, "sse/integer"));
+    }
+
+    @Test
+    public void testBoolean() throws InterruptedException {
+        assertEquals(Arrays.asList(true, false, true, false, true), receive(Boolean.class, "sse/boolean"));
+    }
+
+    @Test
+    public void testLong() throws InterruptedException {
+        assertEquals(Arrays.asList(0L, 1L, 2L, 3L, 4L), receive(Long.class, "sse/long"));
+    }
+
+    @Test
+    public void testString() throws InterruptedException {
+        assertEquals(Arrays.asList(TEST_MESSAGE + 0, TEST_MESSAGE + 1, TEST_MESSAGE + 2, TEST_MESSAGE + 3, TEST_MESSAGE + 4),
+                receive(String.class, "sse/string"));
+    }
+
+    @Test
+    public void testChar() throws InterruptedException {
+        assertEquals(Arrays.asList('F', 'R', 'A', 'N', 'K'),
+                receive(Character.class, "sse/char"));
+    }
+
+    @Test
+    public void testJsonObj() throws InterruptedException {
+        Jsonb jsonb = JsonbBuilder.create();
+        assertEquals(Arrays.asList(
+                new Car(TEST_MESSAGE, "Model 0"),
+                new Car(TEST_MESSAGE, "Model 1"),
+                new Car(TEST_MESSAGE, "Model 2"),
+                new Car(TEST_MESSAGE, "Model 3"),
+                new Car(TEST_MESSAGE, "Model 4")
+                ),
+                receive(String.class, "sse/json-obj")
+                        .stream()
+                        .map(s -> jsonb.fromJson(s, Car.class))
+                        .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testJson() throws InterruptedException {
+        Jsonb jsonb = JsonbBuilder.create();
+        assertEquals(Arrays.asList(
+                new Car(TEST_MESSAGE, "Model 0"),
+                new Car(TEST_MESSAGE, "Model 1"),
+                new Car(TEST_MESSAGE, "Model 2"),
+                new Car(TEST_MESSAGE, "Model 3"),
+                new Car(TEST_MESSAGE, "Model 4")
+                ),
+                receive(String.class, "sse/json")
+                        .stream()
+                        .map(s -> jsonb.fromJson(s, Car.class))
+                        .collect(Collectors.toList()));
+    }
+
+    private <T> List<T> receive(Class<T> type, String path) throws InterruptedException {
+        WebTarget sseTarget = target(path);
+
+        ArrayList<T> result = new ArrayList<>(NUMBER_OF_TEST_MESSAGES);
+
+        final CountDownLatch eventLatch = new CountDownLatch(NUMBER_OF_TEST_MESSAGES);
+        SseEventSource eventSource = SseEventSource.target(sseTarget).build();
+        eventSource.register((event) -> {
+            System.out.println("### Client received: " + event);
+            result.add(event.readData(type));
+            eventLatch.countDown();
+        });
+        eventSource.open();
+
+        // client waiting for confirmation that resource method ended.
+        assertTrue(eventLatch.await(2, TimeUnit.SECONDS));
+        return result;
+    }
+
+    public static class Car {
+        private String brand;
+        private String model;
+
+        public Car() {
+        }
+
+        public Car(final String brand, final String model) {
+            this.brand = brand;
+            this.model = model;
+        }
+
+        public String getBrand() {
+            return brand;
+        }
+
+        public void setBrand(final String brand) {
+            this.brand = brand;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public void setModel(final String model) {
+            this.model = model;
+        }
+
+        @Override
+        public String toString() {
+            return "Car{brand='" + brand + "', model='" + model + "'}";
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Car car = (Car) o;
+            return Objects.equals(brand, car.brand)
+                    && Objects.equals(model, car.model);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(brand, model);
+        }
+    }
+}

--- a/tests/integration/reactive-streams/sse/tck-suite.xml
+++ b/tests/integration/reactive-streams/sse/tck-suite.xml
@@ -1,0 +1,28 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<suite name="reactive-streams-sse-TCK" verbose="2" configfailurepolicy="continue">
+
+    <test name="reactive-streams-sse TCK">
+        <packages>
+            <package name="org.glassfish.jersey.media.sse.internal.*">
+            </package>
+        </packages>
+    </test>
+
+</suite>


### PR DESCRIPTION
Fixes #4501 
Fixes #4500

## Now its possible in Java 11+
```java
    @GET
    @Path("sse")
    @Produces(MediaType.SERVER_SENT_EVENTS)
    public void listenToEvents(@Context java.util.concurrent.Flow.Subscriber<String> eventSink)
    public void listenToEvents(@Context java.util.concurrent.Flow.Subscriber<OutboundEvent> eventSink)
    public void listenToEvents(@Context org.glassfish.jersey.internal.jsr166.Flow.Subscriber<String> eventSink)
    public void listenToEvents(@Context org.glassfish.jersey.internal.jsr166.Flow.Subscriber<OutboundEvent> eventSink)
```

## Java 8
```java
    @GET
    @Path("sse")
    @Produces(MediaType.SERVER_SENT_EVENTS)
    public void listenToEvents(@Context org.glassfish.jersey.internal.jsr166.Flow.Subscriber<String> eventSink)
    public void listenToEvents(@Context org.glassfish.jersey.internal.jsr166.Flow.Subscriber<OutboundEvent> eventSink)
```