### PR TITLE
Fix custom SSLSocketFactory not being set because of an unsafe lazy-initialization in JDK

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java
@@ -71,6 +71,9 @@ public class HttpUrlConnector implements Connector {
 
     private static final Logger LOGGER = Logger.getLogger(HttpUrlConnector.class.getName());
     private static final String ALLOW_RESTRICTED_HEADERS_SYSTEM_PROPERTY = "sun.net.http.allowRestrictedHeaders";
+    // Avoid multi-thread uses of HttpsURLConnection.getDefaultSSLSocketFactory() because it does not implement a
+    // proper lazy-initialization. See https://github.com/jersey/jersey/issues/3293
+    private static final SSLSocketFactory DEFAULT_SSL_SOCKET_FACTORY = HttpsURLConnection.getDefaultSSLSocketFactory();
     // The list of restricted headers is extracted from sun.net.www.protocol.http.HttpURLConnection
     private static final String[] restrictedHeaders = {
             "Access-Control-Request-Headers",
@@ -299,7 +302,7 @@ public class HttpUrlConnector implements Connector {
                 suc.setHostnameVerifier(verifier);
             }
 
-            if (HttpsURLConnection.getDefaultSSLSocketFactory() == suc.getSSLSocketFactory()) {
+            if (DEFAULT_SSL_SOCKET_FACTORY == suc.getSSLSocketFactory()) {
                 // indicates that the custom socket factory was not set
                 suc.setSSLSocketFactory(sslSocketFactory.get());
             }

--- a/tests/e2e-client/src/test/java/org/glassfish/jersey/tests/e2e/client/connector/ssl/SslHttpUrlConnectorTest.java
+++ b/tests/e2e-client/src/test/java/org/glassfish/jersey/tests/e2e/client/connector/ssl/SslHttpUrlConnectorTest.java
@@ -17,10 +17,18 @@
 package org.glassfish.jersey.tests.e2e.client.connector.ssl;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -77,6 +85,61 @@ public class SslHttpUrlConnectorTest extends AbstractConnectorServerTest {
         final Response response = client.target(Server.BASE_URI).path("/").request().get();
         assertEquals(200, response.getStatus());
         assertTrue(socketFactory.isVisited());
+    }
+
+    /**
+     * Test for https://github.com/jersey/jersey/issues/3293
+     *
+     * @author Kevin Conaway
+     */
+    @Test
+    public void testConcurrentRequestsWithCustomSSLContext() throws Exception {
+        final SSLContext sslContext = getSslContext();
+
+        final Client client = ClientBuilder.newBuilder()
+            .sslContext(sslContext)
+            .register(HttpAuthenticationFeature.basic("user", "password"))
+            .register(LoggingFeature.class)
+            .build();
+
+        int numThreads = 5;
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        ExecutorService service = Executors.newFixedThreadPool(numThreads);
+        List<Exception> exceptions = new CopyOnWriteArrayList<>();
+
+        for (int i = 0; i < numThreads; i++) {
+            service.submit(() -> {
+                try {
+                    barrier.await(1, TimeUnit.MINUTES);
+                    for (int call = 0; call < 10; call++) {
+                        final Response response = client.target(Server.BASE_URI).path("/").request().get();
+                        assertEquals(200, response.getStatus());
+                    }
+                } catch (Exception ex) {
+                    exceptions.add(ex);
+                }
+            });
+        }
+
+        service.shutdown();
+
+        assertTrue(
+            service.awaitTermination(1, TimeUnit.MINUTES)
+        );
+
+        assertTrue(
+            toString(exceptions),
+            exceptions.isEmpty()
+        );
+    }
+
+    private String toString(List<Exception> exceptions) {
+        StringWriter writer = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(writer);
+
+        exceptions.forEach(e -> e.printStackTrace(printWriter));
+
+        return writer.toString();
     }
 
     public static class CustomSSLSocketFactory extends SSLSocketFactory {


### PR DESCRIPTION
Hi,

this PR fixes #3293 with an approach similar to the one contributed by @kevinconaway on jersey/jersey#3738 (check up his well written explanation). We (@amplia-iiot) think his contribution was forgotten when the project was transitioned (#3738) over to the Eclipse Foundation and have implemented this more maintainable approach (the change is easier to notice when looking at `secureConnection(JerseyClient, HttpURLConnection)` and avoids multiple calls to `HttpsURLConnection.getDefaultSSLSocketFactory()` making it cleaner).

I've not included the original test by @kevinconaway because I'm not aware of his status regarding the Eclipse Contributor Agreement, but it can be checked at [@6a8e80ec625f2ce9a7585dc45e645fab61aa504c](https://github.com/amplia-iiot/jersey/commit/6a8e80ec625f2ce9a7585dc45e645fab61aa504c) ([bugfix/jersey\#3293-test](https://github.com/amplia-iiot/jersey/tree/bugfix/jersey%233293-test)).

We think this is the way to go for Jersey until the JDK properly makes this lazy-initialization thread-safe like the [implementation](https://android.googlesource.com/platform/libcore/+/af8ca5f/luni/src/main/java/javax/net/ssl/HttpsURLConnection.java) in Android's JDK.

Nevertheless, we are open to feedback regarding this change and discussing alternate approaches.