### PR TITLE
Allow for org.glassfish.jersey.servlet.ServletContainer in web.xml

### DIFF
--- a/containers/jersey-servlet/src/main/java/org/glassfish/jersey/servlet/init/JerseyServletContainerInitializer.java
+++ b/containers/jersey-servlet/src/main/java/org/glassfish/jersey/servlet/init/JerseyServletContainerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -128,12 +128,15 @@ public final class JerseyServletContainerInitializer implements ServletContainer
     }
 
     private void onStartupImpl(final Set<Class<?>> classes, final ServletContext servletContext) throws ServletException {
+        final Set<ServletRegistration> registrationsWithApplication = new HashSet<>();
+
         // first see if there are any application classes in the web app
         for (final Class<? extends Application> applicationClass : getApplicationClasses(classes)) {
             final ServletRegistration servletRegistration = servletContext.getServletRegistration(applicationClass.getName());
 
             if (servletRegistration != null) {
                 addServletWithExistingRegistration(servletContext, servletRegistration, applicationClass, classes);
+                registrationsWithApplication.add(servletRegistration);
             } else {
                 // Servlet is not registered with app name or the app name is used to register a different servlet
                 // check if some servlet defines the app in init params
@@ -145,17 +148,21 @@ public final class JerseyServletContainerInitializer implements ServletContainer
                         if (sr instanceof ServletRegistration) {
                             addServletWithExistingRegistration(servletContext, (ServletRegistration) sr,
                                     applicationClass, classes);
+                            registrationsWithApplication.add((ServletRegistration) sr);
                         }
                     }
                 } else {
                     // app not handled by any servlet/filter -> add it
-                    addServletWithApplication(servletContext, applicationClass, classes);
+                    final ServletRegistration sr = addServletWithApplication(servletContext, applicationClass, classes);
+                    if (sr != null) {
+                        registrationsWithApplication.add(sr);
+                    }
                 }
             }
         }
 
         // check for javax.ws.rs.core.Application registration
-        addServletWithDefaultConfiguration(servletContext, classes);
+        addServletWithDefaultConfiguration(servletContext, registrationsWithApplication, classes);
     }
 
     /**
@@ -211,12 +218,14 @@ public final class JerseyServletContainerInitializer implements ServletContainer
      * Enhance default servlet (named {@link Application}) configuration.
      */
     private static void addServletWithDefaultConfiguration(final ServletContext context,
+                                                           final Set<ServletRegistration> registrationsWithApplication,
                                                            final Set<Class<?>> classes) throws ServletException {
 
         ServletRegistration registration = context.getServletRegistration(Application.class.getName());
 
+        final Set<Class<?>> appClasses = getRootResourceAndProviderClasses(classes);
+
         if (registration != null) {
-            final Set<Class<?>> appClasses = getRootResourceAndProviderClasses(classes);
             final ResourceConfig resourceConfig = ResourceConfig.forApplicationClass(ResourceConfig.class, appClasses)
                     .addProperties(getInitParams(registration))
                     .addProperties(Utils.getContextParams(context));
@@ -239,13 +248,26 @@ public final class JerseyServletContainerInitializer implements ServletContainer
                 }
             }
         }
+
+        // make <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class> without init params
+        // work the same as <servlet-name>javax.ws.rs.Application</servlet-name>
+        for (ServletRegistration servletRegistration : context.getServletRegistrations().values()) {
+            if (isJerseyServlet(servletRegistration.getClassName())
+                    && servletRegistration != registration
+                    && !registrationsWithApplication.contains(servletRegistration)
+                    && getInitParams(servletRegistration).isEmpty()) {
+                final ResourceConfig resourceConfig = ResourceConfig.forApplicationClass(ResourceConfig.class, appClasses)
+                        .addProperties(Utils.getContextParams(context));
+                Utils.store(resourceConfig, context, servletRegistration.getName());
+            }
+        }
     }
 
     /**
      * Add new servlet according to {@link Application} subclass with {@link ApplicationPath} annotation or existing
      * {@code servlet-mapping}.
      */
-    private static void addServletWithApplication(final ServletContext context,
+    private static ServletRegistration addServletWithApplication(final ServletContext context,
                                                   final Class<? extends Application> clazz,
                                                   final Set<Class<?>> defaultClasses) throws ServletException {
         final ApplicationPath ap = clazz.getAnnotation(ApplicationPath.class);
@@ -266,7 +288,9 @@ public final class JerseyServletContainerInitializer implements ServletContainer
             } else {
                 LOGGER.log(Level.WARNING, LocalizationMessages.JERSEY_APP_MAPPING_CONFLICT(clazz.getName(), mapping));
             }
+            return dsr;
         }
+        return null;
     }
 
     /**

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -122,6 +122,7 @@
         <module>servlet-3-init-6</module>
         <module>servlet-3-init-7</module>
         <module>servlet-3-init-8</module>
+        <module>servlet-3-init-9</module>
         <module>servlet-3-init-provider</module>
         <module>servlet-3-params</module>
         <module>servlet-3-sse-1</module>

--- a/tests/integration/servlet-3-init-9/pom.xml
+++ b/tests/integration/servlet-3-init-9/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <artifactId>project</artifactId>
+        <version>2.33-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>servlet-3-init-9</artifactId>
+    <packaging>war</packaging>
+    <name>jersey-tests-integration-servlet-3-init-9</name>
+
+    <description>Servlet integration test - servlet-3-init-9 - no Application subclass is present;
+        dynamically add a servlet for class-name=org.glassfish.jersey.servlet.ServletContainer
+        servlet-mapping in web.xml</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${servlet3.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-external</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+              <groupId>org.mortbay.jetty</groupId>
+              <artifactId>jetty-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/servlet-3-init-9/src/main/java/org/glassfish/jersey/tests/integration/servlet_3_init_9/HelloWorldResource.java
+++ b/tests/integration/servlet-3-init-9/src/main/java/org/glassfish/jersey/tests/integration/servlet_3_init_9/HelloWorldResource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.servlet_3_init_9;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("helloworld")
+public class HelloWorldResource {
+
+    @GET
+    @Produces("text/plain")
+    public Hello get() {
+        return new Hello();
+    }
+
+    public static class Hello {
+
+    }
+}

--- a/tests/integration/servlet-3-init-9/src/main/java/org/glassfish/jersey/tests/integration/servlet_3_init_9/HelloWriter.java
+++ b/tests/integration/servlet-3-init-9/src/main/java/org/glassfish/jersey/tests/integration/servlet_3_init_9/HelloWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.servlet_3_init_9;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class HelloWriter implements MessageBodyWriter<HelloWorldResource.Hello> {
+
+    @Override
+    public boolean isWriteable(final Class<?> type, final Type genericType, final Annotation[] annotations,
+                               final MediaType mediaType) {
+        return type.equals(HelloWorldResource.Hello.class);
+    }
+
+    @Override
+    public long getSize(final HelloWorldResource.Hello hello, final Class<?> type, final Type genericType,
+                        final Annotation[] annotations, final MediaType mediaType) {
+        return -1;
+    }
+
+    @Override
+    public void writeTo(final HelloWorldResource.Hello hello,
+                        final Class<?> type,
+                        final Type genericType,
+                        final Annotation[] annotations,
+                        final MediaType mediaType,
+                        final MultivaluedMap<String, Object> httpHeaders,
+                        final OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write(("Hello World! " + this.getClass().getPackage().getName()).getBytes());
+    }
+}

--- a/tests/integration/servlet-3-init-9/src/main/webapp/WEB-INF/web.xml
+++ b/tests/integration/servlet-3-init-9/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+    <servlet>
+        <servlet-name>myApplication</servlet-name>
+        <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>myApplication</servlet-name>
+        <url-pattern>/a/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>myApplication2</servlet-name>
+        <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>myApplication2</servlet-name>
+        <url-pattern>/b/*</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/tests/integration/servlet-3-init-9/src/test/java/org/glassfish/jersey/tests/integration/servlet_3_init_9/HelloWorldResourceITCase.java
+++ b/tests/integration/servlet-3-init-9/src/test/java/org/glassfish/jersey/tests/integration/servlet_3_init_9/HelloWorldResourceITCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.servlet_3_init_9;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.glassfish.jersey.test.external.ExternalTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class HelloWorldResourceITCase extends JerseyTest {
+
+    @Override
+    protected ResourceConfig configure() {
+        enable(TestProperties.LOG_TRAFFIC);
+
+        return new ResourceConfig(HelloWorldResource.class);
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new ExternalTestContainerFactory();
+    }
+
+    @Test
+    public void testHelloWorldA() throws Exception {
+        String s = target().path("a").path("helloworld").request().get(String.class);
+        assertTrue(s.equals("Hello World! " + this.getClass().getPackage().getName()));
+    }
+
+    @Test
+    public void testHelloWorldB() throws Exception {
+        String s = target().path("b").path("helloworld").request().get(String.class);
+        assertTrue(s.equals("Hello World! " + this.getClass().getPackage().getName()));
+    }
+}


### PR DESCRIPTION
without init parameters and without the Application subclass in the app

Signed-off-by: Jan Supol <jan.supol@oracle.com>