### PR TITLE
Add two missing configuration for Apache - DefaultAuthSchemeRegistry …

### DIFF
--- a/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
+++ b/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheClientProperties.java
@@ -156,6 +156,19 @@ public final class ApacheClientProperties {
      */
     public static final String KEEPALIVE_STRATEGY = "jersey.config.apache.client.keepAliveStrategy";
 
+    /**
+     * RedirectStrategy which can customize how redirects are handled.
+     * <p/>
+     * The value MUST be a subclass of {@link RedirectStrategy}.
+     */
+    public static final String REDIRECT_STRATEGY = "jersey.config.apache.client.redirectStrategy";
+
+    /**
+     * DefaultAuthSchemeRegistry which can customize the auth scheme used.
+     * <p/>
+     * The value MUST be a subclass of {@link org.apache.http.config.Registry}.
+     */
+    public static final String DEFAULT_AUTH_SCHEME_REGISTRY = "jersey.config.apache.client.defaultAuthSchemeRegistry";
 
     /**
      * Strategy that closes the Apache Connection. Accepts an instance of {@link ApacheConnectionClosingStrategy}.


### PR DESCRIPTION
Add two missing configuration for Apache HTTP client properties:

```
builder.setDefaultAuthSchemeRegistry
builder.setRedirectStrategy
```

These are blockers for several use cases. 

In particular, without the ability to update the default auth scheme registry, you cannot do Spnego AuthScheme.