### PR TITLE
Add a wildcard @Produces and @Consumes...

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/MethodSelectingRouter.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/MethodSelectingRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -360,6 +360,15 @@ final class MethodSelectingRouter extends ContentTypeDeterminer implements Route
                     effectiveTypes.addAll(workers.getMessageBodyWriterMediaTypesByType(Object.class));
                 }
                 mediaTypesFromWorkers = true;
+            }
+
+            // As a last resort add */* when no message providers are in effect
+            // i.e. if no entity arg in resource method for a reader not to throw 415
+            // and if void return type for a writer not to throw 406.
+            final boolean noEntityArgInResourceMethod = inputTypes && getEntityParam(invocableMethod) == null;
+            final boolean voidReturnType = !inputTypes && invocableMethod.getRawResponseType() == void.class;
+            if (noEntityArgInResourceMethod || voidReturnType) {
+                effectiveTypes.add(MediaType.WILDCARD_TYPE);
             }
         }
 

--- a/tests/integration/jersey-4722/pom.xml
+++ b/tests/integration/jersey-4722/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <version>2.34-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <description>
+        Reproducer of JERSEY-4722.
+
+        When jersey-media-jaxb is not on a classpath, the providers for */* media types are not available.
+        But they are not needed for void return type and/or when no entity argument.
+    </description>
+
+    <artifactId>jersey-4722</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${servlet4.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-jaxb</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tests/integration/jersey-4722/src/main/java/org/glassfish/jersey/tests/integration/jersey4722/Application4722.java
+++ b/tests/integration/jersey-4722/src/main/java/org/glassfish/jersey/tests/integration/jersey4722/Application4722.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.jersey4722;
+
+import org.glassfish.jersey.CommonProperties;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.ServerProperties;
+
+public class Application4722 extends ResourceConfig {
+    public Application4722() {
+        register(Resource4722.class);
+        property(ServerProperties.WADL_FEATURE_DISABLE, true);
+        property(CommonProperties.PROVIDER_DEFAULT_DISABLE, "ALL");
+    }
+}

--- a/tests/integration/jersey-4722/src/main/java/org/glassfish/jersey/tests/integration/jersey4722/Resource4722.java
+++ b/tests/integration/jersey-4722/src/main/java/org/glassfish/jersey/tests/integration/jersey4722/Resource4722.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.jersey4722;
+
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+@Path("/")
+public class Resource4722 {
+    @PUT
+    public void test(@Context UriInfo uriInfo) {
+        // return 204
+    }
+}

--- a/tests/integration/jersey-4722/src/test/java/org/glassfish/jersey/tests/integration/jersey4722/Jersey4722Test.java
+++ b/tests/integration/jersey-4722/src/test/java/org/glassfish/jersey/tests/integration/jersey4722/Jersey4722Test.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.jersey4722;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+public class Jersey4722Test extends JerseyTest {
+    @Override
+    protected ResourceConfig configure() {
+        return new Application4722();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(configure())).build();
+    }
+
+    @Test
+    public void testDefaultProducesMediaType() {
+        try (Response response = target().request()
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+                .put(Entity.entity("ENTITY", MediaType.TEXT_PLAIN_TYPE))) {
+            Assert.assertEquals(204, response.getStatus());
+        }
+    }
+
+    @Test
+    public void testDefaultConsumesMediaType() {
+        try (Response response = target().request()
+                .put(Entity.entity("ENTITY", new MediaType("TEST", "TEST415")))) {
+            Assert.assertEquals(204, response.getStatus());
+        }
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -88,6 +88,7 @@
         <module>jersey-4321</module>
         <module>jersey-4507</module>
         <module>jersey-4542</module>
+        <module>jersey-4722</module>
         <module>jetty-response-close</module>
         <module>microprofile</module>
         <module>portability-jersey-1</module>


### PR DESCRIPTION
for methods without message providers involved not to get 406/415.

Signed-off-by: jansupol <jan.supol@oracle.com>