### PR TITLE
WIP: Close ChunkedOuput onComplete in AsyncContext

### DIFF
--- a/core-server/src/main/resources/org/glassfish/jersey/server/internal/localization.properties
+++ b/core-server/src/main/resources/org/glassfish/jersey/server/internal/localization.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -197,3 +197,4 @@ warning.monitoring.feature.disabled=MonitoringFeature is registered but the conf
 warning.monitoring.feature.enabled=MonitoringFeature is registered but the configuration property "{0}" (enabling basic monitoring statistics) is FALSE. Monitoring statistics will be disabled. The configuration is inconsistent and may produce unwanted behaviour. Disable MBeans exposure or enable monitoring statistics.
 warning.msg=WARNING: {0}
 warning.too.many.external.req.scopes=More than one external request scope found. None of them will be used. Jersey runtime can only accommodate a single external request scope: {0}
+warning.chunked.close.failure.on.complete="Failed to close ChunkedOutput on complete in async context."


### PR DESCRIPTION
@see https://github.com/eclipse-ee4j/jersey/issues/3719
@see https://bz.apache.org/bugzilla/show_bug.cgi?id=61768

On client disconnect JerseyEventSink is able to write to responses
after the container has completed. This causes non-deterministic
behaviour:
 - empty responses
 - truncated responses
 - sse event strings ending up in responses from other requests

The proposed fix is to register `ChunkedOuput` to the `AsyncContext` as
`CompletionCallback`, closing the resource.

We might want to consider calling `onClose` in `onComplete` as well.