### PR TITLE
Remove helidon connector dependency from BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -63,11 +63,11 @@
                 <artifactId>jersey-apache-connector</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.connectors</groupId>
-                <artifactId>jersey-helidon-connector</artifactId>
-                <version>${project.version}</version>
-            </dependency>
+<!--        <dependency-->
+<!--            <groupId>org.glassfish.jersey.connectors</groupId-->
+<!--            <artifactId>jersey-helidon-connector</artifactId-->
+<!--            <version>${project.version}</version-->
+<!--        </dependency-->
             <dependency>
                 <groupId>org.glassfish.jersey.connectors</groupId>
                 <artifactId>jersey-grizzly-connector</artifactId>


### PR DESCRIPTION
I checked all other dependencies in maven central and all of them are available.

Signed-off-by: tvallin <thibault.vallin@oracle.com>