### PR TITLE
Remove com.sun.org.apache.xml.internal

### DIFF
--- a/examples/osgi-helloworld-webapp/functional-test/pom.xml
+++ b/examples/osgi-helloworld-webapp/functional-test/pom.xml
@@ -91,6 +91,11 @@
 
         <!-- JUnit and Pax-Exam dependencies -->
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.cm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-junit4</artifactId>
             <scope>test</scope>

--- a/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/WebAppFelixTest.java
+++ b/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/WebAppFelixTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -37,6 +37,7 @@ public class WebAppFelixTest extends AbstractWebAppTest {
     @Override
     public List<Option> osgiRuntimeOptions() {
         return Arrays.asList(CoreOptions.options(
+                mavenBundle().groupId("org.osgi").artifactId("org.osgi.service.cm").versionAsInProject(),
                 mavenBundle()
                         .groupId("org.apache.felix").artifactId("org.apache.felix.eventadmin")
                         .versionAsInProject()

--- a/examples/osgi-http-service/functional-test/pom.xml
+++ b/examples/osgi-http-service/functional-test/pom.xml
@@ -107,6 +107,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.http</artifactId>
+            <version>1.2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.cm</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -200,6 +213,16 @@
                         <goals>
                             <goal>test</goal>
                         </goals>
+                        <configuration>
+                            <excludes>
+                                <!--
+                                excluded due to javax.servlet-api collision -
+                                more than one version is required, so it is not possible to execute that test.
+                                (since pax-exam version 4.13.4)
+                                  -->
+                                <exclude>org.glassfish.jersey.examples.osgihttpservice.test.GrizzlyHttpServiceFelixTest</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/examples/osgi-http-service/functional-test/src/test/java/org/glassfish/jersey/examples/osgihttpservice/test/JettyHttpServiceFelixTest.java
+++ b/examples/osgi-http-service/functional-test/src/test/java/org/glassfish/jersey/examples/osgihttpservice/test/JettyHttpServiceFelixTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -27,6 +27,8 @@ public class JettyHttpServiceFelixTest extends AbstractHttpServiceTest {
     @Override
     public List<Option> osgiRuntimeOptions() {
         return Arrays.asList(CoreOptions.options(
+                mavenBundle().groupId("org.osgi").artifactId("org.osgi.service.http").versionAsInProject(),
+                mavenBundle().groupId("org.osgi").artifactId("org.osgi.service.cm").versionAsInProject(),
                 mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.eventadmin").versionAsInProject()
         ));
     }

--- a/ext/wadl-doclet/src/main/java/org/glassfish/jersey/wadl/doclet/DocletUtils.java
+++ b/ext/wadl-doclet/src/main/java/org/glassfish/jersey/wadl/doclet/DocletUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,29 +16,37 @@
 
 package org.glassfish.jersey.wadl.doclet;
 
-import com.sun.org.apache.xml.internal.serialize.OutputFormat;
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
-
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import org.glassfish.jersey.server.wadl.internal.generators.resourcedoc.model.ResourceDocType;
+import org.w3c.dom.CDATASection;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 class DocletUtils {
 
     private static final Logger LOG = Logger.getLogger(DocletUtils.class.getName());
 
     private static String[] getCDataElements(DocProcessor docProcessor) {
-        String[] original = new String[]{"ns1^commentText", "ns2^commentText", "^commentText" };
+        String[] original = new String[]{"commentText"};
         if (docProcessor == null) {
             return original;
         } else {
@@ -64,30 +72,6 @@ class DocletUtils {
         return copy;
     }
 
-    private static XMLSerializer getXMLSerializer(OutputStream os, String[] cdataElements)
-            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
-        // configure an OutputFormat to handle CDATA
-        OutputFormat of = new OutputFormat();
-
-        // specify which of your elements you want to be handled as CDATA.
-        // The use of the '^' between the namespaceURI and the localname
-        // seems to be an implementation detail of the xerces code.
-        // When processing xml that doesn't use namespaces, simply omit the
-        // namespace prefix as shown in the third CDataElement below.
-        of.setCDataElements(cdataElements);
-
-        // set any other options you'd like
-        of.setPreserveSpace(true);
-        of.setIndenting(true);
-
-        // create the serializer
-        XMLSerializer serializer = new XMLSerializer(of);
-
-        serializer.setOutputByteStream(os);
-
-        return serializer;
-    }
-
     private static Class<?>[] getJAXBContextClasses(ResourceDocType result, DocProcessor docProcessor) {
         Class<?>[] clazzes;
         if (docProcessor == null) {
@@ -108,15 +92,39 @@ class DocletUtils {
     }
 
     static boolean createOutputFile(String filePath, DocProcessor docProcessor, ResourceDocType result) {
+        String[] cdataElements = getCDataElements(docProcessor);
+        Class<?>[] classes = getJAXBContextClasses(result, docProcessor);
+        LOG.info("cdataElements " + Arrays.asList(cdataElements));
+        LOG.info("classes " + Arrays.asList(classes));
         try (OutputStream out = new BufferedOutputStream(new FileOutputStream(filePath))) {
-            Class<?>[] clazzes = getJAXBContextClasses(result, docProcessor);
-            JAXBContext c = JAXBContext.newInstance(clazzes);
+            JAXBContext c = JAXBContext.newInstance(classes);
             Marshaller m = c.createMarshaller();
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
-            String[] cdataElements = getCDataElements(docProcessor);
-            XMLSerializer serializer = getXMLSerializer(out, cdataElements);
-            m.marshal(result, serializer);
-            LOG.info("Wrote " + result);
+            StringWriter sw = new StringWriter();
+            // Produces XML in memory
+            m.marshal(result, sw);
+            // Loads the XML from memory for processing
+            Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                    .parse(new ByteArrayInputStream(sw.toString().getBytes()));
+            for (String cdata : cdataElements) {
+                NodeList nodes = document.getElementsByTagName(cdata);
+                LOG.info(nodes.getLength() + " nodes found by " + cdata);
+                for (int i = 0; i < nodes.getLength(); i++) {
+                    Node node = nodes.item(i);
+                    CDATASection cdataSection = document.createCDATASection(node.getTextContent());
+                    // Remove current content
+                    node.setTextContent(null);
+                    // Add it again, but wrapped with CDATA
+                    node.appendChild(cdataSection);
+                }
+                document.createCDATASection(cdata);
+            }
+            DOMSource source = new DOMSource(document);
+            StreamResult streamResult = new StreamResult(out);
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.transform(source, streamResult);
+            LOG.info("Wrote " + result + " in " + filePath);
             return true;
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Could not serialize ResourceDoc.", e);

--- a/pom.xml
+++ b/pom.xml
@@ -2134,7 +2134,7 @@
         <osgi.version>6.0.0</osgi.version>
         <osgi.framework.version>1.10.0</osgi.framework.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
-        <pax.exam.version>4.13.1</pax.exam.version>
+        <pax.exam.version>4.13.4</pax.exam.version>
         <pax.web.version>0.7.4</pax.web.version><!-- TODO: UPGRADE! -->
         <paxexam.mvn.plugin.version>1.2.4</paxexam.mvn.plugin.version>
         <rxjava.version>1.2.5</rxjava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1800,6 +1800,13 @@
             </dependency>
 
             <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.service.cm</artifactId>
+                <version>${osgi.service.cm.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.glassfish.main.ejb</groupId>
                 <artifactId>ejb-container</artifactId>
                 <version>${gf.impl.version}</version>
@@ -2134,6 +2141,7 @@
         <osgi.version>6.0.0</osgi.version>
         <osgi.framework.version>1.10.0</osgi.framework.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
+        <osgi.service.cm.version>1.6.0</osgi.service.cm.version>
         <pax.exam.version>4.13.4</pax.exam.version>
         <pax.web.version>0.7.4</pax.web.version><!-- TODO: UPGRADE! -->
         <paxexam.mvn.plugin.version>1.2.4</paxexam.mvn.plugin.version>

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -101,6 +101,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.cm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam</artifactId>
             <scope>test</scope>

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/ApacheOsgiIntegrationTest.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/basic/ApacheOsgiIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -55,6 +55,7 @@ public class ApacheOsgiIntegrationTest {
         final List<Option> options = Helper.getCommonOsgiOptions();
         options.addAll(Helper.expandedList(
                 mavenBundle().groupId("org.ops4j.pax.logging").artifactId("pax-logging-api").versionAsInProject(),
+                mavenBundle().groupId("org.osgi").artifactId("org.osgi.service.cm").versionAsInProject(),
                 mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpcore-osgi").versionAsInProject(),
                 mavenBundle().groupId("org.apache.httpcomponents").artifactId("httpclient-osgi").versionAsInProject(),
                 mavenBundle().groupId("org.glassfish.jersey.connectors").artifactId("jersey-apache-connector")


### PR DESCRIPTION
Currently when you compile jersey/ext/wadl-doclet with JDK 11+ it gets the next error:

```
[ERROR] /C:/Projects/Jersey/2x/ext/wadl-doclet/src/main/java/org/glassfish/jersey/wadl/doclet/DocletUtils.java:[20,39] package com.sun.org.apache.xml.internal.serialize is not visible
[ERROR]   (package com.sun.org.apache.xml.internal.serialize is declared in module java.xml, but module wadl.doclet does not read it)
```

This PR is about removing that com.sun.org.apache.xml.internal.serialize.

There is one module in Jersey that tests wadl-doclet in jersey/examples/extended-wadl-webapp and it generates the resourcedoc.xml. I am attaching both, with and without my changes.

I set this as a draft because in my computer I am getting one error running the tests that seems to be unrelated:
`java.io.IOException: Error resolving artifact org.ops4j.pax.exam:pax-exam-inject:jar:4.13.1: Could not transfer artifact org.ops4j.pax.exam:pax-exam-inject:jar:4.13.1 from/to central (http://repo1.maven.org/maven2/): Failed to transfer file: http://repo1.maven.org/maven2/org/ops4j/pax/exam/pax-exam-inject/4.13.1/pax-exam-inject-4.13.1.jar. Return code is: 501 , ReasonPhrase:HTTPS Required.`

I will change it to ready for review once Travis or Jenkins shows successful results.


