### PR TITLE
TimeWindowStatisticsImplTest Fix

### DIFF
--- a/core-server/pom.xml
+++ b/core-server/pom.xml
@@ -156,6 +156,9 @@
                     <threadCount>1</threadCount>
                     <forkCount>1C</forkCount>
                     <reuseForks>true</reuseForks>
+                    <systemPropertyVariables>
+                        <jersey.config.server.monitoring.collision.buffer.power>3</jersey.config.server.monitoring.collision.buffer.power>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/monitoring/TimeWindowStatisticsImplTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/monitoring/TimeWindowStatisticsImplTest.java
@@ -16,15 +16,13 @@
 
 package org.glassfish.jersey.server.internal.monitoring;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.concurrent.TimeUnit;
 
-import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.internal.monitoring.core.ReservoirConstants;
 import org.glassfish.jersey.server.internal.monitoring.core.UniformTimeReservoir;
-import org.junit.BeforeClass;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests of {@link TimeWindowStatisticsImpl}.
@@ -34,19 +32,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TimeWindowStatisticsImplTest {
 
-    private static final int COLLISION_BUFFER_POWER = 3;
     private static final double DELTA = 0.0001;
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty(ServerProperties.COLLISION_BUFFER_POWER_JVM_ARG,
-                Integer.toString(COLLISION_BUFFER_POWER));
-    }
-
     @Test
-    public void jvmLoaded() {
-        assertEquals(COLLISION_BUFFER_POWER, ReservoirConstants.COLLISION_BUFFER_POWER);
-        assertEquals(8, ReservoirConstants.COLLISION_BUFFER);
+    public void defaultValueLoaded() {
+        assertEquals(256, ReservoirConstants.COLLISION_BUFFER);
     }
 
     @Test

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/monitoring/TimeWindowStatisticsImplTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/monitoring/TimeWindowStatisticsImplTest.java
@@ -16,13 +16,15 @@
 
 package org.glassfish.jersey.server.internal.monitoring;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.concurrent.TimeUnit;
 
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.internal.monitoring.core.ReservoirConstants;
 import org.glassfish.jersey.server.internal.monitoring.core.UniformTimeReservoir;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests of {@link TimeWindowStatisticsImpl}.
@@ -32,11 +34,14 @@ import org.junit.Test;
  */
 public class TimeWindowStatisticsImplTest {
 
+    // Value is set as system property in maven-surefire-plugin
+    private static final int COLLISION_BUFFER_POWER = 3;
     private static final double DELTA = 0.0001;
 
     @Test
-    public void defaultValueLoaded() {
-        assertEquals(256, ReservoirConstants.COLLISION_BUFFER);
+    public void jvmLoaded() {
+        assertEquals(COLLISION_BUFFER_POWER, ReservoirConstants.COLLISION_BUFFER_POWER);
+        assertEquals(8, ReservoirConstants.COLLISION_BUFFER);
     }
 
     @Test


### PR DESCRIPTION
In Jenkins the default value of 8 is loaded before the property 3 is set.