### PR TITLE
JerseyTest is not compatible with JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1971,6 +1971,12 @@
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit5.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit5.version}</version>
                 <scope>test</scope>

--- a/test-framework/core/pom.xml
+++ b/test-framework/core/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>testng</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
+++ b/test-framework/core/src/main/java/org/glassfish/jersey/test/JerseyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -55,6 +55,8 @@ import org.glassfish.jersey.test.spi.TestContainerFactory;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Parent class for testing JAX-RS and Jersey-based applications using Jersey test framework.
@@ -614,6 +616,7 @@ public abstract class JerseyTest {
      * @throws Exception              if an exception is thrown during setting up the test environment.
      */
     @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final TestContainer testContainer = createTestContainer(context);
 
@@ -634,6 +637,7 @@ public abstract class JerseyTest {
      * @throws Exception if an exception is thrown during tearing down the test environment.
      */
     @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (isLogRecordingEnabled()) {
             unregisterLogHandler();

--- a/tests/integration/jersey-3662/pom.xml
+++ b/tests/integration/jersey-3662/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <version>2.35-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <description>
+        Reproducer of JERSEY-3662
+    </description>
+
+    <artifactId>jersey-3662</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/tests/integration/jersey-3662/src/test/java/org/glassfish/jersey/tests/integration/jersey3662/Junit5Test.java
+++ b/tests/integration/jersey-3662/src/test/java/org/glassfish/jersey/tests/integration/jersey3662/Junit5Test.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.integration.jersey3662;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.jupiter.api.Test;
+
+public class Junit5Test extends JerseyTest {
+
+    @Path("test")
+    public static class TestResource {
+        @GET
+        public String get() {
+            return "test";
+        }
+    }
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(TestResource.class);
+    }
+
+    @Test
+    public void success() {
+        Response response = target().path("test").request().get();
+        assertEquals(200, response.getStatus());
+        assertEquals("test", response.readEntity(String.class));
+    }
+
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -79,7 +79,8 @@
         <module>jersey-2846</module>
         <module>jersey-2878</module>
         <module>jersey-2892</module>
-	    <module>jersey-3796</module>
+	<module>jersey-3662</module>
+	<module>jersey-3796</module>
         <module>jersey-780</module>
         <module>jersey-3670</module>
         <module>jersey-3992</module>


### PR DESCRIPTION
Relates to issue https://github.com/eclipse-ee4j/jersey/issues/3662

This PR allows to run tests with JUnit5. The methods JerseyTest#setUp and JerseyTest#tearDown are invoked in the same way they are with JUnit4. Then, no NullPointerException is thrown.

This PR is unrelated to JUnit5 extensions.

Dependency tree of the test module (junit4 is not a dependency):
```
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ jersey-3662 ---
[INFO] org.glassfish.jersey.tests.integration:jersey-3662:jar:2.35-SNAPSHOT
[INFO] +- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:jar:2.35-SNAPSHOT:compile
[INFO] |  +- jakarta.servlet:jakarta.servlet-api:jar:4.0.3:compile
[INFO] |  +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:2.35-SNAPSHOT:compile
[INFO] |  |  +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
[INFO] |  |  |  \- jakarta.activation:jakarta.activation-api:jar:1.2.2:compile
[INFO] |  |  +- org.glassfish.jersey.core:jersey-server:jar:2.35-SNAPSHOT:compile
[INFO] |  |  |  +- org.glassfish.jersey.core:jersey-client:jar:2.35-SNAPSHOT:compile
[INFO] |  |  |  \- jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
[INFO] |  |  +- org.glassfish.jersey.media:jersey-media-jaxb:jar:2.35-SNAPSHOT:compile
[INFO] |  |  \- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.35-SNAPSHOT:compile
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-grizzly2-http:jar:2.35-SNAPSHOT:compile
[INFO] |  |  +- org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile
[INFO] |  |  +- org.glassfish.grizzly:grizzly-http-server:jar:2.4.4:compile
[INFO] |  |  |  \- org.glassfish.grizzly:grizzly-http:jar:2.4.4:compile
[INFO] |  |  |     \- org.glassfish.grizzly:grizzly-framework:jar:2.4.4:compile
[INFO] |  |  \- jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:compile
[INFO] |  \- org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:jar:2.35-SNAPSHOT:compile
[INFO] |     +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.35-SNAPSHOT:compile
[INFO] |     \- org.glassfish.grizzly:grizzly-http-servlet:jar:2.4.4:compile
[INFO] +- org.junit.jupiter:junit-jupiter:jar:5.6.0:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.6.0:test
[INFO] |  |  +- org.apiguardian:apiguardian-api:jar:1.1.0:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.6.0:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-params:jar:5.6.0:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.6.0:test
[INFO] |     \- org.junit.platform:junit-platform-engine:jar:1.6.0:test
[INFO] \- org.glassfish.jersey.inject:jersey-hk2:jar:2.35-SNAPSHOT:compile
[INFO]    +- org.glassfish.jersey.core:jersey-common:jar:2.35-SNAPSHOT:compile
[INFO]    |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
[INFO]    |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:compile
[INFO]    +- org.glassfish.hk2:hk2-locator:jar:2.6.1:compile
[INFO]    |  +- org.glassfish.hk2.external:aopalliance-repackaged:jar:2.6.1:compile
[INFO]    |  +- org.glassfish.hk2:hk2-api:jar:2.6.1:compile
[INFO]    |  \- org.glassfish.hk2:hk2-utils:jar:2.6.1:compile
[INFO]    \- org.javassist:javassist:jar:3.25.0-GA:compile
```
