### PR TITLE
Use '; ' as a separator between values of Cookie or Cookie2 request headers instead of ',' ...

### DIFF
--- a/connectors/jdk-connector/src/main/java/org/glassfish/jersey/jdk/connector/internal/HttpRequestEncoder.java
+++ b/connectors/jdk-connector/src/main/java/org/glassfish/jersey/jdk/connector/internal/HttpRequestEncoder.java
@@ -36,10 +36,13 @@ class HttpRequestEncoder {
 
     private static void appendUpgradeHeaders(StringBuilder request, Map<String, List<String>> headers) {
         for (Map.Entry<String, List<String>> header : headers.entrySet()) {
+            String delimiter = "Cookie".equalsIgnoreCase(header.getKey()) ||
+                               "Cookie2".equalsIgnoreCase(header.getKey())
+                               ? "; " : ",";
             StringBuilder value = new StringBuilder();
             for (String valuePart : header.getValue()) {
                 if (value.length() != 0) {
-                    value.append(",");
+                    value.append(delimiter);
                 }
                 value.append(valuePart);
             }

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java
@@ -425,6 +425,9 @@ public class HttpUrlConnector implements Connector {
         boolean restrictedSent = false;
         for (Map.Entry<String, List<String>> header : headers.entrySet()) {
             String headerName = header.getKey();
+            String delimiter = "Cookie".equalsIgnoreCase(headerName) ||
+                               "Cookie2".equalsIgnoreCase(headerName)
+                               ? "; " : ",";
             String headerValue;
 
             List<String> headerValues = header.getValue();
@@ -436,7 +439,7 @@ public class HttpUrlConnector implements Connector {
                 boolean add = false;
                 for (Object value : headerValues) {
                     if (add) {
-                        b.append(',');
+                        b.append(delimiter);
                     }
                     add = true;
                     b.append(value);


### PR DESCRIPTION
I propose this patch for issue https://github.com/eclipse-ee4j/jersey/issues/2811