### PR TITLE
Better handling of MicroProfile Rest Client Proxies

### DIFF
--- a/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/RestClientBuilderImpl.java
+++ b/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/RestClientBuilderImpl.java
@@ -449,8 +449,16 @@ class RestClientBuilderImpl implements RestClientBuilder {
         }
 
         // If proxyString is something like "localhost:8765" we need to add a scheme since the connectors expect one
+        String proxyString = createProxyString(proxyHost, proxyPort);
+
+        property(ClientProperties.PROXY_URI, proxyString);
+        return this;
+    }
+
+    static String createProxyString(String proxyHost, int proxyPort) {
         boolean prependScheme = false;
         String proxyString = proxyHost + ":" + proxyPort;
+
         if (proxyString.split(":").length == 2) {
             // Check if first character is a number to account for if proxyHost is given as an IP rather than a name
             // URI.create("127.0.0.1:8765") will lead to an IllegalArgumentException
@@ -472,8 +480,7 @@ class RestClientBuilderImpl implements RestClientBuilder {
                             + proxyString);
         }
 
-        property(ClientProperties.PROXY_URI, proxyString);
-        return this;
+        return proxyString;
     }
 
     @Override

--- a/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/RestClientBuilderImpl.java
+++ b/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/RestClientBuilderImpl.java
@@ -36,6 +36,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.annotation.Priority;
 import javax.net.ssl.HostnameVerifier;
@@ -445,7 +447,32 @@ class RestClientBuilderImpl implements RestClientBuilder {
         if (proxyPort <= 0 || proxyPort > 65535) {
             throw new IllegalArgumentException("Invalid proxy port");
         }
-        property(ClientProperties.PROXY_URI, proxyHost + ":" + proxyPort);
+
+        // If proxyString is something like "localhost:8765" we need to add a scheme since the connectors expect one
+        boolean prependScheme = false;
+        String proxyString = proxyHost + ":" + proxyPort;
+        if (proxyString.split(":").length == 2) {
+            // Check if first character is a number to account for if proxyHost is given as an IP rather than a name
+            // URI.create("127.0.0.1:8765") will lead to an IllegalArgumentException
+            if (proxyString.matches("\\d.*")) {
+                prependScheme = true;
+            } else {
+                // "localhost:8765" will set the scheme as "localhost" and the host as "null"
+                URI proxyURI = URI.create(proxyString);
+                if (proxyURI.getHost() == null && proxyURI.getScheme().equals(proxyHost)) {
+                    prependScheme = true;
+                }
+            }
+        }
+
+        if (prependScheme) {
+            proxyString = "http://" + proxyString;
+            Logger.getLogger(RestClientBuilderImpl.class.getName()).log(Level.FINE,
+                    "No scheme provided with proxyHost: " + proxyHost + ". Defaulting to HTTP, proxy address = "
+                            + proxyString);
+        }
+
+        property(ClientProperties.PROXY_URI, proxyString);
         return this;
     }
 

--- a/ext/microprofile/mp-rest-client/src/test/java/org/glassfish/jersey/microprofile/restclient/RestClientBuilderImplTest.java
+++ b/ext/microprofile/mp-rest-client/src/test/java/org/glassfish/jersey/microprofile/restclient/RestClientBuilderImplTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.microprofile.restclient;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.glassfish.jersey.microprofile.restclient.RestClientBuilderImpl.createProxyString;
+
+public class RestClientBuilderImplTest {
+
+    @Test
+    public void createProxyStringTest() {
+        Assert.assertTrue(createProxyString("localhost", 8765).equals("http://localhost:8765"));
+        Assert.assertTrue(createProxyString("http://localhost", 8765).equals("http://localhost:8765"));
+        Assert.assertTrue(createProxyString("127.0.0.1", 8765).equals("http://127.0.0.1:8765"));
+        Assert.assertTrue(createProxyString("http://192.168.1.1", 8765).equals("http://192.168.1.1:8765"));
+    }
+}


### PR DESCRIPTION
The MicroProfile Rest Client API asks a user to provide just a hostname and a port.
When this is provided to the various connectors which support proxy configuration via `ClientProperties.PROXY_URI` they will fail to translate this if something simple such as `localhost:8765` is provided (as the MicroProfile Rest Client TCK does).

https://github.com/eclipse-ee4j/jersey/blob/master/connectors/apache-connector/src/main/java/org/glassfish/jersey/apache/connector/ApacheConnector.java#L281

```
final URI u = getProxyUri(proxyUri);
final HttpHost proxy = new HttpHost(u.getHost(), u.getPort(), u.getScheme());

...

private static URI getProxyUri(final Object proxy) {
    if (proxy instanceof URI) {
        return (URI) proxy;     }
    else if (proxy instanceof String) {
        return URI.create((String) proxy);
    } else {
        throw new ProcessingException(LocalizationMessages.WRONG_PROXY_URI_TYPE(ClientProperties.PROXY_URI));
    }
}
```

This is because they attempt to convert the given string to a URI and then parse details from it using URI methods. So a proxy config from MicroProfile Rest Client of `localhost:8765` would at the moment be given as-is, and when converted to a URI will result in the _host_ being null and the _scheme_ being set to `localhost`, leading to an error further down the line.

This change attempts to resolve this by simply defaulting to HTTP if no schema is given by essentially doing the same check as the connectors earlier on, resulting in the same string from MicroProfile Rest Client becoming `http://localhost:8765`. I've tried to account for IP addresses as well as host names (since the MicroProfile spec says to support them), but yell if I've missed an acceptable URI format.

Tested on Jersey 2.34 using MicroProfile Rest Client 2.0 TCK with Apache HTTP Client connector (since default Jersey connector doesn't support proxy config in this manner). Not current master or latest 3.0 of MicroProfile Rest Client, but just from eyeballing it none of these bits of code seem to have changed.