### PR TITLE
Replace usage of deprecated beanManager.createInjectionTarget

### DIFF
--- a/ext/bean-validation/src/main/java/org/glassfish/jersey/server/validation/internal/hibernate/DestructibleBeanInstance.java
+++ b/ext/bean-validation/src/main/java/org/glassfish/jersey/server/validation/internal/hibernate/DestructibleBeanInstance.java
@@ -12,6 +12,7 @@ import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 
 /**
  * @author Hardy Ferentschik
@@ -43,7 +44,9 @@ public class DestructibleBeanInstance<T> {
 
     private InjectionTarget<T> createInjectionTarget(BeanManager beanManager, Class<T> type) {
         AnnotatedType<T> annotatedType = beanManager.createAnnotatedType(type);
-        return beanManager.createInjectionTarget(annotatedType);
+        InjectionTargetFactory<T> injectionTargetFactory = beanManager.getInjectionTargetFactory(annotatedType);
+
+        return injectionTargetFactory.createInjectionTarget(null);
     }
 
     private static <T> T createAndInjectBeans(BeanManager beanManager, InjectionTarget<T> injectionTarget) {

--- a/ext/cdi/jersey-cdi1x-servlet/src/main/java/org/glassfish/jersey/ext/cdi1x/servlet/internal/CdiExternalRequestScopeExtension.java
+++ b/ext/cdi/jersey-cdi1x-servlet/src/main/java/org/glassfish/jersey/ext/cdi1x/servlet/internal/CdiExternalRequestScopeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -35,6 +35,7 @@ import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 import javax.enterprise.util.AnnotationLiteral;
 
 /**
@@ -69,7 +70,10 @@ public class CdiExternalRequestScopeExtension implements Extension {
     private void afterBeanDiscovery(@Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
 
         // we need the injection target so that CDI could instantiate the original interceptor for us
-        final InjectionTarget<CdiExternalRequestScope> interceptorTarget = beanManager.createInjectionTarget(requestScopeType);
+        final InjectionTargetFactory<CdiExternalRequestScope> injectionTargetFactory =
+                beanManager.getInjectionTargetFactory(requestScopeType);
+        final InjectionTarget<CdiExternalRequestScope> interceptorTarget =
+                injectionTargetFactory.createInjectionTarget(null);
 
 
         afterBeanDiscovery.addBean(new Bean<CdiExternalRequestScope>() {

--- a/ext/cdi/jersey-cdi1x-validation/src/main/java/org/glassfish/jersey/ext/cdi1x/validation/internal/CdiInterceptorWrapperExtension.java
+++ b/ext/cdi/jersey-cdi1x-validation/src/main/java/org/glassfish/jersey/ext/cdi1x/validation/internal/CdiInterceptorWrapperExtension.java
@@ -37,6 +37,7 @@ import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.interceptor.Interceptor;
 
@@ -100,7 +101,10 @@ public class CdiInterceptorWrapperExtension implements Extension {
 
         // we need the injection target so that CDI could instantiate the original interceptor for us
         final AnnotatedType<ValidationInterceptor> interceptorType = interceptorAnnotatedType;
-        final InjectionTarget<ValidationInterceptor> interceptorTarget = beanManager.createInjectionTarget(interceptorType);
+        final InjectionTargetFactory<ValidationInterceptor> injectionTargetFactory =
+                beanManager.getInjectionTargetFactory(interceptorType);
+        final InjectionTarget<ValidationInterceptor> interceptorTarget =
+                injectionTargetFactory.createInjectionTarget(null);
 
 
         afterBeanDiscovery.addBean(new Bean<ValidationInterceptor>() {

--- a/incubator/cdi-inject-weld/src/main/java/org/glassfish/jersey/inject/weld/internal/bean/BeanHelper.java
+++ b/incubator/cdi-inject-weld/src/main/java/org/glassfish/jersey/inject/weld/internal/bean/BeanHelper.java
@@ -28,6 +28,7 @@ import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.RuntimeType;
@@ -105,7 +106,8 @@ public abstract class BeanHelper {
     public static <T> BindingBeanPair registerBean(RuntimeType runtimeType, ClassBinding<T> binding, AfterBeanDiscovery abd,
                                                    Collection<InjectionResolver> resolvers, BeanManager beanManager) {
         AnnotatedType<T> annotatedType = beanManager.createAnnotatedType(binding.getService());
-        InjectionTarget<T> injectionTarget = beanManager.createInjectionTarget(annotatedType);
+        InjectionTargetFactory<T> injectionTargetFactory = beanManager.getInjectionTargetFactory(annotatedType);
+        InjectionTarget<T> injectionTarget = injectionTargetFactory.createInjectionTarget(null);
 
         ClassBean<T> bean = new ClassBean<>(runtimeType, binding);
         bean.setInjectionTarget(getJerseyInjectionTarget(binding.getService(), injectionTarget, bean, resolvers));

--- a/incubator/cdi-inject-weld/src/main/java/org/glassfish/jersey/inject/weld/internal/managed/CdiInjectionManager.java
+++ b/incubator/cdi-inject-weld/src/main/java/org/glassfish/jersey/inject/weld/internal/managed/CdiInjectionManager.java
@@ -29,6 +29,7 @@ import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 import javax.enterprise.inject.spi.Unmanaged;
 import javax.inject.Singleton;
 import javax.ws.rs.RuntimeType;
@@ -295,10 +296,12 @@ public class CdiInjectionManager implements InjectionManager {
     @Override
     @SuppressWarnings("unchecked")
     public void inject(Object instance) {
+        CreationalContext creationalContext = createCreationalContext(null);
         AnnotatedType annotatedType = beanManager.createAnnotatedType((Class) instance.getClass());
-        InjectionTarget injectionTarget = beanManager.createInjectionTarget(annotatedType);
-        CreationalContext context = createCreationalContext(null);
-        injectionTarget.inject(instance, context);
+        InjectionTargetFactory injectionTargetFactory = beanManager.getInjectionTargetFactory(annotatedType);
+        InjectionTarget injectionTarget = injectionTargetFactory.createInjectionTarget(null);
+
+        injectionTarget.inject(instance, creationalContext);
     }
 
     @Override

--- a/incubator/cdi-inject-weld/src/main/java/org/glassfish/jersey/inject/weld/internal/scope/RequestScopeBean.java
+++ b/incubator/cdi-inject-weld/src/main/java/org/glassfish/jersey/inject/weld/internal/scope/RequestScopeBean.java
@@ -30,6 +30,7 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Singleton;
 
@@ -49,7 +50,8 @@ public class RequestScopeBean implements Bean<CdiRequestScope> {
      */
     public RequestScopeBean(BeanManager beanManager) {
         AnnotatedType<CdiRequestScope> annotatedType = beanManager.createAnnotatedType(CdiRequestScope.class);
-        this.injectionTarget = beanManager.createInjectionTarget(annotatedType);
+        InjectionTargetFactory<CdiRequestScope> injectionTargetFactory = beanManager.getInjectionTargetFactory(annotatedType);
+        this.injectionTarget = injectionTargetFactory.createInjectionTarget(null);
     }
 
     @Override

--- a/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/CdiSeInjectionManager.java
+++ b/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/CdiSeInjectionManager.java
@@ -32,6 +32,7 @@ import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 import javax.enterprise.inject.spi.Unmanaged;
 
 import org.glassfish.jersey.inject.cdi.se.bean.JerseyBean;
@@ -236,9 +237,11 @@ public class CdiSeInjectionManager implements InjectionManager {
     @SuppressWarnings("unchecked")
     public void inject(Object instance) {
         if (isInitialized()) {
-            AnnotatedType annotatedType = beanManager.createAnnotatedType((Class) instance.getClass());
-            InjectionTarget injectionTarget = beanManager.createInjectionTarget(annotatedType);
             CreationalContext context = beanManager.createCreationalContext(null);
+            AnnotatedType annotatedType = beanManager.createAnnotatedType((Class) instance.getClass());
+            InjectionTargetFactory injectionTargetFactory = beanManager.getInjectionTargetFactory(annotatedType);
+            InjectionTarget injectionTarget = injectionTargetFactory.createInjectionTarget(null);
+
             injectionTarget.inject(instance, context);
         }
     }

--- a/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/RequestScopeBean.java
+++ b/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/RequestScopeBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,6 +30,7 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Singleton;
 
@@ -49,7 +50,8 @@ public class RequestScopeBean implements Bean<CdiRequestScope> {
      */
     public RequestScopeBean(BeanManager beanManager) {
         AnnotatedType<CdiRequestScope> annotatedType = beanManager.createAnnotatedType(CdiRequestScope.class);
-        this.injectionTarget = beanManager.createInjectionTarget(annotatedType);
+        InjectionTargetFactory<CdiRequestScope> injectionTargetFactory = beanManager.getInjectionTargetFactory(annotatedType);
+        this.injectionTarget = injectionTargetFactory.createInjectionTarget(null);
     }
 
     @Override

--- a/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/bean/BeanHelper.java
+++ b/inject/cdi2-se/src/main/java/org/glassfish/jersey/inject/cdi/se/bean/BeanHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,7 @@ import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
 
 import org.glassfish.jersey.inject.cdi.se.injector.CachedConstructorAnalyzer;
 import org.glassfish.jersey.inject.cdi.se.injector.InjectionUtils;
@@ -99,7 +100,8 @@ public class BeanHelper {
     public static <T> void registerBean(ClassBinding<T> binding, AfterBeanDiscovery abd, Collection<InjectionResolver> resolvers,
             BeanManager beanManager) {
         AnnotatedType<T> annotatedType = beanManager.createAnnotatedType(binding.getService());
-        InjectionTarget<T> injectionTarget = beanManager.createInjectionTarget(annotatedType);
+        InjectionTargetFactory<T> injectionTargetFactory = beanManager.getInjectionTargetFactory(annotatedType);
+        InjectionTarget<T> injectionTarget = injectionTargetFactory.createInjectionTarget(null);
 
         ClassBean<T> bean = new ClassBean<>(binding);
         bean.setInjectionTarget(getJerseyInjectionTarget(binding.getService(), injectionTarget, bean, resolvers));


### PR DESCRIPTION
The `BeanManager.createInjectionTarget` is deprecated since CDI 1.1 and has been removed in CDI 4. Calling it will result in exceptions when using CDI 4.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>