### PR TITLE
Updated dependency versions

### DIFF
--- a/ext/mvc-jsp/pom.xml
+++ b/ext/mvc-jsp/pom.xml
@@ -54,7 +54,7 @@
                     <instructions>
                         <Import-Package>
                             jakarta.servlet.jsp.*;version="[3.0,4.0)",
-                            jakarta.servlet.*;version="!",
+                            jakarta.servlet.*;version="[5.0,7.0)",
                             *
                         </Import-Package>
                         <Export-Package>org.glassfish.jersey.server.mvc.jsp.*;version=${project.version}</Export-Package>

--- a/ext/mvc/pom.xml
+++ b/ext/mvc/pom.xml
@@ -67,7 +67,7 @@
                 <configuration>
                     <instructions>
                         <Export-Package>org.glassfish.jersey.server.mvc.*;version=${project.version}</Export-Package>
-                        <Import-Package>${jakarta.annotation.osgi.version},*</Import-Package>
+                        <Import-Package> jakarta.servlet.*;version="[5.0,7.0)",${jakarta.annotation.osgi.version},*</Import-Package>
                     </instructions>
                     <unpackBundle>true</unpackBundle>
                 </configuration>


### PR DESCRIPTION
For GlassFish 7 and other OSGi containers, make sure Servlet 6 is a
tolerated version number.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>