### PR TITLE
convert Long,long,Integer,int values to Long/Integer types 

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/PropertiesHelper.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/PropertiesHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -285,6 +285,15 @@ public final class PropertiesHelper {
      * @return value converted to the specified class type.
      */
     public static <T> T convertValue(Object value, Class<T> type) {
+
+        if (((type.equals(Integer.class)) || (type.equals(int.class))) && Number.class.isInstance(value)) {
+            final Integer number2Int = ((Number) value).intValue();
+            return  (T) number2Int;
+        } else if (((type.equals(Long.class)) || (type.equals(long.class))) && Number.class.isInstance(value)) {
+            final Long number2Long =  ((Number) value).longValue();
+            return  (T) number2Long;
+        }
+
         if (!type.isInstance(value)) {
             // TODO: Move string value readers from server to common and utilize them here
             final Constructor constructor = AccessController.doPrivileged(ReflectionHelper.getStringConstructorPA(type));

--- a/core-common/src/test/java/org/glassfish/jersey/internal/util/PropertiesHelperTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/internal/util/PropertiesHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -171,6 +171,32 @@ public class PropertiesHelperTest {
         assertEquals(myNonJerseyProperty, PropertiesHelper.getPropertyNameForRuntime(myNonJerseyProperty, RuntimeType.CLIENT));
         assertEquals(myNonJerseyProperty, PropertiesHelper.getPropertyNameForRuntime(myNonJerseyProperty, RuntimeType.CLIENT));
         assertEquals(myNonJerseyProperty, PropertiesHelper.getPropertyNameForRuntime(myNonJerseyProperty, null));
+    }
+
+    @Test
+    public void testconvertValue() {
+        Long lg = 10L;
+        long l = 10L;
+        Integer ig = 10;
+        int i = 10;
+
+        assertEquals(ig, PropertiesHelper.convertValue(i, Integer.class));
+        assertEquals(ig, PropertiesHelper.convertValue(ig, Integer.class));
+        assertEquals(ig, PropertiesHelper.convertValue(l, Integer.class));
+        assertEquals(ig, PropertiesHelper.convertValue(lg, Integer.class));
+        assertEquals(lg, PropertiesHelper.convertValue(i, Long.class));
+        assertEquals(lg, PropertiesHelper.convertValue(ig, Long.class));
+        assertEquals(lg, PropertiesHelper.convertValue(l, Long.class));
+        assertEquals(lg, PropertiesHelper.convertValue(lg, Long.class));
+        assertEquals(ig, PropertiesHelper.convertValue(i, int.class));
+        assertEquals(ig, PropertiesHelper.convertValue(ig, int.class));
+        assertEquals(ig, PropertiesHelper.convertValue(l, int.class));
+        assertEquals(ig, PropertiesHelper.convertValue(lg, int.class));
+        assertEquals(lg, PropertiesHelper.convertValue(i, long.class));
+        assertEquals(lg, PropertiesHelper.convertValue(ig, long.class));
+        assertEquals(lg, PropertiesHelper.convertValue(l, long.class));
+        assertEquals(lg, PropertiesHelper.convertValue(lg, long.class));
+
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/jersey/issues/4930 .

Conversion of Long/long/Integer/int values to Integer/Long types facilitated.