### PR TITLE
Netty Connector support for TLS over Proxy

### DIFF
--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyClientProperties.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/NettyClientProperties.java
@@ -53,4 +53,6 @@ public class NettyClientProperties {
      *  </p>
      */
     public static final String MAX_CONNECTIONS = "jersey.config.client.maxConnections";
+
+    public static final String ENABLE_SSL_HOSTNAME_VERIFICATION = "jersey.config.client.tls.enableHostnameVerification";
 }


### PR DESCRIPTION
1. Support null PROXY_USERNAME

2. Support SSL Hostname verification

3. Update request host and port in SSL Context

4. Correct order of TLS handler vs Proxy handler