### PR TITLE
fix broken license url for asm objectweb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         </license>
         <license>
             <name>Modified BSD</name>
-            <url>http://asm.objectweb.org/license.html</url>
+            <url>https://asm.ow2.io/license.html</url>
             <distribution>repo</distribution>
             <comments>ASM @ jersey.repackaged.org.objectweb.asm</comments>
         </license>


### PR DESCRIPTION
Signed-off-by: Georg Müller <geo.rgmueller@web.de>
fix broken license url for asm objectweb because the old url is no longer valid and causes errors when using license-maven-plugin