### PR TITLE
Bump JAXB from 3.0.X to 4.0.X

### DIFF
--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/JettisonJaxbContext.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/JettisonJaxbContext.java
@@ -22,7 +22,6 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
-import jakarta.xml.bind.Validator;
 
 import org.glassfish.jersey.jettison.internal.BaseJsonMarshaller;
 import org.glassfish.jersey.jettison.internal.BaseJsonUnmarshaller;
@@ -299,16 +298,5 @@ public final class JettisonJaxbContext extends JAXBContext implements JettisonCo
     @Override
     public Marshaller createMarshaller() throws JAXBException {
         return new JettisonJaxbMarshaller(jaxbContext, getJSONConfiguration());
-    }
-
-    /**
-     * Simply delegates to underlying JAXBContext implementation.
-     *
-     * @return what underlying JAXBContext returns
-     * @throws jakarta.xml.bind.JAXBException
-     */
-    @Override
-    public Validator createValidator() throws JAXBException {
-        return jaxbContext.createValidator();
     }
 }

--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/JettisonJaxbContext.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/JettisonJaxbContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/JettisonJaxbMarshaller.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/JettisonJaxbMarshaller.java
@@ -128,17 +128,17 @@ public final class JettisonJaxbMarshaller extends BaseJsonMarshaller implements 
     }
 
     @Override
-    public void setAdapter(XmlAdapter adapter) {
+    public <A extends XmlAdapter<?, ?>> void setAdapter(A adapter) {
         jaxbMarshaller.setAdapter(adapter);
     }
 
     @Override
-    public <A extends XmlAdapter> void setAdapter(Class<A> type, A adapter) {
+    public <A extends XmlAdapter<?, ?>> void setAdapter(Class<A> type, A adapter) {
         jaxbMarshaller.setAdapter(type, adapter);
     }
 
     @Override
-    public <A extends XmlAdapter> A getAdapter(Class<A> type) {
+    public <A extends XmlAdapter<?, ?>> A getAdapter(Class<A> type) {
         return jaxbMarshaller.getAdapter(type);
     }
 

--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/JettisonJaxbMarshaller.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/JettisonJaxbMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/JettisonJaxbUnmarshaller.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/JettisonJaxbUnmarshaller.java
@@ -123,16 +123,6 @@ public class JettisonJaxbUnmarshaller extends BaseJsonUnmarshaller implements Un
     }
 
     @Override
-    public void setValidating(boolean validating) throws JAXBException {
-        this.jaxbUnmarshaller.setValidating(validating);
-    }
-
-    @Override
-    public boolean isValidating() throws JAXBException {
-        return this.jaxbUnmarshaller.isValidating();
-    }
-
-    @Override
     public void setEventHandler(ValidationEventHandler validationEventHandler) throws JAXBException {
         this.jaxbUnmarshaller.setEventHandler(validationEventHandler);
     }
@@ -163,17 +153,17 @@ public class JettisonJaxbUnmarshaller extends BaseJsonUnmarshaller implements Un
     }
 
     @Override
-    public void setAdapter(XmlAdapter xmlAdapter) {
+    public <A extends XmlAdapter<?, ?>> void setAdapter(A xmlAdapter) {
         this.jaxbUnmarshaller.setAdapter(xmlAdapter);
     }
 
     @Override
-    public <A extends XmlAdapter> void setAdapter(Class<A> type, A adapter) {
+    public <A extends XmlAdapter<?, ?>> void setAdapter(Class<A> type, A adapter) {
         this.jaxbUnmarshaller.setAdapter(type, adapter);
     }
 
     @Override
-    public <A extends XmlAdapter> A getAdapter(Class<A> type) {
+    public <A extends XmlAdapter<?, ?>> A getAdapter(Class<A> type) {
         return this.jaxbUnmarshaller.getAdapter(type);
     }
 

--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/JettisonJaxbUnmarshaller.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/JettisonJaxbUnmarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -2203,7 +2203,7 @@
         <jsonb.api.version>2.0.0</jsonb.api.version>
         <jsonp.ri.version>1.0.0</jsonp.ri.version>
         <jsonp.jaxrs.version>1.0.0</jsonp.jaxrs.version>
-        <moxy.version>3.0.2</moxy.version>
+        <moxy.version>4.0.0-M1</moxy.version>
         <yasson.version>2.0.3</yasson.version>
         <!-- END of Jakartified -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -2193,8 +2193,8 @@
         <jakarta.jsonp.version>2.1.0</jakarta.jsonp.version>
         <jakarta.persistence.version>3.0.0</jakarta.persistence.version>
         <jakarta.validation.api.version>3.0.1</jakarta.validation.api.version>
-        <jakarta.jaxb.api.version>3.0.1</jakarta.jaxb.api.version>
-        <jaxb.ri.version>3.0.2</jaxb.ri.version>
+        <jakarta.jaxb.api.version>4.0.0</jakarta.jaxb.api.version>
+        <jaxb.ri.version>4.0.0-M3</jaxb.ri.version>
         <jaxrs.api.spec.version>3.1</jaxrs.api.spec.version>
         <jaxrs.api.impl.version>3.1.0</jaxrs.api.impl.version>
         <jetty.version>11.0.7</jetty.version>


### PR DESCRIPTION
For Jakarta EE 10, it need to adapt to JAXB 4.0 incompatibility.  
Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>