### PR TITLE
Fix logging delimiter parameterization

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -222,7 +222,6 @@ public class LoggingFeature implements Feature {
                 .level(level)
                 .verbosity(verbosity)
                 .maxEntitySize(maxEntitySize)
-                .separator(DEFAULT_SEPARATOR)
         );
 
     }

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
@@ -49,6 +49,7 @@ import org.glassfish.jersey.CommonProperties;
  * <li>logger level: {@link Level#FINE}</li>
  * <li>verbosity: {@link Verbosity#PAYLOAD_TEXT}</li>
  * <li>maximum entity size: {@value #DEFAULT_MAX_ENTITY_SIZE}</li>
+ * <li>line separator: {@link #DEFAULT_SEPARATOR}</li>
  * </ul>
  * <p>
  * Server configurable properties:

--- a/docs/src/main/docbook/jersey.ent
+++ b/docs/src/main/docbook/jersey.ent
@@ -919,7 +919,7 @@
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_CLIENT</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_VERBOSITY_CLIENT</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT</literal>">
-<!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_SEPARATORE_CLIENT</literal>">
+<!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_SEPARATOR_CLIENT</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_SERVER</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_SERVER</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_VERBOSITY_SERVER</literal>">

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
@@ -266,7 +266,7 @@ public class LoggingFeatureTest {
 
         }
 
-        @Test(expected = AssertionError.class)
+        @Test
         public void testLoggingFeatureBuilderProperty() {
             final Response response = target("/text")
                     .register(LoggingFeature.class)

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -266,14 +266,12 @@ public class LoggingFeatureTest {
 
         }
 
-        @Test
+        @Test(expected = AssertionError.class)
         public void testLoggingFeatureBuilderProperty() {
             final Response response = target("/text")
-                    .register(LoggingFeature
-                            .builder()
-                            .withLogger(Logger.getLogger(LOGGER_NAME))
-                            .build()
-                    ).property(LoggingFeature.LOGGING_FEATURE_SEPARATOR, SEPARATOR)
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .property(LoggingFeature.LOGGING_FEATURE_SEPARATOR, SEPARATOR)
                     .request()
                     .post(Entity.text(ENTITY));
 


### PR DESCRIPTION
Hi all,

While reading the classes and tests for the logging feature I noticed that the code introduced in pull request #4745 to add the improvement requested on #4734 is not working as intended.
This has not been noticed by the existing tests because they were using a constructor that would not pass through the problematic code.

Currently, when registering the `LoggingFeature` and setting the `LoggingFeature.LOGGING_FEATURE_SEPARATOR` property, the empty constructor is called, which calls other constructors with nulls and so on.

Eventually we reach the constructor using a `LoggingFeatureBuilder`, where the arguments are set to be passed to the last constructor.
There, the builder is also set with the default separator, which later causes the following code to ignore the configuration properties on `configureBuilderParameters(...)` .
```java
final String filterSeparator = CommonProperties.getValue(/* read config from properties */);
// ...
// Config read from properties is never set
builder.separator = builder.separator == null ? filterSeparator : builder.separator;
```

Since the builder is initially set with the default separator, it is never overridden by the configurations.
The fix is just to remove the line setting the `DEFAULT_SEPARATOR` on the builder before passing to the last constructor.

I guess a conversation could be had about the other configurations: anything set as non-null in the builder cannot be overridden by configurations later; but that's likely okay because those other constructors are only used in tests and the empty constructor just sets everything as null.