### PR TITLE
Fix regression on LoggingFeature's max entity size

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -305,7 +305,7 @@ abstract class LoggingInterceptor implements WriterInterceptor {
             if ((off | len | ba.length - (len + off) | off + len) < 0) {
                 throw new IndexOutOfBoundsException();
             }
-            if ((baos.size() + len) <= maxEntitySize) {
+            if (baos.size() <= maxEntitySize) {
                 baos.write(ba, off, len);
             }
             out.write(ba, off, len);

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -284,6 +284,23 @@ public class LoggingFeatureTest {
             assertThat(record.getMessage(), containsString(SEPARATOR));
         }
 
+        @Test(expected = AssertionError.class)
+        public void testLoggingFeatureMaxEntitySize() {
+            final Response response = target("/text")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .property(LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE, 1)
+                    .request()
+                    .post(Entity.text(ENTITY));
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for trimmedEntity.
+            String trimmedEntity = ENTITY.charAt(0) + "...more...";
+            List<LogRecord> logRecords = getLoggedRecords();
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), containsString(trimmedEntity));
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), containsString(trimmedEntity));
+        }
     }
 
     /**

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
@@ -284,7 +284,7 @@ public class LoggingFeatureTest {
             assertThat(record.getMessage(), containsString(SEPARATOR));
         }
 
-        @Test(expected = AssertionError.class)
+        @Test
         public void testLoggingFeatureMaxEntitySize() {
             final Response response = target("/text")
                     .register(LoggingFeature.class)


### PR DESCRIPTION
Hi all,

PR #4531 implemented the performance improvement requested on #4522 but introduced a regression related to the max entity size property of `LoggingFeature`.
After it, logs from outbound streams are not appended with "...more..." when their entity is trimmed.

The reason is that we were stopping writes to a `ByteArrayOutputStream` too early, so we would never know if it was written in excess.
This looks like a sufficient fix, let me know if you can think of other edge cases.