### PR TITLE
Updated maven-bundle-plugin from 3.5.0 to 5.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -668,7 +668,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>5.1.4</version>
                     <extensions>true</extensions>
                     <configuration>
                         <instructions>


### PR DESCRIPTION
- fixes osgi.ee=UNKNOWN issue.