### PR TITLE
Redact HTTP headers on LoggingFeature

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/logging/ClientLoggingFilter.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/ClientLoggingFilter.java
@@ -64,7 +64,7 @@ final class ClientLoggingFilter extends LoggingInterceptor implements ClientRequ
      *                      logging filter will print (and buffer in memory) only the specified number of bytes
      *                      and print "...more..." string at the end. Negative values are interpreted as zero.
      *  separator      delimiter for particular log lines. Default is Linux new line delimiter
-     *  redactHeaders  a string of comma separated HTTP headers to be redacted when logging.
+     *  redactHeaders  a collection of HTTP headers to be redacted when logging.
      */
     public ClientLoggingFilter(LoggingFeature.LoggingFeatureBuilder builder) {
         super(builder);

--- a/core-common/src/main/java/org/glassfish/jersey/logging/ClientLoggingFilter.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/ClientLoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -64,6 +64,7 @@ final class ClientLoggingFilter extends LoggingInterceptor implements ClientRequ
      *                      logging filter will print (and buffer in memory) only the specified number of bytes
      *                      and print "...more..." string at the end. Negative values are interpreted as zero.
      *  separator      delimiter for particular log lines. Default is Linux new line delimiter
+     *  redactHeaders  a string of comma separated HTTP headers to be redacted when logging.
      */
     public ClientLoggingFilter(LoggingFeature.LoggingFeatureBuilder builder) {
         super(builder);

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
@@ -44,6 +44,7 @@ import org.glassfish.jersey.CommonProperties;
  * <li>{@link #LOGGING_FEATURE_VERBOSITY}</li>
  * <li>{@link #LOGGING_FEATURE_MAX_ENTITY_SIZE}</li>
  * <li>{@link #LOGGING_FEATURE_SEPARATOR}</li>
+ * <li>{@link #LOGGING_FEATURE_REDACT_HEADERS}</li>
  * </ul>
  * <p>
  * If any of the configuration value is not set, following default values are applied:
@@ -63,6 +64,7 @@ import org.glassfish.jersey.CommonProperties;
  * <li>{@link #LOGGING_FEATURE_VERBOSITY_SERVER}</li>
  * <li>{@link #LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER}</li>
  * <li>{@link #LOGGING_FEATURE_SEPARATOR_SERVER}</li>
+ * <li>{@link #LOGGING_FEATURE_REDACT_HEADERS_SERVER}</li>
  * </ul>
  * Client configurable properties:
  * <ul>
@@ -71,6 +73,7 @@ import org.glassfish.jersey.CommonProperties;
  * <li>{@link #LOGGING_FEATURE_VERBOSITY_CLIENT}</li>
  * <li>{@link #LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT}</li>
  * <li>{@link #LOGGING_FEATURE_SEPARATOR_CLIENT}</li>
+ * <li>{@link #LOGGING_FEATURE_REDACT_HEADERS_CLIENT}</li>
  * </ul>
  *
  * @author Ondrej Kosatka
@@ -108,6 +111,7 @@ public class LoggingFeature implements Feature {
     private static final String VERBOSITY_POSTFIX = ".verbosity";
     private static final String MAX_ENTITY_POSTFIX = ".entity.maxSize";
     private static final String SEPARATOR_POSTFIX = ".separator";
+    private static final String REDACT_HEADERS_POSTFIX = ".headers.redact";
     private static final String LOGGING_FEATURE_COMMON_PREFIX = "jersey.config.logging";
     /**
      * Common logger name property.
@@ -129,6 +133,10 @@ public class LoggingFeature implements Feature {
      * Common property for configuring logging separator.
      */
     public static final String LOGGING_FEATURE_SEPARATOR = LOGGING_FEATURE_COMMON_PREFIX + SEPARATOR_POSTFIX;
+    /**
+     * Common property for configuring headers to be redacted.
+     */
+    public static final String LOGGING_FEATURE_REDACT_HEADERS = LOGGING_FEATURE_COMMON_PREFIX + REDACT_HEADERS_POSTFIX;
 
     private static final String LOGGING_FEATURE_SERVER_PREFIX = "jersey.config.server.logging";
     /**
@@ -151,6 +159,11 @@ public class LoggingFeature implements Feature {
      * Server property for configuring separator.
      */
     public static final String LOGGING_FEATURE_SEPARATOR_SERVER = LOGGING_FEATURE_SERVER_PREFIX + SEPARATOR_POSTFIX;
+    /**
+     * Server property for configuring headers to be redacted.
+     */
+    public static final String LOGGING_FEATURE_REDACT_HEADERS_SERVER =
+            LOGGING_FEATURE_SERVER_PREFIX + REDACT_HEADERS_POSTFIX;
 
     private static final String LOGGING_FEATURE_CLIENT_PREFIX = "jersey.config.client.logging";
     /**
@@ -173,6 +186,11 @@ public class LoggingFeature implements Feature {
      * Client property for logging separator.
      */
     public static final String LOGGING_FEATURE_SEPARATOR_CLIENT = LOGGING_FEATURE_CLIENT_PREFIX + SEPARATOR_POSTFIX;
+    /**
+     * Client property for configuring headers to be redacted.
+     */
+    public static final String LOGGING_FEATURE_REDACT_HEADERS_CLIENT =
+            LOGGING_FEATURE_CLIENT_PREFIX + REDACT_HEADERS_POSTFIX;
 
     private final LoggingFeatureBuilder builder;
 
@@ -318,7 +336,14 @@ public class LoggingFeature implements Feature {
                         LOGGING_FEATURE_MAX_ENTITY_SIZE,
                         DEFAULT_MAX_ENTITY_SIZE
                 ));
-        String redactHeaders = DEFAULT_REDACT_HEADERS;
+        final String redactHeaders = CommonProperties.getValue(
+                properties,
+                runtimeType == RuntimeType.SERVER
+                        ? LOGGING_FEATURE_REDACT_HEADERS_SERVER : LOGGING_FEATURE_REDACT_HEADERS_CLIENT,
+                CommonProperties.getValue(
+                        properties,
+                        LOGGING_FEATURE_REDACT_HEADERS,
+                        DEFAULT_REDACT_HEADERS));
 
         final Level loggerLevel = Level.parse(filterLevel);
 

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
@@ -134,7 +134,7 @@ public class LoggingFeature implements Feature {
      */
     public static final String LOGGING_FEATURE_SEPARATOR = LOGGING_FEATURE_COMMON_PREFIX + SEPARATOR_POSTFIX;
     /**
-     * Common property for configuring headers to be redacted.
+     * Common property for configuring headers to be redacted. The headers are semicolon-separated.
      */
     public static final String LOGGING_FEATURE_REDACT_HEADERS = LOGGING_FEATURE_COMMON_PREFIX + REDACT_HEADERS_POSTFIX;
 
@@ -160,7 +160,7 @@ public class LoggingFeature implements Feature {
      */
     public static final String LOGGING_FEATURE_SEPARATOR_SERVER = LOGGING_FEATURE_SERVER_PREFIX + SEPARATOR_POSTFIX;
     /**
-     * Server property for configuring headers to be redacted.
+     * Server property for configuring headers to be redacted. The headers are semicolon-separated.
      */
     public static final String LOGGING_FEATURE_REDACT_HEADERS_SERVER =
             LOGGING_FEATURE_SERVER_PREFIX + REDACT_HEADERS_POSTFIX;
@@ -187,7 +187,7 @@ public class LoggingFeature implements Feature {
      */
     public static final String LOGGING_FEATURE_SEPARATOR_CLIENT = LOGGING_FEATURE_CLIENT_PREFIX + SEPARATOR_POSTFIX;
     /**
-     * Client property for configuring headers to be redacted.
+     * Client property for configuring headers to be redacted. The headers are semicolon-separated.
      */
     public static final String LOGGING_FEATURE_REDACT_HEADERS_CLIENT =
             LOGGING_FEATURE_CLIENT_PREFIX + REDACT_HEADERS_POSTFIX;

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeature.java
@@ -102,7 +102,7 @@ public class LoggingFeature implements Feature {
      */
     public static final String DEFAULT_SEPARATOR = "\n";
     /**
-     * Default headers to be redacted. If multiple, separate each header with a comma.
+     * Default headers to be redacted. If multiple, separate each header with a semicolon.
      */
     public static final String DEFAULT_REDACT_HEADERS = HttpHeaders.AUTHORIZATION;
 
@@ -354,7 +354,7 @@ public class LoggingFeature implements Feature {
         builder.level = builder.level == null ? loggerLevel : builder.level;
         builder.separator = builder.separator == null ? filterSeparator : builder.separator;
         builder.redactHeaders = builder.redactHeaders == null
-                ? Arrays.asList(redactHeaders.split(",")) : builder.redactHeaders;
+                ? Arrays.asList(redactHeaders.split(";")) : builder.redactHeaders;
 
         return builder;
     }

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeatureAutoDiscoverable.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingFeatureAutoDiscoverable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,6 +34,9 @@ import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER
 import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE;
 import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT;
 import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER;
+import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS;
+import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_CLIENT;
+import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_SERVER;
 import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR;
 import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR_CLIENT;
 import static org.glassfish.jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR_SERVER;
@@ -75,7 +78,8 @@ public final class LoggingFeatureAutoDiscoverable implements AutoDiscoverable {
                 || properties.containsKey(LOGGING_FEATURE_LOGGER_LEVEL)
                 || properties.containsKey(LOGGING_FEATURE_VERBOSITY)
                 || properties.containsKey(LOGGING_FEATURE_MAX_ENTITY_SIZE)
-                || properties.containsKey(LOGGING_FEATURE_SEPARATOR);
+                || properties.containsKey(LOGGING_FEATURE_SEPARATOR)
+                || properties.containsKey(LOGGING_FEATURE_REDACT_HEADERS);
     }
 
     private boolean clientConfigured(Map properties) {
@@ -83,7 +87,8 @@ public final class LoggingFeatureAutoDiscoverable implements AutoDiscoverable {
                 || properties.containsKey(LOGGING_FEATURE_LOGGER_LEVEL_CLIENT)
                 || properties.containsKey(LOGGING_FEATURE_VERBOSITY_CLIENT)
                 || properties.containsKey(LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT)
-                || properties.containsKey(LOGGING_FEATURE_SEPARATOR_CLIENT);
+                || properties.containsKey(LOGGING_FEATURE_SEPARATOR_CLIENT)
+                || properties.containsKey(LOGGING_FEATURE_REDACT_HEADERS_CLIENT);
     }
 
     private boolean serverConfigured(Map properties) {
@@ -91,6 +96,7 @@ public final class LoggingFeatureAutoDiscoverable implements AutoDiscoverable {
                 || properties.containsKey(LOGGING_FEATURE_LOGGER_LEVEL_SERVER)
                 || properties.containsKey(LOGGING_FEATURE_VERBOSITY_SERVER)
                 || properties.containsKey(LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER)
-                || properties.containsKey(LOGGING_FEATURE_SEPARATOR_SERVER);
+                || properties.containsKey(LOGGING_FEATURE_SEPARATOR_SERVER)
+                || properties.containsKey(LOGGING_FEATURE_REDACT_HEADERS_SERVER);
     }
 }

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -134,7 +134,7 @@ abstract class LoggingInterceptor implements WriterInterceptor {
         this.verbosity = builder.verbosity;
         this.maxEntitySize = Math.max(0, builder.maxEntitySize);
         this.separator = builder.separator;
-        this.redactHeaderPredicate = !builder.redactHeaders.isEmpty()
+        this.redactHeaderPredicate = builder.redactHeaders != null && !builder.redactHeaders.isEmpty()
                 ? new RedactHeaderPredicate(builder.redactHeaders)
                 : header -> false;
     }

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -46,6 +46,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.WriterInterceptor;
 import javax.ws.rs.ext.WriterInterceptorContext;
 
+import org.glassfish.jersey.internal.guava.Predicates;
 import org.glassfish.jersey.logging.LoggingFeature.Verbosity;
 import org.glassfish.jersey.message.MessageUtils;
 
@@ -337,6 +338,7 @@ abstract class LoggingInterceptor implements WriterInterceptor {
         RedactHeaderPredicate(Collection<String> headersToRedact) {
             this.headersToRedact = headersToRedact.stream()
                     .filter(Objects::nonNull)
+                    .filter(Predicates.not(String::isEmpty))
                     .map(RedactHeaderPredicate::normalize)
                     .collect(Collectors.toSet());
         }

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -124,7 +124,7 @@ abstract class LoggingInterceptor implements WriterInterceptor {
      *                      logging filter will print (and buffer in memory) only the specified number of bytes
      *                      and print "...more..." string at the end. Negative values are interpreted as zero.
      *  separator      delimiter for particular log lines. Default is Linux new line delimiter
-     *  redactHeaders  a string of comma separated HTTP headers to be redacted when logging.
+     *  redactHeaders  a collection of HTTP headers to be redacted when logging.
      */
 
     LoggingInterceptor(LoggingFeature.LoggingFeatureBuilder builder) {

--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -124,6 +124,7 @@ abstract class LoggingInterceptor implements WriterInterceptor {
      *                      logging filter will print (and buffer in memory) only the specified number of bytes
      *                      and print "...more..." string at the end. Negative values are interpreted as zero.
      *  separator      delimiter for particular log lines. Default is Linux new line delimiter
+     *  redactHeaders  a string of comma separated HTTP headers to be redacted when logging.
      */
 
     LoggingInterceptor(LoggingFeature.LoggingFeatureBuilder builder) {

--- a/core-common/src/main/java/org/glassfish/jersey/logging/ServerLoggingFilter.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/ServerLoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -64,6 +64,7 @@ final class ServerLoggingFilter extends LoggingInterceptor implements ContainerR
      *                      logging filter will print (and buffer in memory) only the specified number of bytes
      *                      and print "...more..." string at the end. Negative values are interpreted as zero.
      *  separator      delimiter for particular log lines. Default is Linux new line delimiter
+     *  redactHeaders  a string of comma separated HTTP headers to be redacted when logging.
      */
     public ServerLoggingFilter(final LoggingFeature.LoggingFeatureBuilder builder) {
         super(builder);

--- a/core-common/src/main/java/org/glassfish/jersey/logging/ServerLoggingFilter.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/ServerLoggingFilter.java
@@ -64,7 +64,7 @@ final class ServerLoggingFilter extends LoggingInterceptor implements ContainerR
      *                      logging filter will print (and buffer in memory) only the specified number of bytes
      *                      and print "...more..." string at the end. Negative values are interpreted as zero.
      *  separator      delimiter for particular log lines. Default is Linux new line delimiter
-     *  redactHeaders  a string of comma separated HTTP headers to be redacted when logging.
+     *  redactHeaders  a collection of HTTP headers to be redacted when logging.
      */
     public ServerLoggingFilter(final LoggingFeature.LoggingFeatureBuilder builder) {
         super(builder);

--- a/docs/src/main/docbook/appendix-properties.xml
+++ b/docs/src/main/docbook/appendix-properties.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -204,6 +204,17 @@
                         <entry>
                             Custom logging delimiter for new lines separation.
                             See <link linkend="logging.xml">logging</link> chapter for more information.
+                        </entry>
+                    </row>
+                    <row>
+                        <entry>&jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS;
+                        </entry>
+                        <entry>
+                            <literal>jersey.config.logging.headers.redact</literal>
+                        </entry>
+                        <entry>
+                            The HTTP headers (semicolon separated) to be redacted when logging.
+                            See <link linkend="logging_chapter">logging</link> chapter for more information.
                         </entry>
                     </row>
                 </tbody>
@@ -669,6 +680,17 @@
                             See <link linkend="logging.xml">logging</link> chapter for more information.
                         </entry>
                     </row>
+                    <row>
+                        <entry>&jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_SERVER;
+                        </entry>
+                        <entry>
+                            <literal>jersey.config.server.logging.headers.redact</literal>
+                        </entry>
+                        <entry>
+                            The HTTP headers (semicolon separated) to be redacted when logging.
+                            See <link linkend="logging_chapter">logging</link> chapter for more information.
+                        </entry>
+                    </row>
                 </tbody>
             </tgroup>
         </table>
@@ -1046,6 +1068,17 @@
                         </entry>
                         <entry>
                             New line delimiter property (client side).
+                            See <link linkend="logging_chapter">logging</link> chapter for more information.
+                        </entry>
+                    </row>
+                    <row>
+                        <entry>&jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_CLIENT;
+                        </entry>
+                        <entry>
+                            <literal>jersey.config.client.logging.headers.redact</literal>
+                        </entry>
+                        <entry>
+                            The HTTP headers (semicolon separated) to be redacted when logging.
                             See <link linkend="logging_chapter">logging</link> chapter for more information.
                         </entry>
                     </row>

--- a/docs/src/main/docbook/jersey.ent
+++ b/docs/src/main/docbook/jersey.ent
@@ -424,21 +424,25 @@
 <!ENTITY jersey.logging.LoggingFeature.DEFAULT_LOGGER_LEVEL "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#DEFAULT_LOGGER_LEVEL'>LoggingFeature.DEFAULT_LOGGER_LEVEL</link>">
 <!ENTITY jersey.logging.LoggingFeature.DEFAULT_VERBOSITY "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#DEFAULT_VERBOSITY'>LoggingFeature.DEFAULT_VERBOSITY</link>">
 <!ENTITY jersey.logging.LoggingFeature.DEFAULT_MAX_ENTITY_SIZE "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#DEFAULT_MAX_ENTITY_SIZE'>LoggingFeature.DEFAULT_MAX_ENTITY_SIZE</link>">
+<!ENTITY jersey.logging.LoggingFeature.DEFAULT_REDACT_HEADERS "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#DEFAULT_REDACT_HEADERS'>LoggingFeature.DEFAULT_REDACT_HEADERS</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_NAME "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_LOGGER_NAME'>LoggingFeature.LOGGING_FEATURE_LOGGER_NAME</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_LOGGER_LEVEL'>LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_VERBOSITY'>LoggingFeature.LOGGING_FEATURE_VERBOSITY</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_MAX_ENTITY_SIZE'>LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_SEPARATOR'>LoggingFeature.LOGGING_FEATURE_SEPARATOR</link>">
+<!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_REDACT_HEADERS'>LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_CLIENT "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_LOGGER_NAME_CLIENT'>LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_CLIENT</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_CLIENT "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_LOGGER_LEVEL_CLIENT'>LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_CLIENT</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY_CLIENT "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_VERBOSITY_CLIENT'>LoggingFeature.LOGGING_FEATURE_VERBOSITY_CLIENT</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT'>LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR_CLIENT "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT'>LoggingFeature.LOGGING_FEATURE_SEPARATOR_CLIENT</link>">
+<!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_CLIENT "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_REDACT_HEADERS_CLIENT'>LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_CLIENT</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_SERVER "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_LOGGER_NAME_SERVER'>LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_SERVER</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_SERVER "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_LOGGER_LEVEL_SERVER'>LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_SERVER</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY_SERVER "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_VERBOSITY_SERVER'>LoggingFeature.LOGGING_FEATURE_VERBOSITY_SERVER</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER'>LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER</link>">
 <!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR_SERVER "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER'>LoggingFeature.LOGGING_FEATURE_SEPARATOR_SERVER</link>">
+<!ENTITY jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_SERVER "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.html#LOGGING_FEATURE_REDACT_HEADERS_SERVER'>LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_SERVER</link>">
 <!ENTITY jersey.logging.LoggingFeature.Verbosity "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.Verbosity.html'>LoggingFeature.Verbosity</link>">
 <!ENTITY jersey.logging.LoggingFeature.Verbosity.HEADERS_ONLY "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.Verbosity.html#HEADERS_ONLY'>LoggingFeature.Verbosity.HEADERS_ONLY</link>">
 <!ENTITY jersey.logging.LoggingFeature.Verbosity.PAYLOAD_ANY "<link xlink:href='&jersey.javadoc.uri.prefix;/logging/LoggingFeature.Verbosity.html#PAYLOAD_ANY'>LoggingFeature.Verbosity.PAYLOAD_ANY</link>">
@@ -910,21 +914,25 @@
 <!ENTITY lit.jersey.logging.LoggingFeature.DEFAULT_LOGGER_LEVEL "<literal>LoggingFeature.DEFAULT_LOGGER_LEVEL</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.DEFAULT_VERBOSITY "<literal>LoggingFeature.DEFAULT_VERBOSITY</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.DEFAULT_MAX_ENTITY_SIZE "<literal>LoggingFeature.DEFAULT_MAX_ENTITY_SIZE</literal>">
+<!ENTITY lit.jersey.logging.LoggingFeature.DEFAULT_REDACT_HEADERS "<literal>LoggingFeature.DEFAULT_REDACT_HEADERS</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_NAME "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_NAME</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY "<literal>LoggingFeature.LOGGING_FEATURE_VERBOSITY</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE "<literal>LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR "<literal>LoggingFeature.LOGGING_FEATURE_SEPARATOR</literal>">
+<!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS "<literal>LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_CLIENT</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_CLIENT</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_VERBOSITY_CLIENT</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_CLIENT</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_SEPARATOR_CLIENT</literal>">
+<!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_CLIENT "<literal>LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_CLIENT</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_SERVER</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_LOGGER_LEVEL_SERVER</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_VERBOSITY_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_VERBOSITY_SERVER</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_MAX_ENTITY_SIZE_SERVER</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_SEPARATOR_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_SEPARATOR_SERVER</literal>">
+<!ENTITY lit.jersey.logging.LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_SERVER "<literal>LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS_SERVER</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.Verbosity "<literal>LoggingFeature.Verbosity</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.Verbosity.HEADERS_ONLY "<literal>LoggingFeature.Verbosity.HEADERS_ONLY</literal>">
 <!ENTITY lit.jersey.logging.LoggingFeature.Verbosity.PAYLOAD_ANY "<literal>LoggingFeature.Verbosity.PAYLOAD_ANY</literal>">

--- a/docs/src/main/docbook/logging.xml
+++ b/docs/src/main/docbook/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2016, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -151,6 +151,19 @@
                                 string at the end. Negative values are interpreted as zero.
                             </para>
                             <para>Default value &jersey.logging.LoggingFeature.DEFAULT_MAX_ENTITY_SIZE;.
+                            </para>
+                        </listitem>
+                        <listitem>
+                            <para>
+                                <literal>Redact HTTP headers</literal>
+                            </para>
+                            <para>
+                                HTTP headers with sensitive information can be configured to print "[redacted]" in place of their
+                                real values. This should be a string with the names of the HTTP headers to be redacted, each entry
+                                separated by a semicolon (;). Header names will be compared in a case-insensitive manner and
+                                ignoring initial or trailing whitespaces.
+                            </para>
+                            <para>Default value &jersey.logging.LoggingFeature.DEFAULT_REDACT_HEADERS;.
                             </para>
                         </listitem>
                     </itemizedlist>

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
@@ -386,7 +386,7 @@ public class LoggingFeatureTest {
             assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
         }
 
-        @Test(expected = AssertionError.class)
+        @Test
         public void testAuthorizationHeaderRedactedByDefault() {
             String headerName = HttpHeaders.AUTHORIZATION;
             String headerValue = "username:password";
@@ -508,7 +508,7 @@ public class LoggingFeatureTest {
             assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
         }
 
-        @Test
+        @Test(expected = AssertionError.class)
         public void testLoggingFeatureRedactZeroHeaders() {
             String headerName = HttpHeaders.AUTHORIZATION;
             String headerValue = "username:password";

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
@@ -18,10 +18,13 @@ package org.glassfish.jersey.tests.e2e.common;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -37,6 +40,8 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -48,9 +53,13 @@ import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
 
+import org.hamcrest.Matcher;
+import org.hamcrest.core.SubstringMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -117,6 +126,16 @@ public class LoggingFeatureTest {
                     .build();
         }
 
+        @Path("/echo-headers")
+        @GET
+        @Produces(TEXT_MEDIA_TYPE)
+        public Response getSameHeadersAsRequest(@Context HttpHeaders httpHeaders) {
+            Response.ResponseBuilder responseBuilder = Response.ok(ENTITY);
+            httpHeaders.getRequestHeaders().forEach(
+                    (key, values) -> values.forEach(
+                            value -> responseBuilder.header(key, value)));
+            return responseBuilder.build();
+        }
     }
 
     /**
@@ -298,6 +317,218 @@ public class LoggingFeatureTest {
             List<LogRecord> logRecords = getLoggedRecords();
             assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), containsString(trimmedEntity));
             assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), containsString(trimmedEntity));
+        }
+
+        @Test
+        public void testSingleValuedHeader() {
+            String headerName = "X-Single-Valued-Header";
+            String headerValue = "test-value";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .request()
+                    .header(headerName, headerValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = new ContainsHeaderMatcher(headerName, headerValue);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+        }
+
+        @Test
+        public void testMultivaluedHeader() {
+            String headerName = "X-Multi-Valued-Header";
+            String firstHeaderValue = "first-value";
+            String secondHeaderValue = "second-value";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .request()
+                    .header(headerName, firstHeaderValue)
+                    .header(headerName, secondHeaderValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = new ContainsHeaderMatcher(headerName, firstHeaderValue, secondHeaderValue);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+        }
+
+        @Test
+        public void testMultipleHeaders() {
+            String firstHeaderName = "X-First-Header";
+            String firstHeaderValue = "first-value";
+            String secondHeaderName = "X-Second-Header";
+            String secondHeaderValue = "second-value";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .request()
+                    .header(firstHeaderName, firstHeaderValue)
+                    .header(secondHeaderName, secondHeaderValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = allOf(
+                    new ContainsHeaderMatcher(firstHeaderName, firstHeaderValue),
+                    new ContainsHeaderMatcher(secondHeaderName, secondHeaderValue));
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+        }
+
+        @Test(expected = AssertionError.class)
+        public void testAuthorizationHeaderRedactedByDefault() {
+            String headerName = HttpHeaders.AUTHORIZATION;
+            String headerValue = "username:password";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .request()
+                    .header(headerName, headerValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = allOf(
+                    new ContainsHeaderMatcher(headerName, "[redacted]"),
+                    not(containsString(headerValue)));
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+        }
+
+        @Test(expected = AssertionError.class)
+        public void testLoggingFeatureRedactOneHeader() {
+            String headerName = "X-Redact-This-Header";
+            String headerValue = "sensitive-info";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .property("LOGGING_FEATURE_REDACT_HEADERS", headerName)
+                    .request()
+                    .header(headerName, headerValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = allOf(
+                    new ContainsHeaderMatcher(headerName, "[redacted]"),
+                    not(containsString(headerValue)));
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+        }
+
+        @Test(expected = AssertionError.class)
+        public void testLoggingFeatureRedactOneHeaderNormalizing() {
+            String headerName = "X-Redact-This-Header";
+            String headerValue = "sensitive-info";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .property("LOGGING_FEATURE_REDACT_HEADERS", " " + headerName.toUpperCase(Locale.ROOT) + " ")
+                    .request()
+                    .header(headerName, headerValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = allOf(
+                    new ContainsHeaderMatcher(headerName, "[redacted]"),
+                    not(containsString(headerValue)));
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+        }
+
+        @Test(expected = AssertionError.class)
+        public void testLoggingFeatureRedactMultivaluedHeader() {
+            String headerName = "X-Redact-This-Header";
+            String firstHeaderValue = "sensitive-info";
+            String secondHeaderValue = "additional-info";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .property("LOGGING_FEATURE_REDACT_HEADERS", headerName)
+                    .request()
+                    .header(headerName, firstHeaderValue)
+                    .header(headerName, secondHeaderValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = allOf(
+                    new ContainsHeaderMatcher(headerName, "[redacted]"),
+                    not(containsString(firstHeaderValue)),
+                    not(containsString(secondHeaderValue)));
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+        }
+
+        @Test(expected = AssertionError.class)
+        public void testLoggingFeatureRedactMultipleHeaders() {
+            String firstHeaderName = "X-Redact-This-Header";
+            String firstHeaderValue = "sensitive-info";
+            String secondHeaderName = "X-Also-Redact-This-Header";
+            String secondHeaderValue = "additional-info";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .property("LOGGING_FEATURE_REDACT_HEADERS", firstHeaderName + "," + secondHeaderName)
+                    .request()
+                    .header(firstHeaderName, firstHeaderValue)
+                    .header(secondHeaderName, secondHeaderValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = allOf(
+                    new ContainsHeaderMatcher(firstHeaderName, "[redacted]"),
+                    not(containsString(firstHeaderValue)),
+                    new ContainsHeaderMatcher(secondHeaderName, "[redacted]"),
+                    not(containsString(secondHeaderValue)));
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+        }
+
+        @Test
+        public void testLoggingFeatureRedactZeroHeaders() {
+            String headerName = HttpHeaders.AUTHORIZATION;
+            String headerValue = "username:password";
+            final Response response = target("/echo-headers")
+                    .register(LoggingFeature.class)
+                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
+                    .property("LOGGING_FEATURE_REDACT_HEADERS", "")
+                    .request()
+                    .header(headerName, headerValue)
+                    .get();
+
+            // Correct response status.
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+            // Check logs for header
+            List<LogRecord> logRecords = getLoggedRecords();
+            Matcher<String> matcher = allOf(
+                    new ContainsHeaderMatcher(headerName, headerValue),
+                    not(containsString("[redacted]")));
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
         }
     }
 
@@ -502,5 +733,47 @@ public class LoggingFeatureTest {
 
         }
 
+    }
+
+    private static final class ContainsHeaderMatcher extends SubstringMatcher {
+
+        private static final boolean ORDER_OF_HEADER_VALUES_IS_GUARANTEED = true;
+
+        ContainsHeaderMatcher(String headerName, String... headerValues) {
+            super(makeRegex(headerName, Arrays.asList(headerValues)));
+        }
+
+        private static String makeRegex(String headerName, List<String> headerValues) {
+            StringBuilder stringBuilder = new StringBuilder("^[\\s\\S]*")
+                    // Header name is case insensitive
+                    .append("(?i)").append(quote(headerName)).append("(?-i): ");
+
+            if (headerValues.size() == 1) {
+                stringBuilder.append(quote(headerValues.get(0)));
+            } else if (headerValues.size() > 1) {
+                if (ORDER_OF_HEADER_VALUES_IS_GUARANTEED) {
+                    stringBuilder.append(String.join(",", headerValues));
+                } else {
+                    headerValues.forEach(headerValue -> stringBuilder
+                            .append("(?=.*").append(quote(headerValue)).append(",?)"));
+                }
+            }
+
+            return stringBuilder.append("[\\s\\S]*$").toString();
+        }
+
+        private static String quote(String input) {
+            return Pattern.quote(input);
+        }
+
+        @Override
+        protected boolean evalSubstringOf(String string) {
+            return string.matches(substring);
+        }
+
+        @Override
+        protected String relationship() {
+            return "matching regex";
+        }
     }
 }

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
@@ -490,7 +490,7 @@ public class LoggingFeatureTest {
             final Response response = target("/echo-headers")
                     .register(LoggingFeature.class)
                     .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME, LOGGER_NAME)
-                    .property(LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS, firstHeaderName + "," + secondHeaderName)
+                    .property(LoggingFeature.LOGGING_FEATURE_REDACT_HEADERS, firstHeaderName + ';' + secondHeaderName)
                     .request()
                     .header(firstHeaderName, firstHeaderValue)
                     .header(secondHeaderName, secondHeaderValue)

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/common/LoggingFeatureTest.java
@@ -335,8 +335,8 @@ public class LoggingFeatureTest {
             // Check logs for header
             List<LogRecord> logRecords = getLoggedRecords();
             Matcher<String> matcher = new ContainsHeaderMatcher(headerName, headerValue);
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
 
         @Test
@@ -357,8 +357,8 @@ public class LoggingFeatureTest {
             // Check logs for header
             List<LogRecord> logRecords = getLoggedRecords();
             Matcher<String> matcher = new ContainsHeaderMatcher(headerName, firstHeaderValue, secondHeaderValue);
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
 
         @Test
@@ -382,8 +382,8 @@ public class LoggingFeatureTest {
             Matcher<String> matcher = allOf(
                     new ContainsHeaderMatcher(firstHeaderName, firstHeaderValue),
                     new ContainsHeaderMatcher(secondHeaderName, secondHeaderValue));
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
 
         @Test
@@ -404,8 +404,8 @@ public class LoggingFeatureTest {
             Matcher<String> matcher = allOf(
                     new ContainsHeaderMatcher(headerName, "[redacted]"),
                     not(containsString(headerValue)));
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
 
         @Test
@@ -427,8 +427,8 @@ public class LoggingFeatureTest {
             Matcher<String> matcher = allOf(
                     new ContainsHeaderMatcher(headerName, "[redacted]"),
                     not(containsString(headerValue)));
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
 
         @Test
@@ -451,8 +451,8 @@ public class LoggingFeatureTest {
             Matcher<String> matcher = allOf(
                     new ContainsHeaderMatcher(headerName, "[redacted]"),
                     not(containsString(headerValue)));
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
 
         @Test
@@ -477,8 +477,8 @@ public class LoggingFeatureTest {
                     new ContainsHeaderMatcher(headerName, "[redacted]"),
                     not(containsString(firstHeaderValue)),
                     not(containsString(secondHeaderValue)));
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
 
         @Test
@@ -505,8 +505,8 @@ public class LoggingFeatureTest {
                     not(containsString(firstHeaderValue)),
                     new ContainsHeaderMatcher(secondHeaderName, "[redacted]"),
                     not(containsString(secondHeaderValue)));
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
 
         @Test
@@ -528,8 +528,8 @@ public class LoggingFeatureTest {
             Matcher<String> matcher = allOf(
                     new ContainsHeaderMatcher(headerName, headerValue),
                     not(containsString("[redacted]")));
-            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage().toLowerCase(), matcher);
-            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage().toLowerCase(), matcher);
+            assertThat(getLoggingFilterRequestLogRecord(logRecords).getMessage(), matcher);
+            assertThat(getLoggingFilterResponseLogRecord(logRecords).getMessage(), matcher);
         }
     }
 


### PR DESCRIPTION
As talked on #5014, this allows configuring `LoggingFeature` with a list of HTTP headers to have their value redacted when printing to logs. By default, the Authorization header is redacted.

Example of a logged request/response with the Authorization header redacted (default behavior):
```
1 * Sending client request on thread main
1 > GET http://localhost:9998/echo-headers
1 > Authorization: [redacted]

1 * Client response received on thread main
1 < 200
1 < accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
1 < authorization: [redacted]
1 < connection: keep-alive
1 < Content-Length: 32
1 < Content-Type: text/plain
1 < host: localhost:9998
1 < user-agent: Jersey/2.36-SNAPSHOT (HttpUrlConnection 1.8.0_92)
This entity must (not) be logged
```

And an example with two headers configured to be redacted (overriding the default behavior of redacting the Authorization header):
```
1 * Sending client request on thread main
1 > GET http://localhost:9998/echo-headers
1 > Authorization: basic username:password
1 > X-Also-Redact-This-Header: [redacted]
1 > X-Redact-This-Header: [redacted]

1 * Client response received on thread main
1 < 200
1 < accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
1 < authorization: basic username:password
1 < connection: keep-alive
1 < Content-Length: 32
1 < Content-Type: text/plain
1 < host: localhost:9998
1 < user-agent: Jersey/2.36-SNAPSHOT (HttpUrlConnection 1.8.0_92)
1 < x-also-redact-this-header: [redacted]
1 < x-redact-this-header: [redacted]
This entity must (not) be logged

```