### PR TITLE
Enhancement for docprocessor

### DIFF
--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessor.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessor.java
@@ -60,9 +60,9 @@ public interface DocProcessor {
      * @param classDoc     the class javadoc
      * @param classDocType the {@link ClassDocType} to extend. This will later be processed by the
      *                     {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
-     * @param docEnv       the doclet environment used to process the classDoc
      */
-    void processClassDoc(TypeElement classDoc, ClassDocType classDocType, DocletEnvironment docEnv);
+    @Deprecated
+    void processClassDoc(TypeElement classDoc, ClassDocType classDocType);
 
     /**
      * Process the provided methodDoc and add your custom information to the methodDocType.<br>
@@ -70,9 +70,9 @@ public interface DocProcessor {
      * @param methodDoc     the {@link ExecutableElement} representing the docs of your method.
      * @param methodDocType the related {@link MethodDocType} that will later be processed by the
      *                      {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
-     * @param docEnv       the doclet environment used to process the classDoc
      */
-    void processMethodDoc(ExecutableElement methodDoc, MethodDocType methodDocType, DocletEnvironment docEnv);
+    @Deprecated
+    void processMethodDoc(ExecutableElement methodDoc, MethodDocType methodDocType);
 
     /**
      * Use this method to extend the provided {@link ParamDocType} with the information from the
@@ -81,8 +81,46 @@ public interface DocProcessor {
      * @param parameter    the parameter (that is documented or not)
      * @param paramDocType the {@link ParamDocType} to extend. This will later be processed by the
      *                     {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
-     * @param docEnv       the doclet environment used to process the classDoc
      */
-    void processParamTag(VariableElement parameter, ParamDocType paramDocType, DocletEnvironment docEnv);
+    @Deprecated
+    void processParamTag(VariableElement parameter, ParamDocType paramDocType);
+
+    /**
+     * Use this method to extend the provided {@link ClassDocType} with the information from
+     * the given {@link TypeElement}.
+     *
+     * @param classDoc     the class javadoc
+     * @param classDocType the {@link ClassDocType} to extend. This will later be processed by the
+     *                     {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
+     * @param docEnv       the doclet environment used to extract info from classDoc
+     */
+    default void processClassDocWithDocEnv(TypeElement classDoc, ClassDocType classDocType, DocletEnvironment docEnv) {
+        processClassDoc(classDoc, classDocType);
+    }
+
+    /**
+     * Process the provided methodDoc and add your custom information to the methodDocType.<br>
+     *
+     * @param methodDoc     the {@link ExecutableElement} representing the docs of your method.
+     * @param methodDocType the related {@link MethodDocType} that will later be processed by the
+     *                      {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
+     * @param docEnv        the doclet environment used to extract info from methodDoc
+     */
+    default void processMethodDocWithDocEnv(ExecutableElement methodDoc, MethodDocType methodDocType, DocletEnvironment docEnv) {
+        processMethodDoc(methodDoc, methodDocType);
+    }
+
+    /**
+     * Use this method to extend the provided {@link ParamDocType} with the information from the
+     * given {@link ParamTag} and {@link Parameter}.
+     *
+     * @param parameter    the parameter (that is documented or not)
+     * @param paramDocType the {@link ParamDocType} to extend. This will later be processed by the
+     *                     {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
+     * @param docEnv       the Doclet Environment used to extract info from parameter
+     */
+    default void processParamTagWithDocEnv(VariableElement parameter, ParamDocType paramDocType, DocletEnvironment docEnv) {
+        processParamTag(parameter, paramDocType);
+    }
 
 }

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessor.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessor.java
@@ -16,6 +16,7 @@
 
 package org.glassfish.jersey.wadl.doclet;
 
+import jdk.javadoc.doclet.DocletEnvironment;
 import org.glassfish.jersey.server.wadl.internal.generators.resourcedoc.model.ClassDocType;
 import org.glassfish.jersey.server.wadl.internal.generators.resourcedoc.model.MethodDocType;
 import org.glassfish.jersey.server.wadl.internal.generators.resourcedoc.model.ParamDocType;
@@ -59,8 +60,9 @@ public interface DocProcessor {
      * @param classDoc     the class javadoc
      * @param classDocType the {@link ClassDocType} to extend. This will later be processed by the
      *                     {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
+     * @param docEnv       the doclet environment used to process the classDoc
      */
-    void processClassDoc(TypeElement classDoc, ClassDocType classDocType);
+    void processClassDoc(TypeElement classDoc, ClassDocType classDocType, DocletEnvironment docEnv);
 
     /**
      * Process the provided methodDoc and add your custom information to the methodDocType.<br>
@@ -68,8 +70,9 @@ public interface DocProcessor {
      * @param methodDoc     the {@link ExecutableElement} representing the docs of your method.
      * @param methodDocType the related {@link MethodDocType} that will later be processed by the
      *                      {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
+     * @param docEnv       the doclet environment used to process the classDoc
      */
-    void processMethodDoc(ExecutableElement methodDoc, MethodDocType methodDocType);
+    void processMethodDoc(ExecutableElement methodDoc, MethodDocType methodDocType, DocletEnvironment docEnv);
 
     /**
      * Use this method to extend the provided {@link ParamDocType} with the information from the
@@ -78,7 +81,8 @@ public interface DocProcessor {
      * @param parameter    the parameter (that is documented or not)
      * @param paramDocType the {@link ParamDocType} to extend. This will later be processed by the
      *                     {@link org.glassfish.jersey.server.wadl.WadlGenerator}s.
+     * @param docEnv       the doclet environment used to process the classDoc
      */
-    void processParamTag(VariableElement parameter, ParamDocType paramDocType);
+    void processParamTag(VariableElement parameter, ParamDocType paramDocType, DocletEnvironment docEnv);
 
 }

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessor.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessor.java
@@ -112,7 +112,7 @@ public interface DocProcessor {
 
     /**
      * Use this method to extend the provided {@link ParamDocType} with the information from the
-     * given {@link ParamTag} and {@link Parameter}.
+     * given {@link VariableElement}.
      *
      * @param parameter    the parameter (that is documented or not)
      * @param paramDocType the {@link ParamDocType} to extend. This will later be processed by the

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessor.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessorWrapper.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessorWrapper.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import jdk.javadoc.doclet.DocletEnvironment;
 import org.glassfish.jersey.server.wadl.internal.generators.resourcedoc.model.ClassDocType;
 import org.glassfish.jersey.server.wadl.internal.generators.resourcedoc.model.MethodDocType;
 import org.glassfish.jersey.server.wadl.internal.generators.resourcedoc.model.ParamDocType;
@@ -74,25 +75,27 @@ public class DocProcessorWrapper implements DocProcessor {
     }
 
     @Override
-    public void processClassDoc(TypeElement classDoc, ClassDocType classDocType) {
+    public void processClassDoc(TypeElement classDoc, ClassDocType classDocType, DocletEnvironment docEnv) {
         for (DocProcessor docProcessor : _docProcessors) {
-            docProcessor.processClassDoc(classDoc, classDocType);
+            docProcessor.processClassDoc(classDoc, classDocType, docEnv);
         }
     }
 
     @Override
     public void processMethodDoc(ExecutableElement methodDoc,
-                                 MethodDocType methodDocType) {
+                                 MethodDocType methodDocType,
+                                 DocletEnvironment docEnv) {
         for (DocProcessor docProcessor : _docProcessors) {
-            docProcessor.processMethodDoc(methodDoc, methodDocType);
+            docProcessor.processMethodDoc(methodDoc, methodDocType, docEnv);
         }
     }
 
     @Override
     public void processParamTag(VariableElement parameter,
-                                ParamDocType paramDocType) {
+                                ParamDocType paramDocType,
+                                DocletEnvironment docEnv) {
         for (DocProcessor docProcessor : _docProcessors) {
-            docProcessor.processParamTag(parameter, paramDocType);
+            docProcessor.processParamTag(parameter, paramDocType, docEnv);
         }
     }
 

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessorWrapper.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessorWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessorWrapper.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/DocProcessorWrapper.java
@@ -27,7 +27,6 @@ import org.glassfish.jersey.server.wadl.internal.generators.resourcedoc.model.Pa
 
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.ExecutableElement;
-import com.sun.source.doctree.ParamTree;
 import javax.lang.model.element.VariableElement;
 
 public class DocProcessorWrapper implements DocProcessor {
@@ -75,28 +74,52 @@ public class DocProcessorWrapper implements DocProcessor {
     }
 
     @Override
-    public void processClassDoc(TypeElement classDoc, ClassDocType classDocType, DocletEnvironment docEnv) {
+    public void processClassDoc(TypeElement classDoc, ClassDocType classDocType) {
         for (DocProcessor docProcessor : _docProcessors) {
-            docProcessor.processClassDoc(classDoc, classDocType, docEnv);
+            docProcessor.processClassDoc(classDoc, classDocType);
         }
     }
 
     @Override
     public void processMethodDoc(ExecutableElement methodDoc,
-                                 MethodDocType methodDocType,
-                                 DocletEnvironment docEnv) {
+                                 MethodDocType methodDocType) {
         for (DocProcessor docProcessor : _docProcessors) {
-            docProcessor.processMethodDoc(methodDoc, methodDocType, docEnv);
+            docProcessor.processMethodDoc(methodDoc, methodDocType);
         }
     }
 
     @Override
     public void processParamTag(VariableElement parameter,
-                                ParamDocType paramDocType,
-                                DocletEnvironment docEnv) {
+                                ParamDocType paramDocType) {
         for (DocProcessor docProcessor : _docProcessors) {
-            docProcessor.processParamTag(parameter, paramDocType, docEnv);
+            docProcessor.processParamTag(parameter, paramDocType);
         }
     }
 
+    @Override
+    public void processClassDocWithDocEnv(TypeElement classDoc,
+                                          ClassDocType classDocType,
+                                          DocletEnvironment docEnv) {
+        for (DocProcessor docProcessor : _docProcessors) {
+            docProcessor.processClassDocWithDocEnv(classDoc, classDocType, docEnv);
+        }
+    }
+
+    @Override
+    public void processMethodDocWithDocEnv(ExecutableElement methodDoc,
+                                           MethodDocType methodDocType,
+                                           DocletEnvironment docEnv) {
+        for (DocProcessor docProcessor : _docProcessors) {
+            docProcessor.processMethodDocWithDocEnv(methodDoc, methodDocType, docEnv);
+        }
+    }
+
+    @Override
+    public void processParamTagWithDocEnv(VariableElement parameter,
+                                          ParamDocType paramDocType,
+                                          DocletEnvironment docEnv) {
+        for (DocProcessor docProcessor : _docProcessors) {
+            docProcessor.processParamTagWithDocEnv(parameter, paramDocType, docEnv);
+        }
+    }
 }

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
@@ -157,7 +157,7 @@ public class ResourceDoclet implements Doclet {
                     ClassDocType classDocType = new ClassDocType();
                     classDocType.setClassName(element.getQualifiedName().toString());
                     classDocType.setCommentText(getComments(docCommentTree));
-                    docProcessor.processClassDoc(element, classDocType, docEnv);
+                    docProcessor.processClassDocWithDocEnv(element, classDocType, docEnv);
                     for (ExecutableElement method : ElementFilter.methodsIn(element.getEnclosedElements())) {
                         Map<DocTree.Kind, Map<String, String>> tags = getTags(docTrees.getDocCommentTree(method));
                         MethodTree methodTree = docTrees.getTree(method);
@@ -172,7 +172,7 @@ public class ResourceDoclet implements Doclet {
                             arguments.append(parameter.asType()).append(COMA);
                             if (paramDocType != null) {
                                 methodDocType.getParamDocs().add(paramDocType);
-                                docProcessor.processParamTag(parameter, paramDocType, docEnv);
+                                docProcessor.processParamTagWithDocEnv(parameter, paramDocType, docEnv);
                             }
                         }
                         // Remove last comma if there are parameters
@@ -181,7 +181,7 @@ public class ResourceDoclet implements Doclet {
                         }
                         arguments.append(")");
                         methodDocType.setMethodSignature(arguments.toString());
-                        docProcessor.processMethodDoc(method, methodDocType, docEnv);
+                        docProcessor.processMethodDocWithDocEnv(method, methodDocType, docEnv);
                         methodDocType.setRequestDoc(buildRequestDocType(tags));
                         methodDocType.setResponseDoc(buildResponseDocType(tags));
                         classDocType.getMethodDocs().add(methodDocType);

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
+++ b/ext/wadl-doclet/src/main/java12/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
@@ -157,7 +157,7 @@ public class ResourceDoclet implements Doclet {
                     ClassDocType classDocType = new ClassDocType();
                     classDocType.setClassName(element.getQualifiedName().toString());
                     classDocType.setCommentText(getComments(docCommentTree));
-                    docProcessor.processClassDoc(element, classDocType);
+                    docProcessor.processClassDoc(element, classDocType, docEnv);
                     for (ExecutableElement method : ElementFilter.methodsIn(element.getEnclosedElements())) {
                         Map<DocTree.Kind, Map<String, String>> tags = getTags(docTrees.getDocCommentTree(method));
                         MethodTree methodTree = docTrees.getTree(method);
@@ -172,7 +172,7 @@ public class ResourceDoclet implements Doclet {
                             arguments.append(parameter.asType()).append(COMA);
                             if (paramDocType != null) {
                                 methodDocType.getParamDocs().add(paramDocType);
-                                docProcessor.processParamTag(parameter, paramDocType);
+                                docProcessor.processParamTag(parameter, paramDocType, docEnv);
                             }
                         }
                         // Remove last comma if there are parameters
@@ -181,7 +181,7 @@ public class ResourceDoclet implements Doclet {
                         }
                         arguments.append(")");
                         methodDocType.setMethodSignature(arguments.toString());
-                        docProcessor.processMethodDoc(method, methodDocType);
+                        docProcessor.processMethodDoc(method, methodDocType, docEnv);
                         methodDocType.setRequestDoc(buildRequestDocType(tags));
                         methodDocType.setResponseDoc(buildResponseDocType(tags));
                         classDocType.getMethodDocs().add(methodDocType);


### PR DESCRIPTION
Current implementation of the `DocProcessor` provides access to types that extend the `Element` class such as `TypeElement`, `ExecutableElement` and `VariableElement`. However extracting javadoc from these is not possible without access to a `DocTrees` object, example shown in usages [here](https://openjdk.java.net/groups/compiler/using-new-doclet.html#tags). By providing access to the `DocletEnvironment` to the `DocProcessor` functions, we can get access to objects that can properly evaluate the javadoc of these elements. 