### PR TITLE
For OSGi services lookup use only classes assignable from service class

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/OsgiRegistry.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/OsgiRegistry.java
@@ -564,9 +564,8 @@ public final class OsgiRegistry implements SynchronousBundleListener {
                                 result.add(clazz);
                             } else if (LOGGER.isLoggable(Level.FINER)) {
                                 LOGGER.log(Level.FINER,
-                                    "Ignoring provider class " + clazz.getName() + " (in " + clazz.getModule() + ")"
-                                    + " because it is not assignable to " + serviceClass.getName()
-                                    + " (in " + serviceClass.getModule() + ")");
+                                    "Ignoring provider class " + clazz.getName() + " because it is not assignable to "
+                                    + " service class " + serviceClass.getName());
                             }
                         }
                     } catch (final Exception ex) {

--- a/core-common/src/main/java/org/glassfish/jersey/internal/OsgiRegistry.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/OsgiRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -115,7 +115,7 @@ public final class OsgiRegistry implements SynchronousBundleListener {
                 final ClassLoader loader,
                 final boolean ignoreOnClassNotFound) {
 
-            final List<Class<?>> providerClasses = locateAllProviders(serviceName);
+            final List<Class<?>> providerClasses = locateAllProviders(serviceClass);
             if (!providerClasses.isEmpty()) {
                 return new Iterator<T>() {
 
@@ -153,7 +153,7 @@ public final class OsgiRegistry implements SynchronousBundleListener {
         @Override
         public <T> Iterator<Class<T>> createClassIterator(
                 final Class<T> service, final String serviceName, final ClassLoader loader, final boolean ignoreOnClassNotFound) {
-            final List<Class<?>> providerClasses = locateAllProviders(serviceName);
+            final List<Class<?>> providerClasses = locateAllProviders(service);
             if (!providerClasses.isEmpty()) {
                 return new Iterator<Class<T>>() {
 
@@ -552,14 +552,18 @@ public final class OsgiRegistry implements SynchronousBundleListener {
         }
     }
 
-    private List<Class<?>> locateAllProviders(final String serviceName) {
+    private List<Class<?>> locateAllProviders(final Class<?> serviceClass) {
         lock.readLock().lock();
         try {
             final List<Class<?>> result = new LinkedList<Class<?>>();
             for (final Map<String, Callable<List<Class<?>>>> value : factories.values()) {
-                if (value.containsKey(serviceName)) {
+                if (value.containsKey(serviceClass.getName())) {
                     try {
-                        result.addAll(value.get(serviceName).call());
+                        for (final Class<?> clazz : value.get(serviceClass.getName()).call()) {
+                            if (serviceClass.isAssignableFrom(clazz)) {
+                                result.add(clazz);
+                            }
+                        }
                     } catch (final Exception ex) {
                         // ignore
                     }

--- a/core-common/src/main/java/org/glassfish/jersey/internal/OsgiRegistry.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/OsgiRegistry.java
@@ -562,6 +562,11 @@ public final class OsgiRegistry implements SynchronousBundleListener {
                         for (final Class<?> clazz : value.get(serviceClass.getName()).call()) {
                             if (serviceClass.isAssignableFrom(clazz)) {
                                 result.add(clazz);
+                            } else if (LOGGER.isLoggable(Level.FINER)) {
+                                LOGGER.log(Level.FINER,
+                                    "Ignoring provider class " + clazz.getName() + " (in " + clazz.getModule() + ")"
+                                    + " because it is not assignable to " + serviceClass.getName()
+                                    + " (in " + serviceClass.getModule() + ")");
                             }
                         }
                     } catch (final Exception ex) {


### PR DESCRIPTION
Closes #5036 
Prevent a situation when the provider class cannot be cast to service class by checking if the service class is assignable from the provider class.