### PR TITLE
Issue #5072 Revert "Make sure the default exception mapper is processed"

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java
@@ -449,10 +449,9 @@ public class ServerRuntime {
                         request.getResponseWriter().failure(responseError);
                     } finally {
                         completionCallbackRunner.onComplete(responseError);
-
-                        defaultMapperResponse = processResponseWithDefaultExceptionMapper(responseError, request);
                     }
 
+                    defaultMapperResponse = processResponseWithDefaultExceptionMapper(responseError, request);
                 }
 
             } finally {


### PR DESCRIPTION
- This reverts commit 38e5a53a179b4a26885cc2527312e9953ebfabf8.
- the change caused GlassFish stopped passing 4 tests in the JAXRS TCK:
  jaxrs/platform/container/completioncallback/*