### PR TITLE
[grizzly] Expose `start` argument while providing `parentContext`

### DIFF
--- a/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
+++ b/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -205,7 +205,7 @@ public final class GrizzlyHttpServerFactory {
      * @return newly created {@code HttpServer}.
      * @throws ProcessingException in case of any failure when creating a new {@code HttpServer} instance.
      * @see GrizzlyHttpContainer
-     * @since 3.1
+     * @since 2.37
      */
     public static HttpServer createHttpServer(final URI uri,
                                               final ResourceConfig config,
@@ -246,7 +246,7 @@ public final class GrizzlyHttpServerFactory {
      * @return newly created {@code HttpServer}.
      * @throws ProcessingException in case of any failure when creating a new {@code HttpServer} instance.
      * @see GrizzlyHttpContainer
-     * @since 3.1
+     * @since 2.37
      */
     public static HttpServer createHttpServer(final URI uri,
                                               final ResourceConfig config,

--- a/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
+++ b/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
@@ -194,6 +194,31 @@ public final class GrizzlyHttpServerFactory {
     /**
      * Create new {@link HttpServer} instance.
      *
+     * @param uri                   uri on which the {@link ApplicationHandler} will be deployed. Only first path
+     *                              segment will be used as context path, the rest will be ignored.
+     * @param config                web application configuration.
+     * @param secure                used for call {@link NetworkListener#setSecure(boolean)}.
+     * @param sslEngineConfigurator Ssl settings to be passed to {@link NetworkListener#setSSLEngineConfig}.
+     * @param parentContext         DI provider specific context with application's registered bindings.
+     * @param start                 if set to false, server will not get started, this allows end users to set
+     *                              additional properties on the underlying listener.
+     * @return newly created {@code HttpServer}.
+     * @throws ProcessingException in case of any failure when creating a new {@code HttpServer} instance.
+     * @see GrizzlyHttpContainer
+     * @since 3.1
+     */
+    public static HttpServer createHttpServer(final URI uri,
+                                              final ResourceConfig config,
+                                              final boolean secure,
+                                              final SSLEngineConfigurator sslEngineConfigurator,
+                                              final Object parentContext,
+                                              final boolean start) {
+        return createHttpServer(uri, new GrizzlyHttpContainer(config, parentContext), secure, sslEngineConfigurator, start);
+    }
+
+    /**
+     * Create new {@link HttpServer} instance.
+     *
      * @param uri           uri on which the {@link ApplicationHandler} will be deployed. Only first path
      *                      segment will be used as context path, the rest will be ignored.
      * @param config        web application configuration.
@@ -207,6 +232,27 @@ public final class GrizzlyHttpServerFactory {
                                               final ResourceConfig config,
                                               final Object parentContext) {
         return createHttpServer(uri, new GrizzlyHttpContainer(config, parentContext), false, null, true);
+    }
+
+    /**
+     * Create new {@link HttpServer} instance.
+     *
+     * @param uri           uri on which the {@link ApplicationHandler} will be deployed. Only first path
+     *                      segment will be used as context path, the rest will be ignored.
+     * @param config        web application configuration.
+     * @param parentContext DI provider specific context with application's registered bindings.
+     * @param start         if set to false, server will not get started, this allows end users to set
+     *                      additional properties on the underlying listener.
+     * @return newly created {@code HttpServer}.
+     * @throws ProcessingException in case of any failure when creating a new {@code HttpServer} instance.
+     * @see GrizzlyHttpContainer
+     * @since 3.1
+     */
+    public static HttpServer createHttpServer(final URI uri,
+                                              final ResourceConfig config,
+                                              final Object parentContext,
+                                              final boolean start) {
+        return createHttpServer(uri, new GrizzlyHttpContainer(config, parentContext), false, null, start);
     }
 
     /**


### PR DESCRIPTION
Exposes the `start` argument in the `createHttpServer` method to allow creating a non-started server.

This is necessary when wanting to register additional addons on the server listener before starting it.

Example:
```java
[...]

final HttpServer server = GrizzlyHttpServerFactory.createHttpServer(uri, resource, serviceLocator, false);

final WebSocketAddOn addon = new WebSocketAddOn();
server.getListeners().forEach(l -> l.registerAddOn(addon));

WebSocketEngine.getEngine().register(contextPath, "/ws", wsManager);

[...]
```