### PR TITLE
Abort JettyRequest when the response Future is completed exceptionally

### DIFF
--- a/connectors/jetty-connector/src/main/java/org/glassfish/jersey/jetty/connector/JettyConnector.java
+++ b/connectors/jetty-connector/src/main/java/org/glassfish/jersey/jetty/connector/JettyConnector.java
@@ -392,8 +392,8 @@ class JettyConnector implements Connector {
         final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
         final Throwable failure;
         try {
-            final CompletableFuture<ClientResponse> responseFuture =
-                    new CompletableFuture<ClientResponse>().whenComplete(
+            final CompletableFuture<ClientResponse> responseFuture = new CompletableFuture<ClientResponse>();
+            responseFuture.whenComplete(
                             (clientResponse, throwable) -> {
                                 if (throwable != null && throwable instanceof CancellationException) {
                                     // take care of future cancellation


### PR DESCRIPTION
Make sure the parent 'responseFuture' CompletableFuture is completed.
This ensures that the jettyRequest.abort() operation is actually performed.

Current situation prevent this code to be ever called as only the chained CompletableFuture is completed.