### PR TITLE
FISH-5723 Fixes WebappClassloader memory-leak issue by removing JAXRS…

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/util/collection/Cache.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/util/collection/Cache.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 package org.glassfish.jersey.internal.util.collection;
 
+import java.util.Enumeration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -105,6 +107,15 @@ public class Cache<K, V> implements Function<K, V> {
      */
     public void clear() {
         cache.clear();
+    }
+
+    /**
+     * Get the cache keys
+     *
+     * @return
+     */
+    public Enumeration<K> keys() {
+        return cache.keys();
     }
 
     /**

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,12 +59,16 @@ import javax.enterprise.inject.spi.AnnotatedConstructor;
 import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.BeforeShutdown;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.InjectionTarget;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.ProcessInjectionTarget;
 import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
 
 import org.glassfish.jersey.ext.cdi1x.internal.spi.InjectionManagerInjectedTarget;
 import org.glassfish.jersey.ext.cdi1x.internal.spi.InjectionManagerStore;
@@ -855,6 +859,11 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
                 beanManager.createAnnotatedType(ProcessJAXRSAnnotatedTypes.class),
                 "Jersey " + ProcessJAXRSAnnotatedTypes.class.getName()
         );
+    }
+
+    @SuppressWarnings("unused")
+    private void beforeShutDown(@Observes final BeforeShutdown beforeShutdown, final BeanManager beanManager) {
+        runtimeSpecifics.clearJaxRsResource(Thread.currentThread().getContextClassLoader());
     }
 
     /**

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProviderClientRuntimeSpecifics.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProviderClientRuntimeSpecifics.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,6 +21,7 @@ import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.ws.rs.core.Context;
 import java.lang.annotation.Annotation;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -59,4 +61,9 @@ class CdiComponentProviderClientRuntimeSpecifics implements CdiComponentProvider
     public boolean isJaxRsResource(Class<?> resource) {
         return false;
     }
+
+    @Override
+    public void clearJaxRsResource(ClassLoader loader) {
+    }
+
 }

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProviderRuntimeSpecifics.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProviderRuntimeSpecifics.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,4 +35,6 @@ interface CdiComponentProviderRuntimeSpecifics {
     boolean isAcceptableResource(Class<?> resource);
 
     boolean isJaxRsResource(Class<?> resource);
+
+    void clearJaxRsResource(ClassLoader loader);
 }

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProviderServerRuntimeSpecifics.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProviderServerRuntimeSpecifics.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,6 +49,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.util.Enumeration;
 
 /**
  * Server side runtime CDI ComponentProvider specific implementation.
@@ -223,6 +225,17 @@ class CdiComponentProviderServerRuntimeSpecifics implements CdiComponentProvider
     @Override
     public boolean isJaxRsResource(Class<?> resource) {
         return jaxRsResourceCache.apply(resource);
+    }
+
+    @Override
+    public void clearJaxRsResource(ClassLoader loader) {
+        Enumeration<Class<?>> keys = jaxRsResourceCache.keys();
+        while (keys.hasMoreElements()) {
+            Class<?> key = keys.nextElement();
+            if (key.getClassLoader() == loader) {
+                jaxRsResourceCache.remove(key);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
…Resources classes from cache on shutdown event (#5102)

* FISH-5723 Fixes WebappClassloader memory-leak issue by removing JAXRS Resources classes from cache on shutdown event

Signed-off-by: Gaurav Gupta <gaurav.gupta@payara.fish>