### PR TITLE
Prevent error with JDK19 related to Thread.Builder

### DIFF
--- a/containers/grizzly2-http/src/test/java/org/glassfish/jersey/grizzly2/httpserver/test/tools/JerseyHttpClientThread.java
+++ b/containers/grizzly2-http/src/test/java/org/glassfish/jersey/grizzly2/httpserver/test/tools/JerseyHttpClientThread.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -23,7 +24,7 @@ import org.glassfish.jersey.client.ClientConfig;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Invocation.Builder;
+import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 
@@ -50,7 +51,7 @@ public class JerseyHttpClientThread extends ClientThread {
     @Override
     public void doGetAndCheckResponse() throws Throwable {
         final WebTarget path = client.target(getSettings().targetUri.toString());
-        final Builder builder = path.request();
+        final Invocation.Builder builder = path.request();
         final Response response = builder.get();
         final String responseMsg = response.readEntity(String.class);
         assertEquals(200, response.getStatus());


### PR DESCRIPTION
Prevents JDK19 compilation error once this branch is update with JDK19 changes:
https://github.com/eclipse-ee4j/jersey/pull/5124#issuecomment-1218473515

Running `mvn clean install -DskipTests` in jersey/containers/grizzly2-http:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.080 s
[INFO] Finished at: 2022-08-18T09:24:10+02:00
[INFO] ------------------------------------------------------------------------
jbescos@jbescos-TECRA-X40-E:~/workspace/jersey/containers/grizzly2-http$ mvn --version
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /home/jbescos/programs/apache-maven-3.6.3
Java version: 19-ea, vendor: Oracle Corporation, runtime: /home/jbescos/programs/java/jdk-19
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "5.4.0-107-generic", arch: "amd64", family: "unix"

```