### PR TITLE
Bump SLF4J API to version 2.0.2

### DIFF
--- a/connectors/jetty-connector/pom.xml
+++ b/connectors/jetty-connector/pom.xml
@@ -44,10 +44,22 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -137,11 +149,23 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-client</artifactId>
                     <version>${jetty.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-util</artifactId>
                     <version>${jetty.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
             <build>

--- a/containers/jetty-http/pom.xml
+++ b/containers/jetty-http/pom.xml
@@ -45,6 +45,10 @@
                     <groupId>org.eclipse.jetty.toolchain</groupId>
                     <artifactId>jetty-jakarta-servlet-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/containers/jetty-servlet/pom.xml
+++ b/containers/jetty-servlet/pom.xml
@@ -107,6 +107,10 @@
                             <groupId>org.eclipse.jetty</groupId>
                             <artifactId>jetty-server</artifactId>
                         </exclusion>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
                     </exclusions>
                 </dependency>
                 <dependency>
@@ -162,6 +166,12 @@
                 <dependency>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-webapp</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish.jersey.containers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2150,7 +2150,7 @@
         <enforcer.version>3.1.0</enforcer.version>
 
         <!--versions, extracted here due to maven-enforcer-plugin -->
-        <slf4j.version>2.0.1</slf4j.version>
+        <slf4j.version>2.0.2</slf4j.version>
         <commons.codec.version>1.15</commons.codec.version>
         <reactive.streams.version>1.0.3</reactive.streams.version>
         <com.uber.jaeger.version>0.27.0</com.uber.jaeger.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2150,7 +2150,7 @@
         <enforcer.version>3.1.0</enforcer.version>
 
         <!--versions, extracted here due to maven-enforcer-plugin -->
-        <slf4j.version>2.0.0-alpha6</slf4j.version>
+        <slf4j.version>2.0.1</slf4j.version>
         <commons.codec.version>1.15</commons.codec.version>
         <reactive.streams.version>1.0.3</reactive.streams.version>
         <com.uber.jaeger.version>0.27.0</com.uber.jaeger.version>


### PR DESCRIPTION
SLF4J 2.0.0, 2.0.1, and 2.0.2 have been released recently.

https://www.slf4j.org/news.html

> # 2022-09-20 - Release of SLF4J 2.0.2
> - Fixed bug in the setContextMap() method of Reload4jMDCAdapter. This issue was reported in [SLF4J-563](https://jira.qos.ch/browse/SLF4J-563) by Michael Wartes.
> - The binary of this version can be reproduced by checking out the tag v_2.0.2 from the source code repository (GitHub). Release built using Java "18" 2022-03-22 build 18+36-2087 under Linux Debian 11.2.
> # 2022-09-14 - Release of SLF4J 2.0.1
> - The Logger.makeLoggingEventBuilder method semantics has changed so that overriding implementations should now always build a new LoggingEventBuilder instance as appropraiate for the implementation, i.e the logging backend. For more details see [SLF4J-560](https://jira.qos.ch/browse/SLF4J-560).
> - Deprecated unused LoggerFactoryBinder and MarkerFactoryBinder classes. This issue was raised in [SLF4J-555](https://jira.qos.ch/browse/SLF4J-555) by Witalij Berdinskich who provided the relevant patch.
> - The binary of this version can be reproduced by checking out the tag v_2.0.1 from the source code repository (GitHub). Release built using Java "18" 2022-03-22 build 18+36-2087 under Linux Debian 11.2.
> 
> # 2022-08-20 - Release of SLF4J 2.0.0
> The the 2.0.x series requires Java 8 and adds a backward-compatible [fluent logging api](https://www.slf4j.org/manual.html#fluent).
> 
> Moreover, SLF4J has been modularized per [JPMS/Jigsaw](http://openjdk.java.net/projects/jigsaw/spec/) specification. The resulting internal changes are [detailed](https://www.slf4j.org/faq.html#changesInVersion200) in the FAQ page.
SLF4J 2.0.x series requires Java 8. It builds upon the 1.8.x series and adds a backward-compatible [fluent logging api](https://www.slf4j.org/manual.html#fluent). By backward-compatible, we mean that existing logging frameworks do not have to be changed for the user to benefit from the fluent logging API. However, existing frameworks must migrate to the ServiceLoader mechanism. The resulting internal changes are [detailed](https://www.slf4j.org/faq.html#changesInVersion200) in the FAQ page.
> - Except minor javadoc changes, this release is identical to 2.0.0-beta1 released earlier this month.
> - The binary of this version can be reproduced by checking out the tag v_2.0.0 from the source code repository (GitHub). Release built using Java "18" 2022-03-22 build 18+36-2087 under Linux Debian 11.2.