### PR TITLE
Default exception mapper processing

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/ExceptionMapperFactory.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/ExceptionMapperFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -179,6 +179,11 @@ public class ExceptionMapperFactory implements ExceptionMappers {
             Set<ExceptionMapperType> exceptionMapperTypes = new LinkedHashSet<>();
             for (ServiceHolder<ExceptionMapper> mapperHandle: mapperHandles) {
                 ExceptionMapper mapper = mapperHandle.getInstance();
+
+                // the default exception mapper is processed by the ServerRuntime
+                if ("org.glassfish.jersey.server.DefaultExceptionMapper".equals(mapper.getClass().getName())) {
+                    continue;
+                }
 
                 if (Proxy.isProxyClass(mapper.getClass())) {
                     SortedSet<Class<? extends ExceptionMapper>> mapperTypes =

--- a/core-server/pom.xml
+++ b/core-server/pom.xml
@@ -243,6 +243,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/core-server/src/test/java/org/glassfish/jersey/server/DefaultExceptionMapperTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/DefaultExceptionMapperTest.java
@@ -22,11 +22,14 @@ import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.CompletionCallback;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.internal.ExceptionMapperFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultExceptionMapperTest {
     public static final String MESSAGE = "DefaultExceptionMapperTest I/O Exception";
@@ -56,6 +59,17 @@ public class DefaultExceptionMapperTest {
         }
 
         Assert.assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void testDefaultExceptionMapperNotRegisteredInExceptionMapperFactory() {
+        ResourceConfig resourceConfig = new ResourceConfig();
+        ApplicationHandler applicationHandler = new ApplicationHandler(resourceConfig);
+
+        // use InjectionManager from ApplicationHandler to set up the default bindings
+        ExceptionMapperFactory exceptionMapperFactory = new ExceptionMapperFactory(applicationHandler.getInjectionManager());
+
+        assertThat(exceptionMapperFactory.find(Throwable.class)).isNull();
     }
 
     @Path("/")


### PR DESCRIPTION
Fixes #5192 

### Problem
The default exception mapper is registered by default in Jersey 3.1.0 and is made avilable through `ExceptionMapperFactory`. If an other exception mapper is registered as `ExceptionMapper<Throwable>`, the first one found will be used. This can lead to a reordering issue where the default exception mapper will be found first.

The `ServerRuntime` additionally won't handle exceptions, if the default exception mapper is returned by `ExceptionMapperFactory.findMapping(...)` (see [here](https://github.com/zUniQueX/jersey/blob/3.1/core-server/src/main/java/org/glassfish/jersey/server/ServerRuntime.java#L556)) and instead will handle the exception with the default exception mapper in a separate method.

### Solution
The proposed change in this PR is to avoid registration of the default exception mapper in the `ExceptionMapperFactory`. This will leave the exception mapper resolving logic as it was in Jersey 3.0.x and provide users the ability to register an `ExceptionMapper<Throwable>`. If none is set, the `ServerRuntime` will eventually handle the exception afterwards because no exception mapper is found.