### PR TITLE
Fix FORM_PARAM_CONSUMED warning

### DIFF
--- a/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/WebComponent.java
+++ b/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/WebComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/WebComponent.java
+++ b/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/WebComponent.java
@@ -603,7 +603,7 @@ public class WebComponent {
                 final String name = (String) parameterNames.nextElement();
                 final List<String> values = Arrays.asList(servletRequest.getParameterValues(name));
 
-                List<String> filteredValues = keepQueryParams ? values : filterQueryParams(name, values, queryParams);
+                final List<String> filteredValues = keepQueryParams ? values : filterQueryParams(name, values, queryParams);
 
                 if (!filteredValues.isEmpty()) {
                     formMap.put(name, filteredValues);

--- a/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/WebComponent.java
+++ b/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/WebComponent.java
@@ -603,7 +603,11 @@ public class WebComponent {
                 final String name = (String) parameterNames.nextElement();
                 final List<String> values = Arrays.asList(servletRequest.getParameterValues(name));
 
-                formMap.put(name, keepQueryParams ? values : filterQueryParams(name, values, queryParams));
+                List<String> filteredValues = keepQueryParams ? values : filterQueryParams(name, values, queryParams);
+
+                if (!filteredValues.isEmpty()) {
+                    formMap.put(name, filteredValues);
+                }
             }
 
             if (!formMap.isEmpty()) {


### PR DESCRIPTION
When request `Content-type` header equals to
`application/x-www-form-urlencoded` and request contains query params
then query params will be treated as form params.  And jersey will
print a FORM_PARAM_CONSUMED warning log message.

This behavior should be configured by
`jersey.config.servlet.form.queryParams.disabled` property.

With this property set to `true` query params are not converted to form
params but due to bug FORM_PARAM_CONSUMED warning is still printed.
