### PR TITLE
Don't Specify Wildcard Package OSGi Version for MicroProfile Rest Client

### DIFF
--- a/ext/microprofile/mp-rest-client/pom.xml
+++ b/ext/microprofile/mp-rest-client/pom.xml
@@ -114,7 +114,6 @@
                         <Import-Package>
                             ${cdi.osgi.version},
                             jakarta.decorator.*;version="[3.0,5)",
-                            org.eclipse.microprofile.rest.client.*;version="[3.0,4)",
                             org.eclipse.microprofile.config.*;version="!",
                             *
                         </Import-Package>

--- a/ext/microprofile/mp-rest-client/pom.xml
+++ b/ext/microprofile/mp-rest-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
Not sure if this is the current "HEAD" branch or not - I'm trying to patch Jersey 3.1.

The OSGi package versions for MicroProfile Rest Client don't conform to the project version.
In the Rest Client 3.0 API jar, the packages are exported as such:
* `org.eclipse.microprofile.rest.client;version="2.0"`
* `org.eclipse.microprofile.rest.client.annotation;version="1.1.1"`
* `org.eclipse.microprofile.rest.client.ext;version="2.0"`
* `org.eclipse.microprofile.rest.client.inject;version="2.0"`
* `org.eclipse.microprofile.rest.client.spi;version="1.1.1"`

And Jersey with its current configuration imports the following:
* `org.eclipse.microprofile.rest.client;version="[3.0,4)"`
* `org.eclipse.microprofile.rest.client.annotation;version="[3.0,4)"`
* `org.eclipse.microprofile.rest.client.ext;version="[3.0,4)"`
* `org.eclipse.microprofile.rest.client.inject;version="[3.0,4)"`
* `org.eclipse.microprofile.rest.client.spi;version="[3.0,4)"`

This change should make it so the imports are as follows:
* `org.eclipse.microprofile.rest.client;version="[2.0,3)"`
* `org.eclipse.microprofile.rest.client.annotation;version="[1.1,2)"`
* `org.eclipse.microprofile.rest.client.ext;version="[2.0,3)"`
* `org.eclipse.microprofile.rest.client.inject;version="[2.0,3)"`
* `org.eclipse.microprofile.rest.client.spi;version="[1.1,2)"`

Signed-off-by: Andrew Pielage <pandrex247@hotmail.com>