### PR TITLE
Proxy client enhancements

### DIFF
--- a/ext/proxy-client/pom.xml
+++ b/ext/proxy-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,10 +61,24 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-bundle</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/InstrumentedProxyClient.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/InstrumentedProxyClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.client.proxy;
+
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import java.lang.reflect.Method;
+
+public interface InstrumentedProxyClient {
+    default WebTarget instrumentWebTarget(final WebTarget webTarget, final Method origin, final Object[] args) {
+        return webTarget;
+    }
+
+    default Invocation.Builder instrumentInvocationBuilder(
+            final Invocation.Builder invocationBuilder,
+            final Method origin,
+            final Object[] args) {
+        return invocationBuilder;
+    }
+}

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,14 +19,17 @@ package org.glassfish.jersey.client.proxy;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 
 public class MyResource implements MyResourceIfc {
 
     @Context HttpHeaders headers;
+    @Context UriInfo uriInfo;
 
     @Override
     public String getIt() {
@@ -162,5 +165,10 @@ public class MyResource implements MyResourceIfc {
     @Override
     public String putIt(MyBean dummyBean) {
         return headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
+    }
+
+    @Override
+    public Map<String, List<String>> instrumentQueryParams() {
+        return uriInfo.getQueryParameters();
     }
 }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceIfc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package org.glassfish.jersey.client.proxy;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -37,7 +38,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
 @Path("myresource")
-public interface MyResourceIfc {
+public interface MyResourceIfc extends MyResourceInstrumentation {
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     String getIt();
@@ -171,4 +172,9 @@ public interface MyResourceIfc {
     @PUT
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     String putIt(MyBean dummyBean);
+
+    @Path("instrumentation")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, List<String>> instrumentQueryParams();
 }

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceInstrumentation.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceInstrumentation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.client.proxy;
+
+import javax.ws.rs.client.WebTarget;
+import java.lang.reflect.Method;
+
+public interface MyResourceInstrumentation extends InstrumentedProxyClient {
+    @Override
+    default WebTarget instrumentWebTarget(final WebTarget webTarget, final Method origin, final Object[] args) {
+        if ("instrumentQueryParams".equals(origin.getName())) {
+            return webTarget.queryParam("key1", "value1").queryParam("key2", "value2");
+        }
+        return webTarget;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1621,6 +1621,12 @@
             </dependency>
 
             <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${bytebuddy.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.glassfish.grizzly</groupId>
                 <artifactId>grizzly-http-server</artifactId>
                 <version>${grizzly2.version}</version>
@@ -2015,6 +2021,12 @@
                 <version>${testng.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.core.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -2163,7 +2175,9 @@
         <!-- asm is now source integrated - keeping this property to see the version -->
         <!-- see core-server/src/main/java/jersey/repackaged/asm/.. -->
         <asm.version>9.4</asm.version>
+        <assertj.core.version>3.21.0</assertj.core.version>
         <bnd.plugin.version>2.3.6</bnd.plugin.version>
+        <bytebuddy.version>1.12.22</bytebuddy.version>
         <commons.io.version>2.11.0</commons.io.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <commons.logging.version>1.2</commons.logging.version>


### PR DESCRIPTION
This PR provides several enhancements to the `proxy-client` module:
 - address deprecation of `AccessController`: The `AccessController` class is deprecated since Java 17 and marked for removal. The proposed change tries to use an `AccessController` if possible and uses a fallback otherwise.
 - parameterize raw generic types: Some generic types were used without generic type arguments and therefore produce warnings. Adding `<?>` as generic type argument fixes this problem.
 - change proxy library: `java.lang.reflect.Proxy` can proxy simple interfaces only. ByteBuddy provides a more sophisticated proxying mechanism and can proxy arbitrary types. This allows for example the execution of custom code in the interface's default methods since these aren't forwarded to the proxy any more.
 - add client instrumentations: Currently the client builds its request without the possibility to modify it. Sometimes, there is the need to modify the request (e.g. for adding dynamic query parameters). The `InstrumentedProxyClient` interface provides a SPI to modify the `WebTarget` and the `Invocation.Builder` if necessary.