### PR TITLE
No longer mark ByteArrayInputStream in LoggingInterceptor

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
+++ b/core-common/src/main/java/org/glassfish/jersey/logging/LoggingInterceptor.java
@@ -17,6 +17,7 @@
 package org.glassfish.jersey.logging;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -216,7 +217,9 @@ abstract class LoggingInterceptor implements WriterInterceptor {
         if (!stream.markSupported()) {
             stream = new BufferedInputStream(stream);
         }
-        stream.mark(maxEntitySize + 1);
+        if (!(stream instanceof ByteArrayInputStream)) {
+          stream.mark(maxEntitySize + 1);
+        }        
         final byte[] entity = new byte[maxEntitySize + 1];
 
         int entitySize = 0;


### PR DESCRIPTION
If the entity has been buffered before with (response.bufferEntity), we'll receive a ByteArrayInputStream here. Calling response.readEntity(...) will always return null, because the marking of a ByteArrayInputStream behaves different then for other streams.