### PR TITLE
Changes to InterceptorInvocationContext related to the integration with Helidon

### DIFF
--- a/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/InterceptorInvocationContext.java
+++ b/ext/microprofile/mp-rest-client/src/main/java/org/glassfish/jersey/microprofile/restclient/InterceptorInvocationContext.java
@@ -31,7 +31,7 @@ import javax.ws.rs.client.WebTarget;
  * Invokes all interceptors bound to the target.
  *
  * This approach needs to be used due to CDI does not handle properly interceptor invocation
- * on proxy instances.
+ * on proxy instances. This class is thread safe.
  *
  * @author David Kral
  */
@@ -42,8 +42,8 @@ class InterceptorInvocationContext implements InvocationContext {
     private final Map<String, Object> contextData;
     private final List<InvocationInterceptor> interceptors;
     private final WebTarget classLevelWebTarget;
-    private Object[] args;
-    private int currentPosition;
+    private volatile Object[] args;
+    private final int currentPosition;
 
     /**
      * Creates new instance of InterceptorInvocationContext.
@@ -57,14 +57,23 @@ class InterceptorInvocationContext implements InvocationContext {
                                  MethodModel methodModel,
                                  Method method,
                                  Object[] args) {
-        this.contextData = new HashMap<>();
         this.currentPosition = 0;
+        this.contextData = new HashMap<>();
         this.methodModel = methodModel;
         this.method = method;
         this.args = args;
         this.classLevelWebTarget = classLevelWebTarget;
         this.interceptors = methodModel.getInvocationInterceptors();
+    }
 
+    InterceptorInvocationContext(InterceptorInvocationContext other, int currentPosition) {
+        this.currentPosition = currentPosition;
+        this.contextData = other.contextData;
+        this.methodModel = other.methodModel;
+        this.method = other.method;
+        this.args = other.args;
+        this.classLevelWebTarget = other.classLevelWebTarget;
+        this.interceptors = other.interceptors;
     }
 
     @Override
@@ -102,10 +111,21 @@ class InterceptorInvocationContext implements InvocationContext {
         return contextData;
     }
 
+    /**
+     * This method shall create the next invocation context using {@code position + 1}
+     * and store it in the {@code contextData} map. This is currently used by Helidon's
+     * fault tolerance implementation to get around a problem with CDI's default invocation
+     * context {@code WeldInvocationContextImpl} not correctly supporting async calls.
+     *
+     * @return value returned by intercepted method.
+     */
     @Override
     public Object proceed() {
+        InvocationContext nextContext = new InterceptorInvocationContext(this, currentPosition + 1);
+        contextData.put(getClass().getName(), nextContext);     // accessible to FT interceptor
+
         if (currentPosition < interceptors.size()) {
-            return interceptors.get(currentPosition++).intercept(this);
+            return interceptors.get(currentPosition).intercept(nextContext);
         } else {
             return methodModel.invokeMethod(classLevelWebTarget, method, args);
         }


### PR DESCRIPTION
Changes to InterceptorInvocationContext related to the integration with Helidon's FT implementation. Allow context to be accessed from different threads, and store it in the context data map.