### PR TITLE
Using Java7+ NIO API for improved performance

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/SslConfigurator.java
+++ b/core-common/src/main/java/org/glassfish/jersey/SslConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,11 @@
 package org.glassfish.jersey;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -635,7 +636,7 @@ public final class SslConfigurator {
                     if (keyStoreBytes != null) {
                         keyStoreInputStream = new ByteArrayInputStream(keyStoreBytes);
                     } else if (!keyStoreFile.equals("NONE")) {
-                        keyStoreInputStream = new FileInputStream(keyStoreFile);
+                        keyStoreInputStream = Files.newInputStream(Paths.get(keyStoreFile));
                     }
                     _keyStore.load(keyStoreInputStream, keyStorePass);
                 } finally {
@@ -710,7 +711,7 @@ public final class SslConfigurator {
                     if (trustStoreBytes != null) {
                         trustStoreInputStream = new ByteArrayInputStream(trustStoreBytes);
                     } else if (!trustStoreFile.equals("NONE")) {
-                        trustStoreInputStream = new FileInputStream(trustStoreFile);
+                        trustStoreInputStream = Files.newInputStream(Paths.get(trustStoreFile));
                     }
                     _trustStore.load(trustStoreInputStream, trustStorePass);
                 } finally {

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/AbstractMessageReaderWriterProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/AbstractMessageReaderWriterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import java.io.Writer;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.MessageBodyReader;
@@ -42,8 +43,11 @@ public abstract class AbstractMessageReaderWriterProvider<T> implements MessageB
 
     /**
      * The UTF-8 Charset.
+     *
+     * @deprecated use {@code StandardCharsets.UTF_8} instead.
      */
-    public static final Charset UTF8 = ReaderWriter.UTF8;
+    @Deprecated(forRemoval = true)
+    public static final Charset UTF8 = StandardCharsets.UTF_8;
 
     /**
      * Reader bytes from an input stream and write then to an output stream.
@@ -51,7 +55,10 @@ public abstract class AbstractMessageReaderWriterProvider<T> implements MessageB
      * @param in  the input stream to read from.
      * @param out the output stream to write to.
      * @throws IOException if there is an error reading or writing bytes.
+     *
+     * @deprecated use {@code ReaderWriter.writeTo(in, out)} instead.
      */
+    @Deprecated
     public static void writeTo(InputStream in, OutputStream out) throws IOException {
         ReaderWriter.writeTo(in, out);
     }
@@ -62,7 +69,10 @@ public abstract class AbstractMessageReaderWriterProvider<T> implements MessageB
      * @param in  the reader to read from.
      * @param out the writer to write to.
      * @throws IOException if there is an error reading or writing characters.
+     *
+     * @deprecated use {@code ReaderWriter.writeTo(in, out)} instead.
      */
+    @Deprecated
     public static void writeTo(Reader in, Writer out) throws IOException {
         ReaderWriter.writeTo(in, out);
     }

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/AbstractMessageReaderWriterProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/AbstractMessageReaderWriterProvider.java
@@ -46,7 +46,7 @@ public abstract class AbstractMessageReaderWriterProvider<T> implements MessageB
      *
      * @deprecated use {@code StandardCharsets.UTF_8} instead.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static final Charset UTF8 = StandardCharsets.UTF_8;
 
     /**

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/FileProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/FileProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,16 +16,14 @@
 
 package org.glassfish.jersey.message.internal;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -62,13 +60,8 @@ public final class FileProvider extends AbstractMessageReaderWriterProvider<File
                          final MultivaluedMap<String, String> httpHeaders,
                          final InputStream entityStream) throws IOException {
         final File file = Utils.createTempFile();
-        final OutputStream stream = new BufferedOutputStream(new FileOutputStream(file));
 
-        try {
-            writeTo(entityStream, stream);
-        } finally {
-            stream.close();
-        }
+        Files.copy(entityStream, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
         return file;
     }
@@ -89,13 +82,7 @@ public final class FileProvider extends AbstractMessageReaderWriterProvider<File
                         final MediaType mediaType,
                         final MultivaluedMap<String, Object> httpHeaders,
                         final OutputStream entityStream) throws IOException {
-        final InputStream stream = new BufferedInputStream(new FileInputStream(t), ReaderWriter.BUFFER_SIZE);
-
-        try {
-            writeTo(stream, entityStream);
-        } finally {
-            stream.close();
-        }
+        Files.copy(t.toPath(), entityStream);
     }
 
     @Override

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java
@@ -245,9 +245,9 @@ public final class ReaderWriter {
      * @throws IOException in case of a write failure.
      */
     public static void writeToAsString(String s, OutputStream out, MediaType type) throws IOException {
-        try (final Writer osw = new OutputStreamWriter(out, getCharset(type))) {
-            osw.write(s);
-        }
+        Writer osw = new OutputStreamWriter(out, getCharset(type));
+        osw.write(s);
+        osw.flush();
     }
 
     /**

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java
@@ -19,12 +19,12 @@ package org.glassfish.jersey.message.internal;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,8 +54,11 @@ public final class ReaderWriter {
     private static final Logger LOGGER = Logger.getLogger(ReaderWriter.class.getName());
     /**
      * The UTF-8 Charset.
+     *
+     * @deprecated use {@code StandardCharsets.UTF_8} instead
      */
-    public static final Charset UTF8 = Charset.forName("UTF-8");
+    @Deprecated(forRemoval = true)
+    public static final Charset UTF8 = StandardCharsets.UTF_8;
     /**
      * The buffer size for arrays of byte and character.
      */
@@ -167,7 +170,7 @@ public final class ReaderWriter {
 
     /**
      * Java 9+ InputStream::readAllBytes
-     * TODO Replace when Java 8 not any longer supported (3.1+)
+     * TODO Replace in Jersey 4.0, as the sole difference to OpenJDK is working around a bug in the input stream.
      */
     private static byte[] readAllBytes(InputStream inputStream) throws IOException {
         List<byte[]> bufs = null;
@@ -242,9 +245,9 @@ public final class ReaderWriter {
      * @throws IOException in case of a write failure.
      */
     public static void writeToAsString(String s, OutputStream out, MediaType type) throws IOException {
-        Writer osw = new OutputStreamWriter(out, getCharset(type));
-        osw.write(s, 0, s.length());
-        osw.flush();
+        try (final Writer osw = new OutputStreamWriter(out, getCharset(type))) {
+            osw.write(s);
+        }
     }
 
     /**

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java
@@ -57,7 +57,7 @@ public final class ReaderWriter {
      *
      * @deprecated use {@code StandardCharsets.UTF_8} instead
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static final Charset UTF8 = StandardCharsets.UTF_8;
     /**
      * The buffer size for arrays of byte and character.

--- a/core-common/src/test/java/org/glassfish/jersey/message/internal/UtilsTest.java
+++ b/core-common/src/test/java/org/glassfish/jersey/message/internal/UtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,22 +22,19 @@ import org.junit.jupiter.api.Test;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 
 public class UtilsTest {
 
     @Test
     public void createTempFile() throws IOException {
         final File file = Utils.createTempFile();
-        final OutputStream stream = new BufferedOutputStream(new FileOutputStream(file));
 
-        try {
+        try (final OutputStream stream = new BufferedOutputStream(Files.newOutputStream(file.toPath()))) {
             final ByteArrayInputStream entityStream = new ByteArrayInputStream("Test stream byte input".getBytes());
             ReaderWriter.writeTo(entityStream, stream);
-        } finally {
-            stream.close();
         }
         Assertions.assertTrue(file.exists());
     }

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/FileSchemeResourceFinderFactory.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/FileSchemeResourceFinderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,10 @@
 package org.glassfish.jersey.server.internal.scanning;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -140,8 +140,8 @@ final class FileSchemeResourceFinderFactory implements UriSchemeResourceFinderFa
                 @Override
                 public InputStream open() {
                     try {
-                        return new FileInputStream(current);
-                    } catch (final FileNotFoundException e) {
+                        return Files.newInputStream(current.toPath());
+                    } catch (final IOException e) {
                         throw new ResourceFinderException(e);
                     }
                 }

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/FilesScanner.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/FilesScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,10 +17,9 @@
 package org.glassfish.jersey.server.internal.scanning;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.NoSuchElementException;
 import java.util.Stack;
 
@@ -60,7 +59,7 @@ public final class FilesScanner extends AbstractResourceFinderAdapter {
     private void processFile(final File f) {
         if (f.getName().endsWith(".jar") || f.getName().endsWith(".zip")) {
             try {
-                compositeResourceFinder.push(new JarFileScanner(new FileInputStream(f), "", true));
+                compositeResourceFinder.push(new JarFileScanner(Files.newInputStream(f.toPath()), "", true));
             } catch (final IOException e) {
                 // logging might be sufficient in this case
                 throw new ResourceFinderException(e);
@@ -117,8 +116,8 @@ public final class FilesScanner extends AbstractResourceFinderAdapter {
                 @Override
                 public InputStream open() {
                     try {
-                        return new FileInputStream(current);
-                    } catch (final FileNotFoundException e) {
+                        return Files.newInputStream(current.toPath());
+                    } catch (final IOException e) {
                         throw new ResourceFinderException(e);
                     }
                 }

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/JarZipSchemeResourceFinderFactory.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/scanning/JarZipSchemeResourceFinderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,12 +16,13 @@
 
 package org.glassfish.jersey.server.internal.scanning;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -140,7 +141,7 @@ final class JarZipSchemeResourceFinderFactory implements UriSchemeResourceFinder
      * if that fails with a {@link java.net.MalformedURLException} then the method will
      * attempt to create a {@link InputStream} instance as follows:
      * <pre>
-     *  return new new FileInputStream(
+     *  return Files.newInputStream(
      *      UriComponent.decode(jarUrlString, UriComponent.Type.PATH)));
      * </pre>
      *
@@ -153,8 +154,8 @@ final class JarZipSchemeResourceFinderFactory implements UriSchemeResourceFinder
         try {
             return new URL(jarUrlString).openStream();
         } catch (final MalformedURLException e) {
-            return new FileInputStream(
-                    UriComponent.decode(jarUrlString, UriComponent.Type.PATH));
+            return Files.newInputStream(
+                    Paths.get(UriComponent.decode(jarUrlString, UriComponent.Type.PATH)));
         }
     }
 }

--- a/core-server/src/main/java/org/glassfish/jersey/server/wadl/internal/generators/WadlGeneratorApplicationDoc.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/wadl/internal/generators/WadlGeneratorApplicationDoc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,8 +17,8 @@
 package org.glassfish.jersey.server.wadl.internal.generators;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 
 import javax.ws.rs.core.Context;
@@ -103,7 +103,7 @@ public class WadlGeneratorApplicationDoc implements WadlGenerator {
 
         InputStream inputStream;
         if (_applicationDocsFile != null) {
-            inputStream = new FileInputStream(_applicationDocsFile);
+            inputStream = Files.newInputStream(_applicationDocsFile.toPath());
         } else {
             inputStream = _applicationDocsStream;
         }

--- a/core-server/src/main/java/org/glassfish/jersey/server/wadl/internal/generators/WadlGeneratorGrammarsSupport.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/wadl/internal/generators/WadlGeneratorGrammarsSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,8 +17,8 @@
 package org.glassfish.jersey.server.wadl.internal.generators;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -116,7 +116,7 @@ public class WadlGeneratorGrammarsSupport implements WadlGenerator {
                     + " is set, one of both is required.");
         }
         _delegate.init();
-        _grammars = WadlUtils.unmarshall(_grammarsFile != null ? new FileInputStream(_grammarsFile) : _grammarsStream,
+        _grammars = WadlUtils.unmarshall(_grammarsFile != null ? Files.newInputStream(_grammarsFile.toPath()) : _grammarsStream,
                 saxFactoryProvider.get(), Grammars.class);
     }
 

--- a/core-server/src/main/java/org/glassfish/jersey/server/wadl/internal/generators/resourcedoc/WadlGeneratorResourceDocSupport.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/wadl/internal/generators/resourcedoc/WadlGeneratorResourceDocSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,8 +17,8 @@
 package org.glassfish.jersey.server.wadl.internal.generators.resourcedoc;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -128,7 +128,8 @@ public class WadlGeneratorResourceDocSupport implements WadlGenerator {
         }
         delegate.init();
 
-        try (final InputStream inputStream = resourceDocFile != null ? new FileInputStream(resourceDocFile) : resourceDocStream) {
+        try (final InputStream inputStream = resourceDocFile != null ? Files.newInputStream(resourceDocFile.toPath())
+                : resourceDocStream) {
             final ResourceDocType resourceDocType =
                     WadlUtils.unmarshall(inputStream, saxFactoryProvider.get(), ResourceDocType.class);
             resourceDoc = new ResourceDocAccessor(resourceDocType);

--- a/core-server/src/test/java/org/glassfish/jersey/server/JarUtils.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/JarUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,10 +19,10 @@ package org.glassfish.jersey.server;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -71,7 +71,7 @@ public final class JarUtils {
         tempJar.deleteOnExit();
         final JarOutputStream jos = new JarOutputStream(
                 new BufferedOutputStream(
-                        new FileOutputStream(tempJar)), new Manifest());
+                        Files.newOutputStream(tempJar.toPath())), new Manifest());
 
         final Set<String> usedSegments = new HashSet<String>();
         for (final Map.Entry<String, String> entry : entries.entrySet()) {
@@ -90,7 +90,7 @@ public final class JarUtils {
             jos.putNextEntry(e);
 
             final InputStream f = new BufferedInputStream(
-                    new FileInputStream(base + entry.getKey()));
+                    Files.newInputStream(Paths.get(base + entry.getKey())));
             final byte[] buf = new byte[1024];
             int read = 1024;
             while ((read = f.read(buf, 0, read)) != -1) {

--- a/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/JarFileScannerTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/internal/scanning/JarFileScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,9 +16,10 @@
 
 package org.glassfish.jersey.server.internal.scanning;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -113,7 +114,7 @@ public class JarFileScannerTest {
     private int countJarEntriesUsingScanner(final String parent, final boolean recursive) throws IOException {
         int scannedEntryCount = 0;
 
-        try (final InputStream jaxRsApi = new FileInputStream(this.jaxRsApiPath)) {
+        try (final InputStream jaxRsApi = Files.newInputStream(Paths.get(this.jaxRsApiPath))) {
             final JarFileScanner jarFileScanner = new JarFileScanner(jaxRsApi, parent, recursive);
             while (jarFileScanner.hasNext()) {
                 // Fetch next entry.
@@ -135,7 +136,7 @@ public class JarFileScannerTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testClassEnumerationWithNonexistentPackage(final boolean recursive) throws IOException {
-        try (final InputStream jaxRsApi = new FileInputStream(this.jaxRsApiPath)) {
+        try (final InputStream jaxRsApi = Files.newInputStream(Paths.get(this.jaxRsApiPath))) {
             final JarFileScanner jarFileScanner = new JarFileScanner(jaxRsApi, "javax/ws/r", recursive);
             assertFalse(jarFileScanner.hasNext(), "Unexpectedly found package 'javax.ws.r' in javax.ws.rs-api");
         }
@@ -144,7 +145,7 @@ public class JarFileScannerTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testClassEnumerationWithClassPrefix(final boolean recursive) throws IOException {
-        try (final InputStream jaxRsApi = new FileInputStream(this.jaxRsApiPath)) {
+        try (final InputStream jaxRsApi = Files.newInputStream(Paths.get(this.jaxRsApiPath))) {
             final JarFileScanner jarFileScanner = new JarFileScanner(jaxRsApi, "javax/ws/rs/GE", recursive);
             assertFalse(jarFileScanner.hasNext(), "Unexpectedly found package 'javax.ws.rs.GE' in javax.ws.rs-api");
         }

--- a/core-server/src/test/java/org/glassfish/jersey/server/wadl/config/WadlGeneratorLoaderTest.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/wadl/config/WadlGeneratorLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,11 +21,11 @@
 package org.glassfish.jersey.server.wadl.config;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Properties;
 
@@ -155,7 +155,7 @@ public class WadlGeneratorLoaderTest {
             /*
             try {
                 System.out.println( "listing file " + _testFileContent.getName() );
-                BufferedReader in = new BufferedReader( new FileReader( _testFileContent ) );
+                BufferedReader in = Files.newBufferedReader( _testFileContent.toPath() );
                 String line = null;
                 while ( (line = in.readLine()) != null ) {
                     System.out.println( line );
@@ -172,7 +172,7 @@ public class WadlGeneratorLoaderTest {
                 _testStreamContent = File.createTempFile("testfile-" + getClass().getSimpleName(), null);
                 OutputStream to = null;
                 try {
-                    to = new FileOutputStream(_testStreamContent);
+                    to = Files.newOutputStream(_testStreamContent.toPath());
                     byte[] buffer = new byte[4096];
                     int bytes_read;
                     while ((bytes_read = _testStream.read(buffer)) != -1) {

--- a/examples/oauth-client-twitter/src/main/java/org/glassfish/jersey/examples/oauth/twitterclient/App.java
+++ b/examples/oauth-client-twitter/src/main/java/org/glassfish/jersey/examples/oauth/twitterclient/App.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -11,11 +11,13 @@
 package org.glassfish.jersey.examples.oauth.twitterclient;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Properties;
 
@@ -141,9 +143,9 @@ public class App {
     }
 
     private static void loadSettings() {
-        FileInputStream st = null;
+        InputStream st = null;
         try {
-            st = new FileInputStream(PROPERTIES_FILE_NAME);
+            st = Files.newInputStream(Paths.get(PROPERTIES_FILE_NAME));
             PROPERTIES.load(st);
         } catch (final IOException e) {
             // ignore
@@ -174,9 +176,9 @@ public class App {
     }
 
     private static void storeSettings() {
-        FileOutputStream st = null;
+        OutputStream st = null;
         try {
-            st = new FileOutputStream(PROPERTIES_FILE_NAME);
+            st = Files.newOutputStream(Paths.get(PROPERTIES_FILE_NAME));
             PROPERTIES.store(st, null);
         } catch (final IOException e) {
             // ignore

--- a/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/AbstractWebAppTest.java
+++ b/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/AbstractWebAppTest.java
@@ -13,7 +13,7 @@ package org.glassfish.jersey.examples.helloworld.test;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.Files;
+import java.nio.file.Files;
 import java.nio.Paths;
 import java.security.AccessController;
 import java.util.ArrayList;

--- a/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/AbstractWebAppTest.java
+++ b/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/AbstractWebAppTest.java
@@ -14,7 +14,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.Paths;
+import java.nio.file.Paths;
 import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/AbstractWebAppTest.java
+++ b/examples/osgi-helloworld-webapp/functional-test/src/test/java/org/glassfish/jersey/examples/helloworld/test/AbstractWebAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -11,9 +11,10 @@
 package org.glassfish.jersey.examples.helloworld.test;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.Files;
+import java.nio.Paths;
 import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -227,7 +228,7 @@ public abstract class AbstractWebAppTest {
 
         try {
 
-            final BufferedReader reader = new BufferedReader(new FileReader(felixPolicy));
+            final BufferedReader reader = Files.newBufferedReader(Paths.get(felixPolicy));
             String line;
             final Set<String> cpiNames = new HashSet<String>();
 

--- a/examples/reload/src/main/java/org/glassfish/jersey/examples/reload/App.java
+++ b/examples/reload/src/main/java/org/glassfish/jersey/examples/reload/App.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -12,11 +12,10 @@ package org.glassfish.jersey.examples.reload;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -168,7 +167,7 @@ public class App {
 
         final List<JavaFile> javaFiles = new LinkedList<>();
 
-        try (BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(configFile), "UTF-8"))) {
+        try (BufferedReader r = Files.newBufferedReader(configFile.toPath())) {
             while (r.ready()) {
                 final String className = r.readLine();
                 if (!className.startsWith("#")) {

--- a/examples/sse-twitter-aggregator/src/main/java/org/glassfish/jersey/examples/aggregator/App.java
+++ b/examples/sse-twitter-aggregator/src/main/java/org/glassfish/jersey/examples/aggregator/App.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,10 +10,10 @@
 
 package org.glassfish.jersey.examples.aggregator;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -141,10 +141,10 @@ public class App {
     private static Properties loadSettings() {
         final Properties properties = new Properties();
 
-        FileInputStream st = null;
+        InputStream st = null;
         try {
             String homeDir = System.getProperty("user.home");
-            st = new FileInputStream(homeDir + File.separator + TWITTER_PROPERTIES_FILE_NAME);
+            st = Files.newInputStream(Paths.get(homeDir, TWITTER_PROPERTIES_FILE_NAME));
             properties.load(st);
         } catch (IOException e) {
             // ignore
@@ -230,7 +230,7 @@ public class App {
             try {
                 fileStream = webRootPath == null
                         ? App.class.getResourceAsStream(WEB_ROOT + uri)
-                        : new FileInputStream(webRootPath + uri);
+                        : Files.newInputStream(Paths.get(webRootPath, uri));
             } catch (IOException e) {
                 fileStream = null;
             }

--- a/ext/mvc/src/main/java/org/glassfish/jersey/server/mvc/spi/AbstractTemplateProcessor.java
+++ b/ext/mvc/src/main/java/org/glassfish/jersey/server/mvc/spi/AbstractTemplateProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,13 +16,13 @@
 
 package org.glassfish.jersey.server.mvc.spi;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -182,8 +182,8 @@ public abstract class AbstractTemplateProcessor<T> implements TemplateProcessor<
             // File-system path.
             if (reader == null) {
                 try {
-                    reader = new InputStreamReader(new FileInputStream(template), encoding);
-                } catch (final FileNotFoundException fnfe) {
+                    reader = new InputStreamReader(Files.newInputStream(Paths.get(template)), encoding);
+                } catch (final IOException ioe) {
                     // NOOP.
                 }
             }

--- a/ext/wadl-doclet/src/main/java/org/glassfish/jersey/wadl/doclet/DocletUtils.java
+++ b/ext/wadl-doclet/src/main/java/org/glassfish/jersey/wadl/doclet/DocletUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,11 +18,12 @@ package org.glassfish.jersey.wadl.doclet;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
-import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -96,7 +97,7 @@ class DocletUtils {
         Class<?>[] classes = getJAXBContextClasses(result, docProcessor);
         LOG.info("cdataElements " + Arrays.asList(cdataElements));
         LOG.info("classes " + Arrays.asList(classes));
-        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(filePath))) {
+        try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(Paths.get(filePath)))) {
             JAXBContext c = JAXBContext.newInstance(classes);
             Marshaller m = c.createMarshaller();
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);

--- a/ext/wadl-doclet/src/main/java8_11/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
+++ b/ext/wadl-doclet/src/main/java8_11/org/glassfish/jersey/wadl/doclet/ResourceDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,6 @@ package org.glassfish.jersey.wadl.doclet;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Array;

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/api/UnsafeCharsInUriTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/api/UnsafeCharsInUriTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,7 +24,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.URI;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -78,7 +78,7 @@ public class UnsafeCharsInUriTest extends JerseyTest {
         // quotes are encoded by browsers, curly brackets are not, so the quotes will be sent pre-encoded
         // HTTP 1.0 is used for simplicity
         String response = sendGetRequestOverSocket(getBaseUri(), "GET /app/test?msg={%22foo%22:%22bar%22} HTTP/1.0");
-        assertArrayEquals("{\"foo\":\"bar\"}".getBytes(Charset.forName("ISO-8859-1")), response.getBytes());
+        assertArrayEquals("{\"foo\":\"bar\"}".getBytes(StandardCharsets.ISO_8859_1), response.getBytes());
     }
 
     @Test
@@ -89,7 +89,7 @@ public class UnsafeCharsInUriTest extends JerseyTest {
         String response = sendGetRequestOverSocket(getBaseUri(),
                                             "GET /app/test?msg=Hello\\World+With+SpecChars+§*)$!±@-_=;`:\\,~| HTTP/1.0");
 
-        assertArrayEquals("Hello\\World With SpecChars §*)$!±@-_=;`:\\,~|".getBytes(Charset.forName("ISO-8859-1")),
+        assertArrayEquals("Hello\\World With SpecChars §*)$!±@-_=;`:\\,~|".getBytes(StandardCharsets.ISO_8859_1),
                      response.getBytes());
     }
 
@@ -99,14 +99,14 @@ public class UnsafeCharsInUriTest extends JerseyTest {
         final Socket socket = new Socket(baseUri.getHost(), baseUri.getPort());
         final PrintWriter pw =
                 new PrintWriter(
-                        new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), Charset.forName("ISO-8859-1"))));
+                        new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.ISO_8859_1)));
 
         pw.println(requestLine);
         pw.println(); // http request should end with a blank line
         pw.flush();
 
         final BufferedReader br =
-                new BufferedReader(new InputStreamReader(socket.getInputStream(), Charset.forName("UTF-8")));
+                new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
 
         String lastLine = null;
         String line;

--- a/tests/performance/jmx-client/src/main/java/org/glassfish/jersey/tests/performance/jmxclient/Main.java
+++ b/tests/performance/jmx-client/src/main/java/org/glassfish/jersey/tests/performance/jmxclient/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,6 @@
 
 package org.glassfish.jersey.tests.performance.jmxclient;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 import javax.management.MBeanServerConnection;
@@ -81,6 +80,6 @@ public class Main {
     private static void writeResult(double resultValue, String propertiesFile) throws IOException {
         Properties resultProps = new Properties();
         resultProps.put("YVALUE", Double.toString(resultValue));
-        resultProps.store(new FileOutputStream(propertiesFile), null);
+        resultProps.store(Files.newOutputStream(Paths.get(propertiesFile)), null);
     }
 }

--- a/tests/performance/tools/src/main/java/org/glassfish/jersey/tests/performance/tools/TestDataGeneratorApp.java
+++ b/tests/performance/tools/src/main/java/org/glassfish/jersey/tests/performance/tools/TestDataGeneratorApp.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;

--- a/tests/performance/tools/src/main/java/org/glassfish/jersey/tests/performance/tools/TestDataGeneratorApp.java
+++ b/tests/performance/tools/src/main/java/org/glassfish/jersey/tests/performance/tools/TestDataGeneratorApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,7 +18,6 @@ package org.glassfish.jersey.tests.performance.tools;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.URI;
@@ -134,7 +133,7 @@ public class TestDataGeneratorApp {
 
         final File file = new File(fileName);
         final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(
-                new FileOutputStream(file), Charset.forName("UTF-8")));
+                Files.newOutputStream(file.toPath()), Charset.forName("UTF-8")));
 
         int actualSize = 0;
         while (actualSize < minimalSize) {

--- a/tests/release-test/src/main/java/org/glassfish/jersey/test/artifacts/MavenUtil.java
+++ b/tests/release-test/src/main/java/org/glassfish/jersey/test/artifacts/MavenUtil.java
@@ -24,6 +24,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;

--- a/tests/release-test/src/main/java/org/glassfish/jersey/test/artifacts/MavenUtil.java
+++ b/tests/release-test/src/main/java/org/glassfish/jersey/test/artifacts/MavenUtil.java
@@ -23,8 +23,8 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -115,7 +115,7 @@ public final class MavenUtil {
 
     private static Model getModelFromFile(File file) throws IOException, XmlPullParserException {
         MavenXpp3Reader mavenReader = new MavenXpp3Reader();
-        try (FileReader fileReader = new FileReader(file)) {
+        try (Reader fileReader = Files.newBufferedReader(file.toPath())) {
             Model model = mavenReader.read(fileReader);
             return model;
         }

--- a/tests/release-test/src/test/java/org/glassfish/jersey/test/artifacts/NoticeFilesTest.java
+++ b/tests/release-test/src/test/java/org/glassfish/jersey/test/artifacts/NoticeFilesTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import javax.ws.rs.core.MediaType;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -154,7 +154,7 @@ public class NoticeFilesTest {
     }
 
     private String getFile(File path) throws IOException {
-        return ReaderWriter.readFromAsString(new FileInputStream(path), MediaType.TEXT_PLAIN_TYPE);
+        return ReaderWriter.readFromAsString(Files.newInputStream(path.toPath()), MediaType.TEXT_PLAIN_TYPE);
     }
 
     private String removeUnnecessary(String dependency) {

--- a/tools/jersey-doc-modulelist-maven-plugin/src/main/java/org/glassfish/jersey/tools/plugins/GenerateJerseyModuleListMojo.java
+++ b/tools/jersey-doc-modulelist-maven-plugin/src/main/java/org/glassfish/jersey/tools/plugins/GenerateJerseyModuleListMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,9 +29,10 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -314,7 +315,7 @@ public class GenerateJerseyModuleListMojo extends AbstractMojo {
     }
 
     public String readFile(String fileName) throws IOException {
-        BufferedReader reader = new BufferedReader(new FileReader(fileName));
+        BufferedReader reader = Files.newBufferedReader(Paths.get(fileName));
         String s;
         StringBuilder sb = new StringBuilder();
         while ((s = reader.readLine()) != null) {


### PR DESCRIPTION
This PR is a partial backport of https://github.com/eclipse-ee4j/jersey/pull/5341 as proposed by @jansupol in https://github.com/eclipse-ee4j/jersey/pull/5341#issuecomment-1589610557.

Compared to PR 5341 it only contains those changes which are compatible with Java 8. In particular this means, it mostly consists of using Java 7+ NIO API plus some more improvements, while the actual benefit (preventing data transmission via the JVM's RAM implemented by `ChannelInputStream::transferTo` in recent JREs) is missing due to the fact that `InputStream::transferTo` was not added to the JRE before Java 9.