### PR TITLE
JerseyEventSink#send throwing non IOExceptions

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package org.glassfish.jersey.server;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.concurrent.BlockingDeque;
@@ -255,11 +256,11 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
                                 // if MBW replaced the stream, let's make sure to set it in the response context.
                                 responseContext.setEntityStream(writtenStream);
                             }
-                        } catch (final IOException ioe) {
+                        } catch (final IOException | UncheckedIOException ioe) {
                             connectionCallback.onDisconnect(asyncContext);
                             throw ioe;
                         } catch (final MappableException mpe) {
-                            if (mpe.getCause() instanceof IOException) {
+                            if (mpe.getCause() instanceof IOException || mpe.getCause() instanceof UncheckedIOException) {
                                 connectionCallback.onDisconnect(asyncContext);
                             }
                             throw mpe;

--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/internal/JerseyEventSink.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/internal/JerseyEventSink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -139,7 +139,7 @@ class JerseyEventSink extends ChunkedOutput<OutboundSseEvent>
         try {
             this.write(event);
             return CompletableFuture.completedFuture(null);
-        } catch (IOException e) {
+        } catch (Exception e) {
             CompletableFuture<Void> future = new CompletableFuture<>();
             future.completeExceptionally(e);
             return future;


### PR DESCRIPTION
Relates to https://github.com/jakartaee/rest/issues/1196

Maybe we should catch Throwable instead of Exception.

I don't know what was the reason to catch only IOExceptions, but in the case of Helidon a runtime exception is thrown:
`java.io.UncheckedIOException: java.net.SocketException: Broken pipe`

Anyway, as it returns a `CompletionStage` I think we should not throw exceptions in `JerseyEventSink#send`.

Also UncheckedIOException is caught in ChunkedOutput