### PR TITLE
Update versions of dependencies in pom.xml

### DIFF
--- a/archetypes/jersey-heroku-webapp/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/jersey-heroku-webapp/src/main/resources/archetype-resources/pom.xml
@@ -117,7 +117,7 @@
 
     <properties>
         <jersey.version>${project.version}</jersey.version>
-        <jetty.version>12.0.3</jetty.version>
+        <jetty.version>12.0.5</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <surefire.mvn.plugin.version>3.2.1</surefire.mvn.plugin.version>
         <war.mvn.plugin.version>3.4.0</war.mvn.plugin.version>

--- a/archetypes/jersey-quickstart-grizzly2/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/jersey-quickstart-grizzly2/src/main/resources/archetype-resources/pom.xml
@@ -83,7 +83,7 @@
 
     <properties>
         <jersey.version>${project.version}</jersey.version>
-        <junit-jupiter.version>5.10.0</junit-jupiter.version>
+        <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <surefire.mvn.plugin.version>3.2.1</surefire.mvn.plugin.version>
     </properties>

--- a/ext/mvc-jsp/pom.xml
+++ b/ext/mvc-jsp/pom.xml
@@ -53,7 +53,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            jakarta.servlet.jsp.*;version="[3.0,4.0)",
+                            jakarta.servlet.jsp.*;version="[3.0,5.0)",
                             jakarta.servlet.*;version="[5.0,7.0)",
                             *
                         </Import-Package>

--- a/ext/mvc-jsp/pom.xml
+++ b/ext/mvc-jsp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -2297,6 +2297,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <helidon.jersey.connector.version>3.0.2</helidon.jersey.connector.version>
         <xmlunit.version>2.9.1</xmlunit.version>
+        <httpcore.version>4.4.16</httpcore.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpclient5.version>5.2.1</httpclient5.version>
         <jackson.version>2.15.3</jackson.version>
@@ -2318,7 +2319,10 @@
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
         <osgi.service.cm.version>1.6.1</osgi.service.cm.version>
         <pax.exam.version>4.13.5</pax.exam.version>
+        <pax.exam.legacy.version>4.13.4</pax.exam.legacy.version>
         <pax.web.version>0.7.4</pax.web.version><!-- TODO: UPGRADE! -->
+        <pax.url.aether.version>2.6.14</pax.url.aether.version>
+        <pax.logging.api.version>2.2.6</pax.logging.api.version>
         <reactive.streams.version>1.0.4</reactive.streams.version>
         <rxjava.version>1.3.8</rxjava.version>
         <rxjava2.version>2.2.21</rxjava2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -2219,7 +2219,7 @@
         <buildhelper.mvn.plugin.version>3.4.0</buildhelper.mvn.plugin.version>
         <buildnumber.mvn.plugin.version>3.2.0</buildnumber.mvn.plugin.version>
         <checkstyle.mvn.plugin.version>3.3.1</checkstyle.mvn.plugin.version>
-        <checkstyle.version>10.12.4</checkstyle.version>
+        <checkstyle.version>10.12.7</checkstyle.version>
         <compiler.mvn.plugin.version>3.11.0</compiler.mvn.plugin.version>
         <!--
         Special version of the compiler plugin just for the jersey-common. All versions above
@@ -2296,7 +2296,7 @@
         <guava.version>31.1-jre</guava.version>
         <hamcrest.version>2.2</hamcrest.version>
         <helidon.jersey.connector.version>3.0.2</helidon.jersey.connector.version>
-        <xmlunit.version>2.9.0</xmlunit.version>
+        <xmlunit.version>2.9.1</xmlunit.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpclient5.version>5.2.1</httpclient5.version>
         <jackson.version>2.15.3</jackson.version>
@@ -2306,7 +2306,7 @@
         <jmh.version>1.37</jmh.version>
         <jmockit.version>1.49</jmockit.version>
         <junit4.version>4.13.2</junit4.version>
-        <junit5.version>5.10.0</junit5.version>
+        <junit5.version>5.10.1</junit5.version>
         <junit-platform-suite.version>1.10.0</junit-platform-suite.version>
         <kryo.version>4.0.2</kryo.version>
         <mockito.version>3.12.4</mockito.version> <!-- CQ 17673 -->
@@ -2316,8 +2316,8 @@
         <osgi.version>6.0.0</osgi.version>
         <osgi.framework.version>1.10.0</osgi.framework.version>
         <osgi.compendium.version>5.0.0</osgi.compendium.version>
-        <osgi.service.cm.version>1.6.0</osgi.service.cm.version>
-        <pax.exam.version>4.13.4</pax.exam.version>
+        <osgi.service.cm.version>1.6.1</osgi.service.cm.version>
+        <pax.exam.version>4.13.5</pax.exam.version>
         <pax.web.version>0.7.4</pax.web.version><!-- TODO: UPGRADE! -->
         <reactive.streams.version>1.0.4</reactive.streams.version>
         <rxjava.version>1.3.8</rxjava.version>
@@ -2348,7 +2348,7 @@
         <cdi.api.version>4.1.0-M1</cdi.api.version>
         <cdi.osgi.version>jakarta.enterprise.*;version="[4.0,5)"</cdi.osgi.version>
         <ejb.version>4.0.1</ejb.version>
-        <grizzly2.version>4.0.1</grizzly2.version>
+        <grizzly2.version>4.0.2</grizzly2.version>
         <grizzly.client.version>1.16</grizzly.client.version>
         <grizzly.npn.version>2.0.0</grizzly.npn.version>
         <hk2.version>4.0.0-M1</hk2.version>
@@ -2360,7 +2360,7 @@
         <jta.api.version>2.0.1</jta.api.version>
         <istack.commons.runtime.version>4.1.1</istack.commons.runtime.version>
         <jakarta.activation-api.version>2.1.1</jakarta.activation-api.version>
-        <jakarta.activation.version>2.0.0</jakarta.activation.version>
+        <jakarta.activation.version>2.0.1</jakarta.activation.version>
         <jakarta.el.version>6.0.0-M1</jakarta.el.version>
         <jakarta.el.impl.version>5.0.0-M1</jakarta.el.impl.version>
         <jakarta.annotation.osgi.version>jakarta.annotation.*;version="[3.0,4)"</jakarta.annotation.osgi.version>
@@ -2375,12 +2375,12 @@
         <jaxrs.api.spec.version>3.1</jaxrs.api.spec.version>
         <jaxrs.api.impl.version>3.1.0</jaxrs.api.impl.version>
         <jetty.osgi.version>org.eclipse.jetty.*;version="[11,15)"</jetty.osgi.version>
-        <jetty.version>12.0.3</jetty.version>
+        <jetty.version>12.0.5</jetty.version>
         <jetty9.version>9.4.53.v20231009</jetty9.version>
         <jetty11.version>11.0.18</jetty11.version>
-        <jetty.plugin.version>12.0.3</jetty.plugin.version>
+        <jetty.plugin.version>12.0.5</jetty.plugin.version>
         <jsonb.api.version>3.0.0</jsonb.api.version>
-        <jsonp.ri.version>1.1.1</jsonp.ri.version>
+        <jsonp.ri.version>1.1.5</jsonp.ri.version>
         <jsonp.jaxrs.version>1.1.1</jsonp.jaxrs.version>
         <moxy.version>4.0.2</moxy.version>
         <yasson.version>3.0.3</yasson.version>

--- a/tests/osgi/functional/pom.xml
+++ b/tests/osgi/functional/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -155,6 +155,7 @@
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-container-forked</artifactId>
             <scope>test</scope>
+            <version>${pax.exam.legacy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
@@ -174,7 +175,7 @@
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>
             <artifactId>pax-url-aether</artifactId>
-            <version>2.6.2</version>
+            <version>${pax.url.aether.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -208,13 +209,13 @@
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
             <scope>test</scope>
-            <version>1.11.5</version>
+            <version>${pax.logging.api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-osgi</artifactId>
             <scope>test</scope>
-            <version>4.4.6</version>
+            <version>${httpcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/util/Helper.java
+++ b/tests/osgi/functional/src/test/java/org/glassfish/jersey/osgi/test/util/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -144,6 +144,7 @@ public class Helper {
                 // jakarta.annotation has to go first!
                 mavenBundle().groupId("jakarta.annotation").artifactId("jakarta.annotation-api").versionAsInProject(),
                 mavenBundle().groupId("jakarta.activation").artifactId("jakarta.activation-api").versionAsInProject(),
+                mavenBundle().groupId("jakarta.el").artifactId("jakarta.el-api").versionAsInProject(),
                 mavenBundle().groupId("jakarta.inject").artifactId("jakarta.inject-api").versionAsInProject(),
                 mavenBundle().groupId("jakarta.xml.bind").artifactId("jakarta.xml.bind-api").versionAsInProject(),
                 junitBundles(),

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -48,7 +48,9 @@
         <module>integration</module>
         <module>jmockit</module>
         <module>mem-leaks</module>
+        <!-- TMP DISABLE - Enable again later 
         <module>osgi</module>
+        -->
         <module>stress</module>
         <module>performance</module>
     </modules>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -48,9 +48,7 @@
         <module>integration</module>
         <module>jmockit</module>
         <module>mem-leaks</module>
-        <!-- TMP DISABLE - Enable again later 
         <module>osgi</module>
-        -->
         <module>stress</module>
         <module>performance</module>
     </modules>


### PR DESCRIPTION
Temporary disabled the osgi test module. It already failed on the current state of the 4.0 branch.

We should of course fix and activate it later again.