### PR TITLE
Adding support for private fields in `@BeanParam`

### DIFF
--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/RequestParameters.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/RequestParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/RequestParameters.java
+++ b/ext/proxy-client/src/main/java/org/glassfish/jersey/client/proxy/RequestParameters.java
@@ -156,7 +156,7 @@ class RequestParameters {
                 anns.put(ann.annotationType(), ann);
             }
 
-            if (hasAnyParamAnnotation(anns)) {
+            if (field.canAccess(beanParam) && hasAnyParamAnnotation(anns)) {
                 value = field.get(beanParam);
             } else {
                 // get getter annotations if there are no field annotations

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParamWithPrivateField.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParamWithPrivateField.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.client.proxy;
+
+import jakarta.ws.rs.*;
+
+/**
+ * @author Divyansh Shekhar Gaur
+ */
+public class MyBeanParamWithPrivateField {
+
+    @QueryParam("privateFieldParam")
+    private String privateFieldParam;
+
+    public MyBeanParamWithPrivateField() {}
+
+    public String getPrivateFieldParam() {
+        return privateFieldParam;
+    }
+
+    public void setPrivateFieldParam(String privateFieldParam) {
+        this.privateFieldParam = privateFieldParam;
+    }
+}

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParamWithPrivateField.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParamWithPrivateField.java
@@ -16,7 +16,8 @@
 
 package org.glassfish.jersey.client.proxy;
 
-import jakarta.ws.rs.*;
+
+import jakarta.ws.rs.QueryParam;
 
 /**
  * @author Divyansh Shekhar Gaur

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParamWithPrivateField.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyBeanParamWithPrivateField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceWithBeanParam.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceWithBeanParam.java
@@ -54,6 +54,11 @@ public class MyResourceWithBeanParam implements MyResourceWithBeanParamIfc {
     }
 
     @Override
+    public String echoPrivateField(@BeanParam MyBeanParamWithPrivateField bean) {
+        return bean.getPrivateFieldParam();
+    }
+
+    @Override
     public String echo(MyBeanParam bean) {
         return ("HEADER=" + bean.getHeaderParam() + ",PATH=" + bean.getPathParam() + ",FORM="
                 + bean.getFormParam1() + "," + bean.getFormParam2() + ",QUERY=" + bean.getQueryParam()

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceWithBeanParam.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceWithBeanParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceWithBeanParamIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceWithBeanParamIfc.java
@@ -61,6 +61,12 @@ public interface MyResourceWithBeanParamIfc {
 
     @POST
     @Consumes("application/x-www-form-urlencoded")
+    @Path("getPrivateField")
+    @Produces("text/plain")
+    public String echoPrivateField(@BeanParam MyBeanParamWithPrivateField bean);
+
+    @POST
+    @Consumes("application/x-www-form-urlencoded")
     @Path("all/{pathParam}")
     @Produces("text/plain")
     public String echo(@BeanParam MyBeanParam bean);

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceWithBeanParamIfc.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/MyResourceWithBeanParamIfc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryBeanParamTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryBeanParamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryBeanParamTest.java
+++ b/ext/proxy-client/src/test/java/org/glassfish/jersey/client/proxy/WebResourceFactoryBeanParamTest.java
@@ -138,4 +138,14 @@ public class WebResourceFactoryBeanParamTest  extends JerseyTest {
 
         assertEquals("query", response);
     }
+
+    @Test
+    public void testBeanParamPrivateFieldQuery() {
+        MyBeanParamWithPrivateField myGetBeanParam = new MyBeanParamWithPrivateField();
+        myGetBeanParam.setPrivateFieldParam("query");
+
+        String response = resourceWithBeanParam.echoPrivateField(myGetBeanParam);
+
+        assertEquals("query", response);
+    }
 }


### PR DESCRIPTION
### Purpose
Added support for private fields in POJOs used as `BeanParam`

### Issue / Need
The jersey server already supports classes with private fields annotated QueryParam, HeaderParam etc to be used as BeanParam in the JAX-RS API interface. e.g.
Given a POJO representing an employee:
```java
public class Employee {
    private String id;
    private String firstName;

    public Employee() {
    }

    public String getId() {
        return id;
    }

    public void setId(String id) {
        this.id = id;
    }

    public String getFirstName() {
        return firstName;
    }

    public void setFirstName(String firstName) {
        this.firstName = firstName;
    }
}
```
We can use the above class as `@BeanParam` in our service interface as below
```java
    @GET
    @Path("employees")
    List<Employee> findEmployee(@BeanParam FindEmployeeRequest findEmployeeRequest);
```
The above works with Jersey server.
However, the same class and interface cannot be used with `jersey-proxy-client` as of now because the `jersey-proxy-client`, upon encountering fields with private fields having getters failes with following error:
```
java.lang.IllegalAccessException: class org.glassfish.jersey.client.proxy.RequestParameters cannot access a member of class com.dsgaur.example.jersey.api.FindEmployeeRequest with modifiers "private"
	at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:394)
	at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:714)
	at java.base/java.lang.reflect.Field.checkAccess(Field.java:1156)
	at java.base/java.lang.reflect.Field.get(Field.java:441)
	at org.glassfish.jersey.client.proxy.RequestParameters.addBeanParameter(RequestParameters.java:160)
	at org.glassfish.jersey.client.proxy.RequestParameters.addParameter(RequestParameters.java:139)
	at org.glassfish.jersey.client.proxy.WebResourceFactory.invoke(WebResourceFactory.java:203)
```

This breaks the compatibility of having a common API module with JAX-RS annotated service interfaces and POJOs shared by the server application and the various client applications which might be using the same service. This is a typical usecase.

### Why it fails
It is not checking if the field is accessible before calling `Field.get(beanParam)`, which causes the above error. This statement is reached when a class being used as `@BeanParam` has annotations on the field declaration but the field is private.

### Fix
Check if the field is accessible in the current beanParam object before calling get(). If the field is accessible, get the value, otherwise use the getter for that field if present.

### Affected Versions:
3.x
4.x

Fixed #5526 

Signed-off-by: Divyansh Shekhar Gaur <divyanshshekhar@users.noreply.github.com>