### PR TITLE
ObjectMapper.findModules throws Error

### DIFF
--- a/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/DefaultJacksonJaxbJsonProvider.java
+++ b/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/DefaultJacksonJaxbJsonProvider.java
@@ -103,7 +103,7 @@ public class DefaultJacksonJaxbJsonProvider extends JacksonJaxbJsonProvider {
         final List<Module> modules;
         try {
             modules = ObjectMapper.findModules();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             LOGGER.warning(LocalizationMessages.ERROR_MODULES_NOT_LOADED(e.getMessage()));
             return Collections.emptyList();
         }


### PR DESCRIPTION
We need to catch Throwable because it will throw `java.util.ServiceConfigurationError`

Related to https://github.com/eclipse-ee4j/jersey/pull/5604