### PR TITLE
Add ability to configure the queue capacity for ChunkedOutput

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -77,17 +77,17 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
     protected ChunkedOutput() {
         this.chunkDelimiter = ZERO_LENGTH_DELIMITER;
     }
-
+    
     /**
      * Create new {@code ChunkedOutput}.
      * 
      * @param queueCapacity the queueCapacity before adding items will block
-     */    
+     */
     protected ChunkedOutput(final int queueCapacity) {
         this.chunkDelimiter = ZERO_LENGTH_DELIMITER;
         queue = new LinkedBlockingDeque<>(queueCapacity);
-    } 
-
+    }
+    
     /**
      * Create {@code ChunkedOutput} with specified type.
      *
@@ -189,7 +189,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
         }
 
         if (chunk != null) {
-            queue.add(chunk);
+            queue.put(chunk);
         }
 
         flushQueue();

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -51,7 +51,7 @@ import org.glassfish.jersey.server.internal.process.MappableException;
 public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
     private static final byte[] ZERO_LENGTH_DELIMITER = new byte[0];
 
-    private final BlockingDeque<T> queue = new LinkedBlockingDeque<>();
+    private BlockingDeque<T> queue = new LinkedBlockingDeque<>();
     private final byte[] chunkDelimiter;
     private final AtomicBoolean resumed = new AtomicBoolean(false);
     private final Object lock = new Object();
@@ -77,6 +77,16 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
     protected ChunkedOutput() {
         this.chunkDelimiter = ZERO_LENGTH_DELIMITER;
     }
+
+    /**
+     * Create new {@code ChunkedOutput}.
+     * 
+     * @param queueCapacity the queueCapacity before adding items will block
+     */    
+    protected ChunkedOutput(final int queueCapacity) {
+        this.chunkDelimiter = ZERO_LENGTH_DELIMITER;
+        queue = new LinkedBlockingDeque<>(queueCapacity);
+    } 
 
     /**
      * Create {@code ChunkedOutput} with specified type.


### PR DESCRIPTION
Adding constructor which sets the queue capacity.

This allows for calling write from different threads until the queue is full. Subsequent write calls will block until the queue is emptied.

This change allows to prevent memory issues in case of slow clients. Basically, a backpressure mechanism based on the queue size.

This change provides a way to call write on ChunkedOutput from multiple threads to improve throughput, while preventing memory issues in case of slow clients. The queue is bounded and thus cannot grow endlessly.