### PR TITLE
Add ability to configure the queue capacity for ChunkedOutput

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -83,7 +83,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
      * @param builder the builder to use
      */
     private ChunkedOutput(ChunkedOutputBuilder<T> builder) {
-        super(builder.chunkType != null ? builder.chunkType : String.class);
+        super(builder.chunkType);
 
         if (builder.queueCapacity > 0) {
             queue = new LinkedBlockingDeque<>(builder.queueCapacity);
@@ -199,10 +199,11 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
     /**
      * Returns a builder to create a ChunkedOutput with custom configuration.
      *
+     * @param chunkType      chunk type. Must not be {code null}.
      * @return builder
      */
-    public static <T> ChunkedOutputBuilder<T> newBuilder() {
-        return new ChunkedOutputBuilder<>();
+    public static <T> ChunkedOutputBuilder<T> newBuilder(Type chunkType) {
+        return new ChunkedOutputBuilder<>(chunkType);
     }
 
     /**
@@ -454,8 +455,9 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
         private Provider<AsyncContext> asyncContextProvider;
         private Type chunkType;
 
-        private ChunkedOutputBuilder() {
+        private ChunkedOutputBuilder(Type chunkType) {
             // hide constructor
+            this.chunkType = chunkType;
         }
 
         /**
@@ -463,7 +465,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
          * @param chunkDelimiter the chunk delimiter in bytes
          * @return builder
          */
-        public ChunkedOutputBuilder<Y> withChunkDelimiter(byte[] chunkDelimiter) {
+        public ChunkedOutputBuilder<Y> chunkDelimiter(byte[] chunkDelimiter) {
             this.chunkDelimiter = chunkDelimiter;
             return this;
         }
@@ -473,7 +475,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
          * @param queueCapacity the queue capacity
          * @return builder
          */
-        public ChunkedOutputBuilder<Y> withQueueCapacity(int queueCapacity) {
+        public ChunkedOutputBuilder<Y> queueCapacity(int queueCapacity) {
             this.queueCapacity = queueCapacity;
             return this;
         }
@@ -483,18 +485,8 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
          * @param asyncContextProvider the async context provider
          * @return builder
          */
-        public ChunkedOutputBuilder<Y> withAsyncContextProvider(Provider<AsyncContext> asyncContextProvider) {
+        public ChunkedOutputBuilder<Y> asyncContextProvider(Provider<AsyncContext> asyncContextProvider) {
             this.asyncContextProvider = asyncContextProvider;
-            return this;
-        }
-
-        /**
-         * Set the chunk type.
-         * @param chunkType the chunk type
-         * @return builder
-         */
-        public ChunkedOutputBuilder<Y> withChunkType(Type chunkType) {
-            this.chunkType = chunkType;
             return this;
         }
 

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -234,7 +234,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
      * @param chunkType      chunk type. Must not be {code null}.
      * @return builder
      */
-    public static <T> Builder<T> builder(Type chunkType) {
+    public static <T> TypedBuilder<T> builder(Type chunkType) {
         return new TypedBuilder<>(chunkType);
     }
 

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -467,7 +467,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
         }
 
         /**
-         * Set the queue capacity. If greather than 0, the queue is bounded and will block when full.
+         * Set the queue capacity. If greater than 0, the queue is bounded and will block when full.
          * @param queueCapacity the queue capacity
          * @return builder
          */

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -84,6 +84,8 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
      * @param builder the builder to use
      */
     private ChunkedOutput(ChunkedOutputBuilder<T> builder) {
+        super(builder.chunkType != null ? builder.chunkType : String.class);
+
         if (builder.queueCapacity > 0) {
             queue = new LinkedBlockingDeque<>(builder.queueCapacity);
         } else {
@@ -219,6 +221,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
             try {
                 queue.put(chunk);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new IOException(e);
             }
         }
@@ -450,6 +453,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
         private byte[] chunkDelimiter;
         private int queueCapacity = -1;
         private Provider<AsyncContext> asyncContextProvider;
+        private Type chunkType;
 
         public ChunkedOutputBuilder<Y> withChunkDelimiter(byte[] chunkDelimiter) {
             this.chunkDelimiter = chunkDelimiter;
@@ -463,6 +467,11 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
 
         public ChunkedOutputBuilder<Y> withAsyncContextProvider(Provider<AsyncContext> asyncContextProvider) {
             this.asyncContextProvider = asyncContextProvider;
+            return this;
+        }
+
+        public ChunkedOutputBuilder<Y> withChunkType(Type chunkType) {
+            this.chunkType = chunkType;
             return this;
         }
 

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -69,7 +69,6 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
     private volatile ContainerResponse responseContext;
     private volatile ConnectionCallback connectionCallback;
 
-
     /**
      * Create new {@code ChunkedOutput}.
      */
@@ -385,7 +384,6 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
 
     /**
      * Get state information.
-     * <p>
      * Please note that {@code ChunkedOutput} can be closed by the client side - client can close connection
      * from its side.
      *
@@ -455,6 +453,10 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
         private int queueCapacity = -1;
         private Provider<AsyncContext> asyncContextProvider;
         private Type chunkType;
+
+        private ChunkedOutputBuilder() {
+            // hide constructor
+        }
 
         /**
          * Set the chunk delimiter, in bytes.

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -385,6 +385,7 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
 
     /**
      * Get state information.
+     * <p>
      * Please note that {@code ChunkedOutput} can be closed by the client side - client can close connection
      * from its side.
      *
@@ -455,26 +456,50 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
         private Provider<AsyncContext> asyncContextProvider;
         private Type chunkType;
 
+        /**
+         * Set the chunk delimiter, in bytes.
+         * @param chunkDelimiter the chunk delimiter in bytes
+         * @return builder
+         */
         public ChunkedOutputBuilder<Y> withChunkDelimiter(byte[] chunkDelimiter) {
             this.chunkDelimiter = chunkDelimiter;
             return this;
         }
 
+        /**
+         * Set the queue capacity. If greather than 0, the queue is bounded and will block when full.
+         * @param queueCapacity the queue capacity
+         * @return builder
+         */
         public ChunkedOutputBuilder<Y> withQueueCapacity(int queueCapacity) {
             this.queueCapacity = queueCapacity;
             return this;
         }
 
+        /**
+         * Set the async context provider.
+         * @param asyncContextProvider the async context provider
+         * @return builder
+         */
         public ChunkedOutputBuilder<Y> withAsyncContextProvider(Provider<AsyncContext> asyncContextProvider) {
             this.asyncContextProvider = asyncContextProvider;
             return this;
         }
 
+        /**
+         * Set the chunk type.
+         * @param chunkType the chunk type
+         * @return builder
+         */
         public ChunkedOutputBuilder<Y> withChunkType(Type chunkType) {
             this.chunkType = chunkType;
             return this;
         }
 
+        /**
+         * Build the ChunkedOutput based on the given configuration.
+         * @return the ChunkedOutput
+         */
         public ChunkedOutput<Y> build() {
             return new ChunkedOutput<>(this);
         }

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -216,7 +216,11 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
         }
 
         if (chunk != null) {
-            queue.add(chunk);
+            try {
+                queue.put(chunk);
+            } catch (InterruptedException e) {
+                throw new IOException(e);
+            }
         }
 
         flushQueue();

--- a/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ChunkedOutput.java
@@ -432,7 +432,8 @@ public class ChunkedOutput<T> extends GenericType<T> implements Closeable {
      * @param e Exception causing the close
      */
     protected void onClose(Exception e) {
-
+        // drain queue when an exception occurs to prevent deadlocks
+        queue.clear();
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/docs/src/main/docbook/async.xml
+++ b/docs/src/main/docbook/async.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/docs/src/main/docbook/async.xml
+++ b/docs/src/main/docbook/async.xml
@@ -271,7 +271,7 @@ public class AsyncResource {
         final ChunkedOutput<String> output = new ChunkedOutput<String>(String.class);
 
         // Or use the builder pattern instead, which also allows to configure the queue capacity
-        // final ChunkedOutput<String> output = ChunkedOutput.<String>newBuilder().withQueueCapacity(10).build();
+        // final ChunkedOutput<String> output = ChunkedOutput.<String>newBuilder(String.class).queueCapacity(10).build();
 
         new Thread() {
             public void run() {

--- a/docs/src/main/docbook/async.xml
+++ b/docs/src/main/docbook/async.xml
@@ -270,6 +270,9 @@ public class AsyncResource {
     public ChunkedOutput<String> getChunkedResponse() {
         final ChunkedOutput<String> output = new ChunkedOutput<String>(String.class);
 
+        // Or use the builder pattern instead, which also allows to configure the queue capacity
+        // final ChunkedOutput<String> output = ChunkedOutput.<String>newBuilder().withQueueCapacity(10).build();
+
         new Thread() {
             public void run() {
                 try {

--- a/docs/src/main/docbook/async.xml
+++ b/docs/src/main/docbook/async.xml
@@ -271,7 +271,7 @@ public class AsyncResource {
         final ChunkedOutput<String> output = new ChunkedOutput<String>(String.class);
 
         // Or use the builder pattern instead, which also allows to configure the queue capacity
-        // final ChunkedOutput<String> output = ChunkedOutput.<String>newBuilder(String.class).queueCapacity(10).build();
+        // final ChunkedOutput<String> output = ChunkedOutput.<String>builder(String.class).queueCapacity(10).build();
 
         new Thread() {
             public void run() {

--- a/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
+++ b/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
@@ -68,7 +68,7 @@ public class ChunkedInputOutputTest extends JerseyTest {
         @GET
         @Path("/testWithBuilder")
         public ChunkedOutput<String> getWithBuilder() {
-            return getOutput(ChunkedOutput.<String>newBuilder().withQueueCapacity(2).withChunkDelimiter("\r\n".getBytes()).build());
+            return getOutput(ChunkedOutput.<String>newBuilder(String.class).queueCapacity(2).chunkDelimiter("\r\n".getBytes()).build());
         }
 
         /**

--- a/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
+++ b/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
@@ -68,7 +68,8 @@ public class ChunkedInputOutputTest extends JerseyTest {
         @GET
         @Path("/testWithBuilder")
         public ChunkedOutput<String> getWithBuilder() {
-            return getOutput(ChunkedOutput.<String>newBuilder(String.class).queueCapacity(2).chunkDelimiter("\r\n".getBytes()).build());
+            return getOutput(ChunkedOutput.<String>newBuilder(String.class).queueCapacity(2)
+                             .chunkDelimiter("\r\n".getBytes()).build());
         }
 
         /**

--- a/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
+++ b/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -68,8 +68,7 @@ public class ChunkedInputOutputTest extends JerseyTest {
         @GET
         @Path("/testWithBuilder")
         public ChunkedOutput<String> getWithBuilder() {
-            return getOutput(ChunkedOutput.<String>newBuilder(String.class).queueCapacity(2)
-                             .chunkDelimiter("\r\n".getBytes()).build());
+            return getOutput(ChunkedOutput.<String>builder(String.class).queueCapacity(2).chunkDelimiter("\r\n".getBytes()).build());
         }
 
         /**

--- a/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
+++ b/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
+++ b/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/ChunkedInputOutputTest.java
@@ -68,7 +68,8 @@ public class ChunkedInputOutputTest extends JerseyTest {
         @GET
         @Path("/testWithBuilder")
         public ChunkedOutput<String> getWithBuilder() {
-            return getOutput(ChunkedOutput.<String>builder(String.class).queueCapacity(2).chunkDelimiter("\r\n".getBytes()).build());
+            return getOutput(ChunkedOutput.<String>builder(String.class).queueCapacity(2)
+                             .chunkDelimiter("\r\n".getBytes()).build());
         }
 
         /**


### PR DESCRIPTION
Adding constructors which set the queue capacity.

This allows for calling `ChunkedOutput.write` from multiple concurrent threads until the queue is full. Subsequent `write` calls will block until the queue is emptied by `flushQueue`. This change allows to prevent memory issues in case of slow clients. Basically, a backpressure mechanism based on the queue size.

This change provides a way to call write on `ChunkedOutput` from multiple threads to improve throughput, while preventing memory issues in case of slow clients. The queue is bounded and thus cannot grow endlessly.

The code now uses `put` (https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/LinkedBlockingQueue.html#put-E-) instead of `add` (https://docs.oracle.com/javase/8/docs/api/java/util/AbstractQueue.html#add-E-) so it blocks when the queue is full.