### PR TITLE
Set reasonable timeout and disable concurrent builds

### DIFF
--- a/etc/jenkins/Jenkinsfile_ci_build
+++ b/etc/jenkins/Jenkinsfile_ci_build
@@ -2,7 +2,8 @@ pipeline {
     agent none
 
     options {
-          timeout(time: 30, activity: true, unit: 'HOURS')
+          timeout(time: 10, activity: true, unit: 'HOURS')
+          disableConcurrentBuilds()
     }
 
     stages {


### PR DESCRIPTION
Apply Jenkins/CI best practices and avoid builds hanging for days.