### PR TITLE
ResponseWriter#writeResponseStatusAndHeaders drops some redundant code

### DIFF
--- a/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/internal/ResponseWriter.java
+++ b/containers/jersey-servlet-core/src/main/java/org/glassfish/jersey/servlet/internal/ResponseWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -142,12 +142,7 @@ public class ResponseWriter implements ContainerResponseWriter {
             }
         }
 
-        final String reasonPhrase = responseContext.getStatusInfo().getReasonPhrase();
-        if (reasonPhrase != null) {
-            response.setStatus(responseContext.getStatus());
-        } else {
-            response.setStatus(responseContext.getStatus());
-        }
+        response.setStatus(responseContext.getStatus());
 
         if (!responseContext.hasEntity()) {
             return null;


### PR DESCRIPTION
A condition with identical branches.
    
Found this when looking at:
4977fecc8704dd2178dacf0ba9590f2463f8accb
Author: jansupol <jan.supol@oracle.com>
Date:   Mon Feb 21 18:23:20 2022 +0100
Replace removed API in Servlet 6
