### PR TITLE
NPE when creating DefaultJacksonJaxbJsonProvider instance with no params constructor

### DIFF
--- a/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/DefaultJacksonJaxbJsonProvider.java
+++ b/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/DefaultJacksonJaxbJsonProvider.java
@@ -59,10 +59,6 @@ public class DefaultJacksonJaxbJsonProvider extends JacksonJaxbJsonProvider {
     //do not register JaxbAnnotationModule because it brakes default annotations processing
     private static final String[] EXCLUDE_MODULE_NAMES = {"JaxbAnnotationModule", "JakartaXmlBindAnnotationModule"};
 
-    public DefaultJacksonJaxbJsonProvider() {
-        super(new JacksonMapperConfigurator(null, DEFAULT_ANNOTATIONS));
-    }
-
     public DefaultJacksonJaxbJsonProvider(Providers providers, Configuration config, Annotations... annotationsToUse) {
         super(new JacksonMapperConfigurator(null, annotationsToUse));
         this.commonConfig = config;


### PR DESCRIPTION
Sample PR for
[#5734](https://github.com/eclipse-ee4j/jersey/issues/5734)