### PR TITLE
Keep only 2 builds with artifacts and disable concurrent builds

### DIFF
--- a/etc/jenkins/Jenkinsfile_EE4J_build
+++ b/etc/jenkins/Jenkinsfile_EE4J_build
@@ -5,6 +5,10 @@ pipeline {
     triggers {
         pollSCM('H H * * *')
     }
+    options {
+        disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr:'15', artifactNumToKeepStr: '2' ))
+    }
     tools {
         jdk 'oracle-jdk8-latest'
         maven 'apache-maven-latest'

--- a/etc/jenkins/Jenkinsfile_ci_build
+++ b/etc/jenkins/Jenkinsfile_ci_build
@@ -3,6 +3,8 @@ pipeline {
 
     options {
           timeout(time: 30, activity: true, unit: 'HOURS')
+          buildDiscarder(logRotator(numToKeepStr:'15', artifactNumToKeepStr: '2' ))
+          disableConcurrentBuilds()
     }
 
     stages {

--- a/etc/jenkins/Jenkinsfile_master_build
+++ b/etc/jenkins/Jenkinsfile_master_build
@@ -5,6 +5,10 @@ pipeline {
     triggers {
         pollSCM('H H * * *')
     }
+    options {
+        disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr:'15', artifactNumToKeepStr: '2' ))
+    }
     tools {
         jdk 'oracle-jdk8-latest'
         maven 'apache-maven-latest'


### PR DESCRIPTION
Reduce disk usage by keeping only 2 builds with artifacts. Avoid build queue issues by disabling concurrent builds.

cc: @senivam