### PR TITLE
test(flaky): Sorting headers for deterministic order

### DIFF
--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java
@@ -35,6 +35,9 @@ import javax.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
 
 public class NoJAXBNoWadlTest extends JerseyTest {
 
@@ -74,7 +77,9 @@ public class NoJAXBNoWadlTest extends JerseyTest {
 
         try (Response r = target("dummy").request(MediaTypes.WADL_TYPE).options()) {
             String headers = r.getHeaderString(HttpHeaders.ALLOW);
-            Assertions.assertEquals("OPTIONS,PUT", headers);
+            List<String> methods = Arrays.asList(headers.split(","));
+            Collections.sort(methods);
+            Assertions.assertEquals(Arrays.asList("OPTIONS", "PUT"), methods);
         }
         System.out.println(readableStream.toString());
         Assertions.assertEquals(!shouldHaveJaxb,

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
The order of HTTP methods in the `ALLOW` header (OPTIONS,PUT vs PUT,OPTIONS) is not guaranteed to be consistent in `getHeaderString()`, so the following test case fails if the order changes: 

https://github.com/eclipse-ee4j/jersey/blob/89de7de2cd2d6e3fb3c1100eef2f0cc891ff79f2/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java#L69

This PR proposes to sort the headers so that the order assumptions (in this PR, alphabetical order) in the test cases are correct.

This change was confirmed by running the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which explores and reports errors in different behaviors of under-determined Java APIs.

To reproduce this problem, you can run the test with NonDex using these commands:

```
mvn install -pl tests/e2e -am -DskipTests

mvn -pl tests/e2e edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.glassfish.jersey.tests.e2e.server.wadl.NoJAXBNoWadlTest#testOptionsNoWadl
```
Here are screenshots of the output produced by NonDex before and after the fix: 

![image](https://github.com/user-attachments/assets/14f5d7a4-df4f-4f2c-97b9-cac0a3f4798f)
![image](https://github.com/user-attachments/assets/74ed2e97-5e09-421e-b6fb-063ad47dd4e9)


Please let me know if you want to discuss these changes. 