### PR TITLE
Netty connector hang up after repeated buffer overflow errors when writing data #5753

### DIFF
--- a/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/JerseyChunkedInput.java
+++ b/connectors/netty-connector/src/main/java/org/glassfish/jersey/netty/connector/internal/JerseyChunkedInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -208,10 +208,12 @@ public class JerseyChunkedInput extends OutputStream implements ChunkedInput<Byt
         try {
             boolean queued = queue.offer(bufferSupplier.get(), WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
             if (!queued) {
+                close();
                 throw new IOException("Buffer overflow.");
             }
 
         } catch (InterruptedException e) {
+            close();
             throw new IOException(e);
         }
     }


### PR DESCRIPTION
https://github.com/eclipse-ee4j/jersey/issues/5753

I didn't include a test because it is tricky. I was testing it with the example provided in the issue.