### PR TITLE
fixed flaky test in testDisabledModule()

### DIFF
--- a/media/json-jackson/src/test/java/org/glassfish/jersey/jackson/internal/DefaultJsonJacksonProviderForBothModulesTest.java
+++ b/media/json-jackson/src/test/java/org/glassfish/jersey/jackson/internal/DefaultJsonJacksonProviderForBothModulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Application;
 
+import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DefaultJsonJacksonProviderForBothModulesTest extends JerseyTest {
@@ -36,8 +39,12 @@ public class DefaultJsonJacksonProviderForBothModulesTest extends JerseyTest {
     public final void testDisabledModule() {
         final String response = target("entity/simple")
                 .request().get(String.class);
+        String expected = "{\"name\":\"Hello\",\"value\":\"World\"}";
+        List<String> response_list = Arrays.asList(response.replaceAll("[{}]", "").split(","));
+        List<String> expected_list = Arrays.asList(expected.replaceAll("[{}]", "").split(","));
+        Collections.sort(response_list);
 
-        assertEquals("{\"name\":\"Hello\",\"value\":\"World\"}", response);
+        assertEquals(expected_list, response_list);
     }
 
 }


### PR DESCRIPTION
The order of the objects in response string returned by `target("entity/simple").request().get(String.class)` isn't guaranteed to be consistent, returning  `<{"value":"World","name":"Hello"}>` instead of `<{"name":"Hello","value":"World"}>`. The test case `testDisabledModule()` fails if this happens. 

This PR proposes to convert the response and expected strings into Lists, which are then sorted, so that the order assumptions (in this PR, alphabetical order) in the test cases are correct.

This change was confirmed by running the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which explores and reports errors in different behaviors of under-determined Java APIs.

To reproduce this problem, you can run the test with NonDex using these commands:
```
mvn install -pl media/json-jackson -am -DskipTests
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl media/json-jackson -Dtest=org.glassfish.jersey.jackson.internal.DefaultJsonJacksonProviderForBothModulesTest#testDisabledModule
```

Here are screenshots of the output produced by NonDex before and after the fix:

![image](https://github.com/user-attachments/assets/e731f94d-5433-40eb-acd3-ad0358faec2d)
![image](https://github.com/user-attachments/assets/3ac35be5-f748-4048-b77e-19ac4c0476c2)

Please let me know if you want to discuss these changes.
