### PR TITLE
Fix flaky 2

### DIFF
--- a/inject/cdi2-se/src/test/java/org/glassfish/jersey/inject/cdi/se/DisposableSupplierTest.java
+++ b/inject/cdi2-se/src/test/java/org/glassfish/jersey/inject/cdi/se/DisposableSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/inject/cdi2-se/src/test/java/org/glassfish/jersey/inject/cdi/se/DisposableSupplierTest.java
+++ b/inject/cdi2-se/src/test/java/org/glassfish/jersey/inject/cdi/se/DisposableSupplierTest.java
@@ -17,6 +17,8 @@
 package org.glassfish.jersey.inject.cdi.se;
 
 import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -368,9 +370,17 @@ public class DisposableSupplierTest {
 
             // All instances should be the same because they are request scoped.
             ComposedObject instance = injectionManager.getInstance(ComposedObject.class);
-            assertEquals("1", instance.getFirst());
-            assertEquals("2", instance.getSecond());
-            assertEquals("3", instance.getThird());
+            Set<String> set1 = new HashSet<String>() {{
+                add("1");
+                add("2");
+                add("3");
+            }};
+            Set<String> set2 = new HashSet<String>() {{
+                add(instance.getFirst().toString());
+                add(instance.getSecond().toString());
+                add(instance.getThird().toString());
+            }};
+            assertEquals(set1, set2);
         });
 
         Supplier<String> cleanedSupplier = atomicSupplier.get();

--- a/inject/hk2/src/test/java/org/glassfish/jersey/inject/hk2/DisposableSupplierTest.java
+++ b/inject/hk2/src/test/java/org/glassfish/jersey/inject/hk2/DisposableSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/inject/hk2/src/test/java/org/glassfish/jersey/inject/hk2/DisposableSupplierTest.java
+++ b/inject/hk2/src/test/java/org/glassfish/jersey/inject/hk2/DisposableSupplierTest.java
@@ -17,6 +17,8 @@
 package org.glassfish.jersey.inject.hk2;
 
 import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -374,9 +376,17 @@ public class DisposableSupplierTest {
 
             // All instances should be the same because they are request scoped.
             ComposedObject instance = injectionManager.getInstance(ComposedObject.class);
-            assertEquals("1", instance.first);
-            assertEquals("2", instance.second);
-            assertEquals("3", instance.third);
+            Set<String> set1 = new HashSet<String>() {{
+                add("1");
+                add("2");
+                add("3");
+            }};
+            Set<String> set2 = new HashSet<String>() {{
+                add(instance.first.toString());
+                add(instance.second.toString());
+                add(instance.third.toString());
+            }};
+            assertEquals(set1, set2);
         });
 
         Supplier<String> cleanedSupplier = atomicSupplier.get();


### PR DESCRIPTION
Duplicate flaky test fixes same as this PR: https://github.com/eclipse-ee4j/jersey/pull/5764

I found two additional instances of the `testDisposeComposedObjectWithPerLookupFields()` test which sometimes fail under non-deterministic behavior. I used the same fix as the one in the PR above, using a HashSet comparison to check the strings within the `ComposedObject`. 

You can reproduce this error using the https://github.com/TestingResearchIllinois/NonDex tool, which explores and reports errors in different behaviors of under-determined Java APIs.

To reproduce this problem, you can run the test with NonDex using these commands after building: 
```
# First Test
mvn -pl inject/cdi2-se edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.glassfish.jersey.inject.cdi.se.DisposableSupplierTest#testDisposeComposedObjectWithPerLookupFields
# Second Test
mvn -pl inject/hk2 edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.glassfish.jersey.inject.hk2.DisposableSupplierTest#testDisposeComposedObjectWithPerLookupFields
```

Here are screenshots of the output produced by NonDex before and after the fix for the first test case: 

![image](https://github.com/user-attachments/assets/35eb294f-321c-4ce9-bc15-eed6f96de291)
![image](https://github.com/user-attachments/assets/a586c55e-4606-4896-ba48-9c53e9e4c51e)

Please let me know if you want to discuss these changes. 