### PR TITLE
[2.x] ParamConverterProvider constructors are now protected to allow extensibility

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/internal/inject/ParamConverters.java
+++ b/core-common/src/main/java/org/glassfish/jersey/internal/inject/ParamConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -121,7 +121,7 @@ public class ParamConverters {
     @Singleton
     public static class StringConstructor extends ParamConverterCompliance implements ParamConverterProvider {
 
-        private StringConstructor(boolean canReturnNull) {
+        protected StringConstructor(boolean canReturnNull) {
             super(canReturnNull);
         }
 
@@ -150,7 +150,7 @@ public class ParamConverters {
     @Singleton
     public static class TypeValueOf extends ParamConverterCompliance implements ParamConverterProvider {
 
-        private TypeValueOf(boolean canReturnNull) {
+        protected TypeValueOf(boolean canReturnNull) {
             super(canReturnNull);
         }
 
@@ -178,7 +178,7 @@ public class ParamConverters {
     @Singleton
     public static class TypeFromString extends ParamConverterCompliance implements ParamConverterProvider {
 
-        private TypeFromString(boolean canReturnNull) {
+        protected TypeFromString(boolean canReturnNull) {
             super(canReturnNull);
         }
 
@@ -206,7 +206,7 @@ public class ParamConverters {
     @Singleton
     public static class TypeFromStringEnum extends TypeFromString {
 
-        private TypeFromStringEnum(boolean canReturnNull) {
+        protected TypeFromStringEnum(boolean canReturnNull) {
             super(canReturnNull);
         }
 
@@ -221,7 +221,7 @@ public class ParamConverters {
     @Singleton
     public static class CharacterProvider extends ParamConverterCompliance implements ParamConverterProvider {
 
-        private CharacterProvider(boolean canReturnNull) {
+        protected CharacterProvider(boolean canReturnNull) {
             super(canReturnNull);
         }
 
@@ -266,7 +266,7 @@ public class ParamConverters {
     @Singleton
     public static class DateProvider extends ParamConverterCompliance implements ParamConverterProvider {
 
-        private DateProvider(boolean canReturnNull) {
+        protected DateProvider(boolean canReturnNull) {
             super(canReturnNull);
         }
 
@@ -309,7 +309,7 @@ public class ParamConverters {
         // Delegates to this provider when the type of Optional is extracted.
         private final InjectionManager manager;
 
-        public OptionalCustomProvider(InjectionManager manager, boolean canReturnNull) {
+        protected OptionalCustomProvider(InjectionManager manager, boolean canReturnNull) {
             super(canReturnNull);
             this.manager = manager;
         }
@@ -364,6 +364,8 @@ public class ParamConverters {
      */
     @Singleton
     public static class OptionalProvider implements ParamConverterProvider {
+
+        protected OptionalProvider() {}
 
         @Override
         public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {


### PR DESCRIPTION
This PR addresses #5791 and opens back up constructors that were ?unintentionally? closed in #5349.
This allows users to decorate or extend the functionality of built-in providers without fully copy-pasting the implementations into user projects.