### PR TITLE
Fix exception message on failure to create JakartaXmlBindAnnotationIntrospector

### DIFF
--- a/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/jackson/jaxrs/json/JsonMapperConfigurator.java
+++ b/media/json-jackson/src/main/java/org/glassfish/jersey/jackson/internal/jackson/jaxrs/json/JsonMapperConfigurator.java
@@ -129,7 +129,7 @@ public class JsonMapperConfigurator
                     }
                     return _jaxbIntrospectorClass.newInstance();
                 } catch (Exception e) {
-                    throw new IllegalStateException("Failed to instantiate JaxbAnnotationIntrospector: "+e.getMessage(), e);
+                    throw new IllegalStateException("Failed to instantiate JakartaXmlBindAnnotationIntrospector: "+e.getMessage(), e);
                 }
             default:
                 throw new IllegalStateException();


### PR DESCRIPTION
Commit https://github.com/eclipse-ee4j/jersey/commit/62ba351c6a1fde072b5634318551704eb277371d addressed the wrong class being used in Jersey 3.0.x but didn't adjust an error message accordingly. This PR fixes this.