### PR TITLE
Use string as hashcode in lock map in HttpUrlConnectorProvider

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/HttpUrlConnectorProvider.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/HttpUrlConnectorProvider.java
@@ -298,7 +298,7 @@ public class HttpUrlConnectorProvider implements ConnectorProvider {
 
     private static class DefaultConnectionFactory implements ConnectionFactory {
 
-        private final ConcurrentHashMap<URL, Lock> locks = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<String, Lock> locks = new ConcurrentHashMap<>();
 
         @Override
         public HttpURLConnection getConnection(final URL url) throws IOException {
@@ -311,7 +311,7 @@ public class HttpUrlConnectorProvider implements ConnectorProvider {
         }
 
         private HttpURLConnection connect(URL url, Proxy proxy) throws IOException {
-            Lock lock = locks.computeIfAbsent(url, u -> new ReentrantLock());
+            Lock lock = locks.computeIfAbsent(url.toString(), u -> new ReentrantLock());
             lock.lock();
             try {
                 return (proxy == null) ? (HttpURLConnection) url.openConnection() : (HttpURLConnection) url.openConnection(proxy);


### PR DESCRIPTION
See issue: https://github.com/eclipse-ee4j/jersey/issues/5814

This patch changes the key type of the `locks` map in `org.glassfish.jersey.client.HttpUrlConnectorProvider` to avoid calling `getInetAddress` on the URL's  every time a URL connection is opened.

This is an issue when using the built-in JVM http proxy mechanism.
