### PR TITLE
Improving SSE Performance

### DIFF
--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -124,18 +124,15 @@ class OutboundEventWriter implements MessageBodyWriter<OutboundSseEvent> {
                     httpHeaders,
                     new OutputStream() {
 
-                        private boolean start = true;
+                        private int lastChar = '\n';
 
                         @Override
                         public void write(final int i) throws IOException {
-                            if (start) {
+                            if (lastChar == '\n') {
                                 entityStream.write(DATA_LEAD);
-                                start = false;
                             }
                             entityStream.write(i);
-                            if (i == '\n') {
-                                entityStream.write(DATA_LEAD);
-                            }
+                            lastChar = i;
                         }
                     });
             entityStream.write(EOL);

--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
@@ -16,6 +16,8 @@
 
 package org.glassfish.jersey.media.sse;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
@@ -43,14 +45,12 @@ import org.glassfish.jersey.message.MessageUtils;
  */
 class OutboundEventWriter implements MessageBodyWriter<OutboundSseEvent> {
 
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-
     // encoding does not matter (lower ASCII characters)
-    private static final byte[] COMMENT_LEAD = ": ".getBytes(UTF8);
-    private static final byte[] NAME_LEAD = "event: ".getBytes(UTF8);
-    private static final byte[] ID_LEAD = "id: ".getBytes(UTF8);
-    private static final byte[] RETRY_LEAD = "retry: ".getBytes(UTF8);
-    private static final byte[] DATA_LEAD = "data: ".getBytes(UTF8);
+    private static final byte[] COMMENT_LEAD = ": ".getBytes(UTF_8);
+    private static final byte[] NAME_LEAD = "event: ".getBytes(UTF_8);
+    private static final byte[] ID_LEAD = "id: ".getBytes(UTF_8);
+    private static final byte[] RETRY_LEAD = "retry: ".getBytes(UTF_8);
+    private static final byte[] DATA_LEAD = "data: ".getBytes(UTF_8);
     private static final byte[] EOL = {'\n'};
 
     private final Provider<MessageBodyWorkers> workersProvider;

--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
@@ -122,20 +122,26 @@ class OutboundEventWriter implements MessageBodyWriter<OutboundSseEvent> {
                     annotations,
                     eventMediaType,
                     httpHeaders,
-                    new OutputStream() {
-
-                        private int lastChar = '\n';
-
-                        @Override
-                        public void write(final int i) throws IOException {
-                            if (lastChar == '\n') {
-                                entityStream.write(DATA_LEAD);
-                            }
-                            entityStream.write(i);
-                            lastChar = i;
-                        }
-                    });
+                    new DataLeadStream(entityStream));
             entityStream.write(EOL);
+        }
+    }
+
+    private static final class DataLeadStream extends OutputStream {
+        private final OutputStream entityStream;
+        private int lastChar = '\n';
+
+        DataLeadStream(final OutputStream entityStream) {
+            this.entityStream = entityStream;
+        }
+
+        @Override
+        public final void write(final int i) throws IOException {
+            if (lastChar == '\n') {
+                entityStream.write(DATA_LEAD);
+            }
+            entityStream.write(i);
+            lastChar = i;
         }
     }
 }


### PR DESCRIPTION
SSE, in contrast to "usual" polling-style REST APIs, typically implies a comparably higher amount of messages sent to a comparably higher amount of peers, as a lot of events is sent to a lot of observers each time a resource is modified.

To reduce server load, it makes sense to make the event sending part as lean as possible.

Due to that reasoning I propose the adoption of the attached changes:
* Make the actual critical path (i. e. the inner per-character-loop needed to attach the `DATA_LEAD` prefix) as fast as possible, making it at most likely for inlining, even if it might make the code three lines longer and slightly harder to read.
* Don't use lookups where static information can be provided (here: UTF-8 charset) - *This change is independent of SSE, but I just came across it when looking at the sole changed code file.*

*NB: The outcome of this PR is even **more correct** than the original code, as a trailing `\n` as the last character produced by the "inner" MBW previously lead to a "dangling" (i. e. otherwise empty) `DATA_LEAD` prefix!*