### PR TITLE
Pass tests on JDK 24

### DIFF
--- a/tests/integration/cdi-integration/pom.xml
+++ b/tests/integration/cdi-integration/pom.xml
@@ -66,7 +66,7 @@
         <profile>
             <id>gf-inject</id>
             <activation>
-                <jdk>[11,)</jdk>
+                <jdk>[11,24)</jdk>
             </activation>
             <modules>
                 <module>gf-cdi-inject</module>


### PR DESCRIPTION
JDK 24 does not support SNI for 127.0.0.1 by java.net.http client GF does not start with JDK 24