### PR TITLE
Added the basic Develocity configuration.

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,6 +38,8 @@ jobs:
           cache: maven
       - name: Copyright
         run: etc/scripts/copyright.sh
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Upload copyright info
         uses: actions/upload-artifact@v4
         with:
@@ -57,6 +59,8 @@ jobs:
           cache: maven
       - name: Checkstyle
         run: etc/scripts/checkstyle.sh
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Upload checkstyle info
         uses: actions/upload-artifact@v4
         with:
@@ -76,6 +80,8 @@ jobs:
           cache: maven
       - name: Build JDK17+ required modules
         run: mvn -B -U -V clean install -DskipTests -pl :jersey-helidon-connector -am
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4.1.0
         with:
@@ -84,6 +90,8 @@ jobs:
           cache: maven
       - name: Build ApiDocs
         run: etc/scripts/apidocs.sh
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
   archetypes:
     timeout-minutes: 45
     runs-on: ubuntu-latest
@@ -97,3 +105,5 @@ jobs:
           cache: maven
       - name: Test archetypes
         run: etc/scripts/test-archetypes.sh
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>ee4j.jersey</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23.1</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+</extensions>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Build Status](https://travis-ci.org/eclipse-ee4j/jersey.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jersey)
 &nbsp;[![EPL-2.0](./etc/epl.svg)](https://www.eclipse.org/legal/epl-2.0/)
 &nbsp;[![GPL+CPE-2.0](./etc/gpl.svg)](https://www.gnu.org/software/classpath/license.html)
+&nbsp;[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://develocity-staging.eclipse.org/)
 
 ### About Jersey
 

--- a/etc/jenkins/Jenkinsfile_EE4J_build
+++ b/etc/jenkins/Jenkinsfile_EE4J_build
@@ -1,5 +1,12 @@
 #!/usr/bin/env groovy
 
+def secrets = [
+    [path: 'cbi/ee4j.jersey/develocity.eclipse.org', secretValues: [
+        [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
+        ]
+    ]
+]
+
 pipeline {
     agent any
     triggers {
@@ -42,7 +49,9 @@ pipeline {
                         done
                        '''
                         configFileProvider([configFile(fileId: CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_XML')]) {
-                            sh "$MVN -s $MAVEN_SETTINGS_XML clean install"
+                            withVault([vaultSecrets: secrets]) {
+                                sh "$MVN -s $MAVEN_SETTINGS_XML clean install"
+                            }
                         }
                     }
                 }

--- a/etc/jenkins/Jenkinsfile_ci_build
+++ b/etc/jenkins/Jenkinsfile_ci_build
@@ -1,3 +1,10 @@
+def secrets = [
+    [path: 'cbi/ee4j.jersey/develocity.eclipse.org', secretValues: [
+        [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
+        ]
+    ]
+]
+
 pipeline {
     agent none
 
@@ -19,9 +26,11 @@ pipeline {
                         maven 'apache-maven-latest'
                     }
                     steps {
-                        sh '''
-                                bash ${WORKSPACE}/etc/jenkins/jenkins_build.sh
-                            '''
+                        withVault([vaultSecrets: secrets]) {
+                            sh '''
+                                    bash ${WORKSPACE}/etc/jenkins/jenkins_build.sh
+                                '''
+                        }
                     }
                 }
                 stage('JDK 11') {
@@ -33,9 +42,11 @@ pipeline {
                         maven 'apache-maven-latest'
                     }
                     steps {
-                        sh '''
-                                bash ${WORKSPACE}/etc/jenkins/jenkins_build.sh
-                            '''
+                        withVault([vaultSecrets: secrets]) {
+                            sh '''
+                                    bash ${WORKSPACE}/etc/jenkins/jenkins_build.sh
+                                '''
+                        }
                     }
                 }
                 stage('JDK 21') {
@@ -47,9 +58,11 @@ pipeline {
                         maven 'apache-maven-latest'
                     }
                     steps {
-                        sh '''
-                                bash ${WORKSPACE}/etc/jenkins/jenkins_build.sh
-                            '''
+                        withVault([vaultSecrets: secrets]) {
+                            sh '''
+                                    bash ${WORKSPACE}/etc/jenkins/jenkins_build.sh
+                                '''
+                        }
                     }
                 }
             }

--- a/etc/jenkins/Jenkinsfile_master_build
+++ b/etc/jenkins/Jenkinsfile_master_build
@@ -1,5 +1,12 @@
 #!/usr/bin/env groovy
 
+def secrets = [
+    [path: 'cbi/ee4j.jersey/develocity.eclipse.org', secretValues: [
+        [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
+        ]
+    ]
+]
+
 pipeline {
     agent any
     triggers {
@@ -42,7 +49,9 @@ pipeline {
                         done
                        '''
                         configFileProvider([configFile(fileId: CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_XML')]) {
-                            sh "$MVN -s $MAVEN_SETTINGS_XML clean install"
+                            withVault([vaultSecrets: secrets]) {
+                                sh "$MVN -s $MAVEN_SETTINGS_XML clean install"
+                            }
                         }
                     }
                 }

--- a/etc/jenkins/Jenkinsfile_release
+++ b/etc/jenkins/Jenkinsfile_release
@@ -21,6 +21,13 @@ node {
     def   RELEASE_FOLDER='.'
     def   RELEASE_BRANCH=BRANCH
 
+    def secrets = [
+        [path: 'cbi/ee4j.jersey/develocity.eclipse.org', secretValues: [
+            [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
+            ]
+        ]
+    ]
+
     env.JAVA_HOME="/opt/tools/java/oracle/jdk-8/1.8.0_181"
     env.PATH="${env.JAVA_HOME}/bin:${env.PATH}"
     sh '/opt/tools/java/oracle/jdk-8/1.8.0_181/bin/java -version'
@@ -144,8 +151,10 @@ node {
                 configFileProvider([configFile(fileId: SECURITY_FILE_ID, targetLocation: '/home/jenkins/.m2/')]) {
 
                     configFileProvider([configFile(fileId: CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_XML')]) {
-                        sh "${MVN_HOME}/bin/mvn -q -B -s ${MAVEN_SETTINGS_XML} -DskipTests -Ddoclint=none -Dadditionalparam='-Xdoclint:none' " +
-                                " -U -C clean package source:jar javadoc:jar ${TARGET}"
+                        withVault([vaultSecrets: secrets]) {
+                            sh "${MVN_HOME}/bin/mvn -q -B -s ${MAVEN_SETTINGS_XML} -DskipTests -Ddoclint=none -Dadditionalparam='-Xdoclint:none' " +
+                                    " -U -C clean package source:jar javadoc:jar ${TARGET}"
+                        }
                     }
                 }
         }


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as explained in the issue #5861.

## Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Local and remote caching was left disabled on this PR by design so that the build is not affected by this change.

The build scans of the Eclipse Jersey project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Jersey project and all other Eclipse projects.

On this Develocity instance, the Eclipse Jersey project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time. For example, look at the [Quarkus instance trends dashboard](https://ge.quarkus.io/scans/trends?search.relativeStartTime=P28D&search.tags=ci&search.timeZoneId=Europe%2FLjubljana) with the `ci` filter applied.
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures. You can also explore the [Quarkus instance](https://ge.quarkus.io/scans/failures?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) for example of a different OSS projects Develocity instance.
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests. Going to the [Quarkus instance](https://ge.quarkus.io/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) again, this will probably give you a better representation of the type of data available. You can also order it by flakiness, which is a good starting point when deciding which tests need fixing the most.

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. 

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**

Note: This PR doesn't configure Travis, as that's not documented in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration). 