### PR TITLE
jnh-connector: Fixed issue where FirstByteCachingStream failed to inc…

### DIFF
--- a/connectors/jnh-connector/src/main/java/org/glassfish/jersey/jnh/connector/JavaNetHttpConnector.java
+++ b/connectors/jnh-connector/src/main/java/org/glassfish/jersey/jnh/connector/JavaNetHttpConnector.java
@@ -377,6 +377,7 @@ public class JavaNetHttpConnector implements Connector {
                 if (zero != -1) {
                     b[off] = (byte) (zero & 0xFF);
                     r = inner.read(b, off + 1, len - 1);
+                    r = (r == -1) ? 1 : r + 1;
                 } else {
                     r = inner.read(b, off, len);
                 }

--- a/connectors/jnh-connector/src/main/java/org/glassfish/jersey/jnh/connector/JavaNetHttpConnector.java
+++ b/connectors/jnh-connector/src/main/java/org/glassfish/jersey/jnh/connector/JavaNetHttpConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/connectors/jnh-connector/src/test/java/org/glassfish/jersey/jnh/connector/FirstByteCachingStreamTest.java
+++ b/connectors/jnh-connector/src/test/java/org/glassfish/jersey/jnh/connector/FirstByteCachingStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/connectors/jnh-connector/src/test/java/org/glassfish/jersey/jnh/connector/FirstByteCachingStreamTest.java
+++ b/connectors/jnh-connector/src/test/java/org/glassfish/jersey/jnh/connector/FirstByteCachingStreamTest.java
@@ -54,6 +54,19 @@ class FirstByteCachingStreamTest {
     }
 
     @Test
+    void testOneByteInArray() throws Exception {
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(new byte[]{'A'});
+        InputStream testIs = createFirstByteCachingStream(byteArrayInputStream);
+        Assertions.assertEquals(1, testIs.available());
+
+        byte[] bytes = new byte[1];
+        int l = testIs.read(bytes);
+        Assertions.assertEquals(1, l);
+        Assertions.assertEquals('A', bytes[0]);
+        Assertions.assertEquals(0, testIs.available());
+    }
+
+    @Test
     void testTwoBytes() throws Exception {
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(new byte[]{'A', 'B'});
         InputStream testIs = createFirstByteCachingStream(byteArrayInputStream);
@@ -73,7 +86,8 @@ class FirstByteCachingStreamTest {
         Assertions.assertEquals(2, testIs.available());
 
         byte[] bytes = new byte[2];
-        testIs.read(bytes);
+        int l = testIs.read(bytes);
+        Assertions.assertEquals(2, l);
         Assertions.assertEquals('A', bytes[0]);
         Assertions.assertEquals('B', bytes[1]);
         Assertions.assertEquals(0, testIs.available());


### PR DESCRIPTION
Fixed issue where FirstByteCachingStream fails to include the buffered byte in returned data length when reading with array.

When the problem occurred, the returned length was 1 byte less than the actual array content and the consumer failed to "see" the whole response data. Detected through Jackson parse error reporting missing closing '}'.