### PR TITLE
Upgrade HK2-extra osgi-resource-locator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1524,7 +1524,7 @@
             <dependency>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>osgi-resource-locator</artifactId>
-                <version>1.0.3</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.main.hk2</groupId>


### PR DESCRIPTION
3.0.0 version is a major version only to fix versioning issues, otherwise it contains only minor changes.

See release notes: https://github.com/eclipse-ee4j/glassfish-hk2-extra/releases/tag/3.0.0-RELEASE

Releasing a new version of Jersey with this change would allow to integrate the new version of HK2-extra into GlassFish. Without this, GlassFish gets OSGi version conflicts, see: https://github.com/eclipse-ee4j/glassfish/pull/25366