### PR TITLE
Removed obsolete-for-removal UTF8 constant

### DIFF
--- a/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
+++ b/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.jersey.grizzly2.httpserver;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ThreadFactory;
 
 import jakarta.ws.rs.ProcessingException;
@@ -39,7 +40,6 @@ import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.grizzly.http.server.ServerConfiguration;
 import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
-import org.glassfish.grizzly.utils.Charsets;
 
 /**
  * Factory for creating Grizzly Http Server.
@@ -321,7 +321,7 @@ public final class GrizzlyHttpServerFactory {
         }
 
         config.setPassTraceRequest(true);
-        config.setDefaultQueryEncoding(Charsets.UTF8_CHARSET);
+        config.setDefaultQueryEncoding(StandardCharsets.UTF_8);
 
         if (start) {
             try {

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/AbstractMessageReaderWriterProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/AbstractMessageReaderWriterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,14 +40,6 @@ import jakarta.ws.rs.ext.MessageBodyWriter;
 public abstract class AbstractMessageReaderWriterProvider<T> implements MessageBodyReader<T>, MessageBodyWriter<T> {
 
     // TODO: refactor away all constants & static wrappers of ReaderWriter methods and constants - those can be used directly.
-
-    /**
-     * The UTF-8 Charset.
-     *
-     * @deprecated use {@code StandardCharsets.UTF_8} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public static final Charset UTF8 = StandardCharsets.UTF_8;
 
     /**
      * Reader bytes from an input stream and write then to an output stream.

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,13 +52,7 @@ import org.glassfish.jersey.message.MessageProperties;
 public final class ReaderWriter {
 
     private static final Logger LOGGER = Logger.getLogger(ReaderWriter.class.getName());
-    /**
-     * The UTF-8 Charset.
-     *
-     * @deprecated use {@code StandardCharsets.UTF_8} instead
-     */
-    @Deprecated(forRemoval = true)
-    public static final Charset UTF8 = StandardCharsets.UTF_8;
+
     /**
      * The buffer size for arrays of byte and character.
      */

--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/BaseJsonMarshaller.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/BaseJsonMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,11 +16,12 @@
 
 package org.glassfish.jersey.jettison.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.nio.charset.Charset;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
@@ -39,8 +40,6 @@ import org.glassfish.jersey.jettison.JettisonMarshaller;
  * @author Michal Gajdos
  */
 public class BaseJsonMarshaller implements JettisonMarshaller, JettisonConfigured {
-
-    private static final Charset UTF8 = Charset.forName("UTF-8");
 
     protected final Marshaller jaxbMarshaller;
     protected JettisonConfig jsonConfig;
@@ -67,7 +66,7 @@ public class BaseJsonMarshaller implements JettisonMarshaller, JettisonConfigure
             throw new IllegalArgumentException("The output stream is null");
         }
 
-        marshallToJSON(o, new OutputStreamWriter(outputStream, UTF8));
+        marshallToJSON(o, new OutputStreamWriter(outputStream, UTF_8));
     }
 
     public void marshallToJSON(Object o, Writer writer) throws JAXBException {

--- a/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/BaseJsonUnmarshaller.java
+++ b/media/json-jettison/src/main/java/org/glassfish/jersey/jettison/internal/BaseJsonUnmarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,10 +16,11 @@
 
 package org.glassfish.jersey.jettison.internal;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.Charset;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -41,8 +42,6 @@ import org.glassfish.jersey.jettison.JettisonUnmarshaller;
  */
 public class BaseJsonUnmarshaller implements JettisonUnmarshaller, JettisonConfigured {
 
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-
     protected final Unmarshaller jaxbUnmarshaller;
     protected final JettisonConfig jsonConfig;
 
@@ -62,7 +61,7 @@ public class BaseJsonUnmarshaller implements JettisonUnmarshaller, JettisonConfi
 
     // JsonUnmarshaller
     public <T> T unmarshalFromJSON(InputStream inputStream, Class<T> expectedType) throws JAXBException {
-        return unmarshalFromJSON(new InputStreamReader(inputStream, UTF8), expectedType);
+        return unmarshalFromJSON(new InputStreamReader(inputStream, UTF_8), expectedType);
     }
 
     @SuppressWarnings("unchecked")
@@ -75,7 +74,7 @@ public class BaseJsonUnmarshaller implements JettisonUnmarshaller, JettisonConfi
     }
 
     public <T> JAXBElement<T> unmarshalJAXBElementFromJSON(InputStream inputStream, Class<T> declaredType) throws JAXBException {
-        return unmarshalJAXBElementFromJSON(new InputStreamReader(inputStream, UTF8), declaredType);
+        return unmarshalJAXBElementFromJSON(new InputStreamReader(inputStream, UTF_8), declaredType);
     }
 
     public <T> JAXBElement<T> unmarshalJAXBElementFromJSON(Reader reader, Class<T> declaredType) throws JAXBException {

--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/OutboundEventWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,6 +15,8 @@
  */
 
 package org.glassfish.jersey.media.sse;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -43,14 +45,12 @@ import org.glassfish.jersey.message.MessageUtils;
  */
 class OutboundEventWriter implements MessageBodyWriter<OutboundSseEvent> {
 
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-
     // encoding does not matter (lower ASCII characters)
-    private static final byte[] COMMENT_LEAD = ": ".getBytes(UTF8);
-    private static final byte[] NAME_LEAD = "event: ".getBytes(UTF8);
-    private static final byte[] ID_LEAD = "id: ".getBytes(UTF8);
-    private static final byte[] RETRY_LEAD = "retry: ".getBytes(UTF8);
-    private static final byte[] DATA_LEAD = "data: ".getBytes(UTF8);
+    private static final byte[] COMMENT_LEAD = ": ".getBytes(UTF_8);
+    private static final byte[] NAME_LEAD = "event: ".getBytes(UTF_8);
+    private static final byte[] ID_LEAD = "id: ".getBytes(UTF_8);
+    private static final byte[] RETRY_LEAD = "retry: ".getBytes(UTF_8);
+    private static final byte[] DATA_LEAD = "data: ".getBytes(UTF_8);
     private static final byte[] EOL = {'\n'};
 
     private final Provider<MessageBodyWorkers> workersProvider;


### PR DESCRIPTION
# Aim

The target of this PR is to finally remove the `UTF8` custom constants which are currently deprecated-for-removal.

# Justification

There is no need to keep custom constants without a good reason.

4.0 is a major release, so removing code which is deprecated-for-removal is justified and does not break SemVer rules.

`StandardCharsets.UTF_8` exists since Java 7. Minimum supported JRE in 4.0 is 17+.