### PR TITLE
Fix wrong handling of duplicate cookies

### DIFF
--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/CookiesParser.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/CookiesParser.java
@@ -94,7 +94,9 @@ public class CookiesParser {
     private static void checkSimilarCookieName(Map<String, Cookie> cookies, MutableCookie cookie) {
         if (cookie != null) {
             if (cookies.containsKey(cookie.name)){
-                if (cookie.path.length() >= cookies.get(cookie.name).getPath().length()){
+                int pathLen = cookie.path == null ? 0 : cookie.path.length();
+                int oldPathLen = cookies.get(cookie.name).getPath() == null ? 0 : cookies.get(cookie.name).getPath().length();
+                if (pathLen >= oldPathLen) {
                     cookies.put(cookie.name, cookie.getImmutableCookie());
                 }
             } else {

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/CookiesParser.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/CookiesParser.java
@@ -94,7 +94,7 @@ public class CookiesParser {
     private static void checkSimilarCookieName(Map<String, Cookie> cookies, MutableCookie cookie) {
         if (cookie != null) {
             if (cookies.containsKey(cookie.name)){
-                if (cookie.path.length() > cookies.get(cookie.name).getPath().length()){
+                if (cookie.path.length() >= cookies.get(cookie.name).getPath().length()){
                     cookies.put(cookie.name, cookie.getImmutableCookie());
                 }
             } else {

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/CookiesParser.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/CookiesParser.java
@@ -87,14 +87,14 @@ public class CookiesParser {
 
     /**
      * Check if a cookie with identical name had been parsed.
-     * If yes, the one with the longest string will be kept
+     * If yes, the one with the longest path will be kept
      * @param cookies : Map of cookies
      * @param cookie : Cookie to be checked
      */
     private static void checkSimilarCookieName(Map<String, Cookie> cookies, MutableCookie cookie) {
         if (cookie != null) {
             if (cookies.containsKey(cookie.name)){
-                if (cookie.value.length() > cookies.get(cookie.name).getValue().length()){
+                if (cookie.path.length() > cookies.get(cookie.name).getPath().length()){
                     cookies.put(cookie.name, cookie.getImmutableCookie());
                 }
             } else {


### PR DESCRIPTION
----
Handling duplicate cookies on server side has no clear specification.

But if there is any hint or common-sense about it, it is the "longest **path**" wins, instead of currently implemented logic of "longest **value**" wins.

Section [5.4](https://www.rfc-editor.org/rfc/rfc6265#section-5.4), subsection 2 has this to say:

```
The user agent SHOULD sort the cookie-list in the following order:

Cookies with longer paths are listed before cookies with shorter paths.
NOTE: Not all user agents sort the cookie-list in this order, but this order reflects common practice when this document was written, and, historically, there have been servers that (erroneously) depended on this order.
```
though it is not for server side, it does mention how the path of cookie matters.


----
For duplicate cookies that has even same path, let us use the last value, as have been doing in earlier version (such as 2.22.1).

For example:

- Visit https://site1.domain/, it sets cookieX=value1, domain=.domain, path=/

- Visit https://site2.subdomain.domain/, it sets cookieX=value2, domain=.subdomain.domain, path=/

- Visit https://site2.subdomain.domain/ again, the Browser will just send cookies with the creation order (because the path are same, browsers have no idea which should be first), i.e., cookieX=value1;cookieX=value2

- Previous implementation of CookieParser will result in the cookieX=value1 being used, then the server side is not satisfied with the cookie value. (Actually in earlier version(2.22.1) it uses cookieX=value2.)

Let us use the last cookie value, so both web sites will work,
- Visit https://site2.subdomain.domain/ will use value2
- Visit https://site1.domain/ will use value1 because the domain of value2 can not be applied to this parent domain.