### PR TITLE
fix: jaxrs-ri import-package on org.glassfish.hk2.osgiresourcelocator

### DIFF
--- a/bundles/jaxrs-ri/pom.xml
+++ b/bundles/jaxrs-ri/pom.xml
@@ -302,6 +302,7 @@
                             javax.xml.transform.stream;resolution:=optional,
                             org.w3c.dom;resolution:=optional,
                             org.xml.sax;resolution:=optional,
+                            org.glassfish.hk2.osgiresourcelocator;version="[1.0,2)",
                             ${hk2.osgi.version},
                             *
                         ]]></Import-Package>


### PR DESCRIPTION
Refer to issue: https://github.com/eclipse-ee4j/jersey/issues/5946

Where import-package for org.glassfish.hk2.osgiresourcelocator doesn't seem's correct, it's catched by the global import: `${hk2.osgi.version}` which resolve to: <hk2.osgi.version>org.glassfish.hk2.*;version="[2.5,4)"</hk2.osgi.version>.

But `osgiresourcelocator` is not following other `org.glassfish.hk2.*` versioning.

One `jaxrs-ri` repackaged bundle: `jersey-commons:2.47` is using 1.x version of `osgiresourcelocator`
```
<dependency>
                <groupId>org.glassfish.hk2</groupId>
                <artifactId>osgi-resource-locator</artifactId>
                <version>1.0.3</version>
            </dependency>
```