### PR TITLE
OSGi Package Incompatibility

### DIFF
--- a/ext/microprofile/mp-rest-client/pom.xml
+++ b/ext/microprofile/mp-rest-client/pom.xml
@@ -121,6 +121,7 @@
                             ${cdi.osgi.version},
                             jakarta.decorator.*;version="[3.0,5)",
                             org.eclipse.microprofile.config.*;version="!",
+                            org.eclipse.microprofile.rest.client;version="[2.0,3)",
                             *
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
Jersey 3.1.11 increased the imported OSGi package version of the microprofile rest client, causing compatibility issues with OSGi dependents.

This PR forces the import version to its prior value to fix the issue.