### PR TITLE
Expand MicroProfile Rest Client OSGi Range

### DIFF
--- a/ext/microprofile/mp-rest-client/pom.xml
+++ b/ext/microprofile/mp-rest-client/pom.xml
@@ -121,6 +121,7 @@
                             ${cdi.osgi.version},
                             jakarta.decorator.*;version="[3.0,5)",
                             org.eclipse.microprofile.config.*;version="!",
+                            org.eclipse.microprofile.rest.client;version="[2.0,3)",
                             *
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
Support for MicroProfile REST client 4.0 was added in this PR: https://github.com/eclipse-ee4j/jersey/pull/5831

Given that a TCK runner for version 3.0 was added alongside the new 4.0 version in the same PR I assume the intent was to support both 3.0 and 4.0 versions.

If so, then the OSGi version range configuration of the `org.eclipse.microprofile.rest.client` package needs to expanded to still include the version provided by the 3.0 API.

Without this change, an OSGi runtime still providing the REST Client 3.0 API will fail to resolve.