### PR TITLE
OSGi Package Incompatibility (Alternate)

### DIFF
--- a/ext/microprofile/mp-rest-client/pom.xml
+++ b/ext/microprofile/mp-rest-client/pom.xml
@@ -121,6 +121,8 @@
                             ${cdi.osgi.version},
                             jakarta.decorator.*;version="[3.0,5)",
                             org.eclipse.microprofile.config.*;version="!",
+                            org.eclipse.microprofile.rest.client;version="!",
+                            org.eclipse.microprofile.rest.client.*;version="!",
                             *
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
Alternate of https://github.com/eclipse-ee4j/jersey/pull/5993

Jersey 3.1.11 increased the imported OSGi package version of the microprofile rest client, causing compatibility issues with OSGi dependents.

This PR removes the package import version validation to fix the issue as per https://github.com/eclipse-ee4j/jersey/pull/5993#discussion_r2370343132
