### PR TITLE
Upgrading Netty, Jetty and Spring 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2198,7 +2198,7 @@
         <kryo.version>4.0.3</kryo.version>
         <mockito.version>4.11.0</mockito.version> <!-- CQ 17673 -->
         <mustache.version>0.9.14</mustache.version>
-        <netty.version>4.1.122.Final</netty.version>
+        <netty.version>4.1.125.Final</netty.version>
         <opentracing.version>0.33.0</opentracing.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.framework.version>1.10.0</osgi.framework.version>
@@ -2217,7 +2217,7 @@
         <servlet6.version>6.1.0</servlet6.version>
 
         <slf4j.version>2.0.17</slf4j.version>
-        <spring6.version>6.0.23</spring6.version>
+        <spring6.version>6.2.11</spring6.version>
         <testng.version>7.11.0</testng.version>
         <testng6.version>6.14.3</testng6.version>
         <thymeleaf.version>3.1.3.RELEASE</thymeleaf.version>
@@ -2270,7 +2270,7 @@
         <jaxrs.api.impl.version>4.0.0</jaxrs.api.impl.version>
         <jakarta.rest.osgi.version>jakarta.ws.rs;version="[3.1,5)",jakarta.ws.rs.client;version="[3.1,5)",jakarta.ws.rs.container;version="[3.1,5)",jakarta.ws.rs.core;version="[3.1,5)",jakarta.ws.rs.ext;version="[3.1,5)",jakarta.ws.rs.sse;version="[3.1,5)"</jakarta.rest.osgi.version>
         <jetty.osgi.version>org.eclipse.jetty.*;version="[11,15)"</jetty.osgi.version>
-        <jetty.version>12.0.22</jetty.version>
+        <jetty.version>12.0.27</jetty.version>
         <jetty9.version>9.4.57.v20241219</jetty9.version>
         <jetty11.version>11.0.25</jetty11.version>
         <jetty.plugin.version>12.0.22</jetty.plugin.version>


### PR DESCRIPTION
### Summary

## Why
To remove the CVEs as outlined below:

Netty
CVE-2025-55163	
CVE-2025-58056
CVE-2025-58057

Jetty
CVE-2025-5115

Spring6
CVE-2024-38820
CVE-2025-22233
CVE-2025-41234
CVE-2025-41249

## What
Upgrade the dependency versions

Netty - 4.1.122.Final -> 4.1.125.Final
Jetty - 12.0.22 -> 12.0.27
Spring6 - 6.0.23 -> 6.2.11

## Evidence
[trivy_output.json](https://github.com/user-attachments/files/22719857/trivy_output.json)

## Additional Resources
I was fixing the Jettison CVEs and there is a test case which is failing. I have raised a question about the same. This would be raised as a separate PR post the discussion.
https://github.com/eclipse-ee4j/jersey/discussions/6005