### PR TITLE
Deadlock with JerseyClassAnalyzer#resolverAnnotations #5996

### DIFF
--- a/inject/hk2/src/main/java/org/glassfish/jersey/inject/hk2/JerseyClassAnalyzer.java
+++ b/inject/hk2/src/main/java/org/glassfish/jersey/inject/hk2/JerseyClassAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -35,9 +34,6 @@ import org.glassfish.jersey.internal.Errors;
 import org.glassfish.jersey.internal.LocalizationMessages;
 import org.glassfish.jersey.internal.inject.InjectionResolver;
 import org.glassfish.jersey.internal.util.collection.ImmutableCollectors;
-import org.glassfish.jersey.internal.util.collection.LazyValue;
-import org.glassfish.jersey.internal.util.collection.Value;
-import org.glassfish.jersey.internal.util.collection.Values;
 
 import org.glassfish.hk2.api.ClassAnalyzer;
 import org.glassfish.hk2.api.MultiException;
@@ -79,33 +75,31 @@ public final class JerseyClassAnalyzer implements ClassAnalyzer {
 
         @Override
         protected void configure() {
-            ClassAnalyzer defaultAnalyzer =
-                    serviceLocator.getService(ClassAnalyzer.class, ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME);
-
-            Supplier<List<InjectionResolver>> resolvers = () -> serviceLocator.getAllServices(InjectionResolver.class);
-
-            bind(new JerseyClassAnalyzer(defaultAnalyzer, resolvers))
+            bind(JerseyClassAnalyzer.class)
                     .analyzeWith(ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME)
                     .named(JerseyClassAnalyzer.NAME)
                     .to(ClassAnalyzer.class);
         }
     }
 
+    private final Set<Class> resolverAnnotations;
     private final ClassAnalyzer defaultAnalyzer;
-    private final LazyValue<Set<Class>> resolverAnnotations;
+
     /**
      * Injection constructor.
      *
-     * @param defaultAnalyzer   default HK2 class analyzer.
-     * @param supplierResolvers configured injection resolvers.
+     * @param serviceLocator current injection manager.
      */
-    private JerseyClassAnalyzer(ClassAnalyzer defaultAnalyzer, Supplier<List<InjectionResolver>> supplierResolvers) {
-        this.defaultAnalyzer = defaultAnalyzer;
-        Value<Set<Class>> resolvers = () -> supplierResolvers.get().stream()
+    @Inject
+    public JerseyClassAnalyzer(ServiceLocator serviceLocator) {
+        defaultAnalyzer = serviceLocator.getService(ClassAnalyzer.class, ClassAnalyzer.DEFAULT_IMPLEMENTATION_NAME);
+        // Load the resolver annotations once to avoid potential deadlock later
+        // See https://github.com/eclipse-ee4j/jersey/issues/5996
+        List<InjectionResolver> resolvers = serviceLocator.getAllServices(InjectionResolver.class);
+        this.resolverAnnotations = resolvers.stream()
                 .filter(InjectionResolver::isConstructorParameterIndicator)
                 .map(InjectionResolver::getAnnotation)
                 .collect(ImmutableCollectors.toImmutableSet());
-        this.resolverAnnotations = Values.lazy(resolvers);
     }
 
     @SuppressWarnings("unchecked")
@@ -186,7 +180,7 @@ public final class JerseyClassAnalyzer implements ClassAnalyzer {
 
         final int paramSize = constructor.getParameterTypes().length;
 
-        if (paramSize != 0 && resolverAnnotations.get().isEmpty()) {
+        if (paramSize != 0 && resolverAnnotations.isEmpty()) {
             return false;
         }
 
@@ -200,7 +194,7 @@ public final class JerseyClassAnalyzer implements ClassAnalyzer {
         for (final Annotation[] paramAnnotations : constructor.getParameterAnnotations()) {
             boolean found = false;
             for (final Annotation paramAnnotation : paramAnnotations) {
-                if (resolverAnnotations.get().contains(paramAnnotation.annotationType())) {
+                if (resolverAnnotations.contains(paramAnnotation.annotationType())) {
                     found = true;
                     break;
                 }


### PR DESCRIPTION
See the analysis here: https://github.com/eclipse-ee4j/jersey/issues/5996

There are no tests because it is tricky to create a test for the dead lock. It would require to modify some existing classes just for this purpose.

The problem is that JerseyClassAnalyzer is invoking lazily `ServiceLocatorImpl#getAllServices` within an HTTP request. That holds a lock inside HK2 in a moment where there could be a dead lock.

The fix is about initialize it in the moment the server starts, so we avoid that problematic stack trace to happen within an HTTP request.

This is how it was before the fix:
```
"jetty-thread-36@2197" prio=5 tid=0x24 nid=NA waiting
  java.lang.Thread.State: WAITING
	at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:221)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireShared(AbstractQueuedSynchronizer.java:1079)
	at java.util.concurrent.locks.ReentrantReadWriteLock$ReadLock.lock(ReentrantReadWriteLock.java:738)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.internalGetAllServiceHandles(ServiceLocatorImpl.java:1440)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getAllServices(ServiceLocatorImpl.java:799)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getAllServices(ServiceLocatorImpl.java:787)
	at org.glassfish.jersey.inject.hk2.JerseyClassAnalyzer$Binder.lambda$configure$0(JerseyClassAnalyzer.java:85)
	at org.glassfish.jersey.inject.hk2.JerseyClassAnalyzer$Binder$$Lambda/0x0000025a58188560.get(Unknown Source:-1)
	at org.glassfish.jersey.inject.hk2.JerseyClassAnalyzer.lambda$new$0(JerseyClassAnalyzer.java:104)
	at org.glassfish.jersey.inject.hk2.JerseyClassAnalyzer$$Lambda/0x0000025a581889c0.get(Unknown Source:-1)
	at org.glassfish.jersey.internal.util.collection.Values$LazyValueImpl.get(Values.java:317)
	  - locked <0x11ce> (a java.lang.Object)
	at org.glassfish.jersey.inject.hk2.JerseyClassAnalyzer.isCompatible(JerseyClassAnalyzer.java:189)
	at org.glassfish.jersey.inject.hk2.JerseyClassAnalyzer.getConstructor(JerseyClassAnalyzer.java:156)
	at org.jvnet.hk2.internal.Utilities.getConstructor(Utilities.java:156)
	at org.jvnet.hk2.internal.ClazzCreator.initialize(ClazzCreator.java:105)
	at org.jvnet.hk2.internal.ClazzCreator.initialize(ClazzCreator.java:156)
	at org.jvnet.hk2.internal.SystemDescriptor.internalReify(SystemDescriptor.java:716)
	at org.jvnet.hk2.internal.SystemDescriptor.reify(SystemDescriptor.java:670)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.reifyDescriptor(ServiceLocatorImpl.java:442)
	at org.jvnet.hk2.internal.Utilities.createService(Utilities.java:2066)
	at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:93)
	  - locked <0x11cf> (a java.lang.Object)
	at org.jvnet.hk2.internal.ServiceHandleImpl.getService(ServiceHandleImpl.java:67)
	at org.glassfish.jersey.inject.hk2.AbstractHk2InjectionManager.getInstance(AbstractHk2InjectionManager.java:156)
	at org.glassfish.jersey.inject.hk2.ImmediateHk2InjectionManager.getInstance(ImmediateHk2InjectionManager.java:30)
	at org.glassfish.jersey.server.internal.inject.BeanParamValueParamProvider$BeanParamValueProvider.apply(BeanParamValueParamProvider.java:73)
	at org.glassfish.jersey.server.internal.inject.BeanParamValueParamProvider$BeanParamValueProvider.apply(BeanParamValueParamProvider.java:44)
	at org.glassfish.jersey.server.spi.internal.ParamValueFactoryWithSource.apply(ParamValueFactoryWithSource.java:50)
	at org.glassfish.jersey.server.spi.internal.ParameterValueHelper.getParameterValues(ParameterValueHelper.java:64)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$AbstractMethodParamInvoker.getParamValues(JavaResourceMethodDispatcherProvider.java:109)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$TypeOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:219)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:93)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:478)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:400)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:256)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:235)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:684)
```

And this is how it is now:

```
Thread [ForkJoinPool-1-worker-1] (Suspended (breakpoint at line 99 in JerseyClassAnalyzer))	
	owns: Object  (id=84)	
	owns: Object  (id=85)	
	owns: Issue5996Test  (id=86)	
	JerseyClassAnalyzer.<init>(ServiceLocator) line: 99	
	DirectMethodHandle$Holder.newInvokeSpecial(Object, Object) line: not available	
	0x00007f30d4014400.invoke(Object, Object) line: not available	
	Invokers$Holder.invokeExact_MT(Object, Object, Object) line: not available	
	DirectConstructorHandleAccessor.invokeImpl(Object[]) line: 87	
	DirectConstructorHandleAccessor.newInstance(Object[]) line: 62	
	Constructor<T>.newInstanceWithCaller(Object[], boolean, Class<?>) line: 502	
	Constructor<T>.newInstance(Object...) line: 486	
	ReflectionHelper.makeMe(Constructor<?>, Object[], boolean) line: 1356	
	ClazzCreator<T>.createMe(Map<SystemInjecteeImpl,Object>) line: 248	
	ClazzCreator<T>.create(ServiceHandle<?>, SystemDescriptor<?>) line: 342	
	SystemDescriptor<T>.create(ServiceHandle<?>) line: 463	
	PerLookupContext.findOrCreate(ActiveDescriptor<T>, ServiceHandle<?>) line: 46	
	Utilities.createService(ActiveDescriptor<T>, Injectee, ServiceLocatorImpl, ServiceHandle<T>, Class<?>) line: 2102	
	ServiceHandleImpl<T>.getService(ServiceHandle<T>) line: 93	
	ServiceHandleImpl<T>.getService() line: 67	
	ServiceLocatorImpl.reupClassAnalyzers() line: 1997	
	ServiceLocatorImpl.reup(List<SystemDescriptor<?>>, boolean, boolean, boolean, boolean, boolean, HashSet<String>, boolean) line: 2059	
	ServiceLocatorImpl.addConfiguration(DynamicConfigurationImpl) line: 2114	
	DynamicConfigurationImpl.commit() line: 262	
	ServiceLocatorUtilities.bind(ServiceLocator, Binder...) line: 166	
	ImmediateHk2InjectionManager(AbstractHk2InjectionManager).<init>(Object) line: 66	
	ImmediateHk2InjectionManager.<init>(Object) line: 38	
	Hk2InjectionManagerFactory$Hk2InjectionManagerStrategy$1.createInjectionManager(Object) line: 55	
	Hk2InjectionManagerFactory.create(Object) line: 73	
	Injections.createInjectionManager(Object) line: 81	
	ApplicationHandler.<init>(Application, Binder, Object) line: 261	
	ApplicationHandler.<init>(Application, Binder) line: 248	
```

In previous stacktrace it is triggered when `ApplicationHandler.handle` and in the other when application gets deployed `ApplicationHandler.<init>`