### PR TITLE
Issue #6002 | Ignore warnings for get method consumes entity

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/ApplicationHandler.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ApplicationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the

--- a/core-server/src/main/java/org/glassfish/jersey/server/ApplicationHandler.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ApplicationHandler.java
@@ -366,7 +366,7 @@ public final class ApplicationHandler implements ContainerLifecycleListener {
 
             if (!disableValidation()) {
                 ComponentModelValidator validator = new ComponentModelValidator(
-                        bootstrapBag.getValueParamProviders(), bootstrapBag.getMessageBodyWorkers());
+                        bootstrapBag.getValueParamProviders(), bootstrapBag.getMessageBodyWorkers(), runtimeConfig);
                     validator.validate(bootstrapBag.getResourceModel());
             }
 

--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerProperties.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/core-server/src/main/java/org/glassfish/jersey/server/ServerProperties.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ServerProperties.java
@@ -462,6 +462,23 @@ public final class ServerProperties {
             "jersey.config.server.resource.validation.ignoreErrors";
 
     /**
+     * If {@code true} then validation of application resource models will not log a warning when a get resource method consumes an entity.
+     *
+     * This impacts both the validation of root resources during deployment as well as validation of any sub resources
+     * returned from sub-resource locators.
+     * <p>
+     * The default value is {@code false}.
+     * </p>
+     * <p>
+     * The name of the configuration property is <tt>{@value}</tt>.
+     * </p>
+     *
+     * @see #RESOURCE_VALIDATION_DISABLE
+     */
+    public static final String RESOURCE_VALIDATION_IGNORE_GET_CONSUMES_ENTITY_WARNINGS =
+            "jersey.config.server.resource.validation.ignoreGetConsumesEntityWarnings";
+
+    /**
      * If {@code true} then application monitoring will be enabled.
      *
      * This will enable the possibility

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/RuntimeLocatorModelBuilder.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/RuntimeLocatorModelBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/RuntimeLocatorModelBuilder.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/internal/routing/RuntimeLocatorModelBuilder.java
@@ -228,7 +228,7 @@ final class RuntimeLocatorModelBuilder {
         Errors.process(new Runnable() {
             @Override
             public void run() {
-                final ComponentModelValidator validator = new ComponentModelValidator(valueSuppliers, messageBodyWorkers);
+                final ComponentModelValidator validator = new ComponentModelValidator(valueSuppliers, messageBodyWorkers, config);
                 validator.validate(component);
 
                 if (Errors.fatalIssuesFound() && !ignoreValidationErrors) {

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/ComponentModelValidator.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/ComponentModelValidator.java
@@ -23,8 +23,11 @@ import java.util.List;
 import org.glassfish.jersey.Severity;
 import org.glassfish.jersey.internal.Errors;
 import org.glassfish.jersey.message.MessageBodyWorkers;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.model.internal.ModelErrors;
 import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
+
+import javax.ws.rs.core.Configuration;
 
 /**
  * A resource model validator that checks the given resource model.
@@ -57,10 +60,16 @@ public final class ComponentModelValidator {
     private final List<ResourceModelIssue> issueList = new LinkedList<>();
 
     public ComponentModelValidator(Collection<ValueParamProvider> valueParamProviders, MessageBodyWorkers msgBodyWorkers) {
+        this(valueParamProviders, msgBodyWorkers, null);
+    }
+
+    public ComponentModelValidator(Collection<ValueParamProvider> valueParamProviders,
+                                   MessageBodyWorkers msgBodyWorkers,
+                                   Configuration configuration) {
         validators = new ArrayList<>();
         validators.add(new ResourceValidator());
         validators.add(new RuntimeResourceModelValidator(msgBodyWorkers));
-        validators.add(new ResourceMethodValidator(valueParamProviders));
+        validators.add(new ResourceMethodValidator(valueParamProviders, configuration));
         validators.add(new InvocableValidator());
     }
 

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/ComponentModelValidator.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/ComponentModelValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodValidator.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodValidator.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/model/ResourceMethodValidator.java
@@ -37,9 +37,11 @@ import javax.ws.rs.MatrixParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Configuration;
 
 import org.glassfish.jersey.internal.Errors;
 import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.internal.LocalizationMessages;
 import org.glassfish.jersey.server.model.internal.SseTypeResolver;
 import org.glassfish.jersey.server.spi.internal.ParameterValueHelper;
@@ -54,9 +56,15 @@ import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
 class ResourceMethodValidator extends AbstractResourceModelVisitor {
 
     private final Collection<ValueParamProvider> valueParamProviders;
+    private final Configuration configuration;
 
     ResourceMethodValidator(Collection<ValueParamProvider> valueParamProviders) {
+        this(valueParamProviders, null);
+    }
+
+    ResourceMethodValidator(Collection<ValueParamProvider> valueParamProviders, Configuration configuration) {
         this.valueParamProviders = valueParamProviders;
+        this.configuration = configuration;
     }
 
     @Override
@@ -99,7 +107,7 @@ class ResourceMethodValidator extends AbstractResourceModelVisitor {
             }
 
             // ensure GET does not consume an entity parameter, if not inflector-based
-            if (invocable.requiresEntity() && !invocable.isInflector()) {
+            if (invocable.requiresEntity() && !invocable.isInflector() && !shouldIgnoreGetConsumesEntityWarnings(configuration)) {
                 Errors.warning(method, LocalizationMessages.GET_CONSUMES_ENTITY(invocable.getHandlingMethod()));
             }
             // ensure GET does not consume any @FormParam annotated parameter
@@ -151,6 +159,16 @@ class ResourceMethodValidator extends AbstractResourceModelVisitor {
         if (httpMethodAnnotations.size() != 0) {
             checkUnexpectedAnnotations(method);
         }
+    }
+
+    private static Boolean shouldIgnoreGetConsumesEntityWarnings(Configuration configuration) {
+        if (configuration == null) {
+            return Boolean.FALSE;
+        }
+        return ServerProperties.getValue(configuration.getProperties(),
+                ServerProperties.RESOURCE_VALIDATION_IGNORE_GET_CONSUMES_ENTITY_WARNINGS,
+                Boolean.FALSE,
+                Boolean.class);
     }
 
     private void checkUnexpectedAnnotations(ResourceMethod resourceMethod) {


### PR DESCRIPTION
Hi! I am trying to solve #6002 as per this comment: https://github.com/eclipse-ee4j/jersey/issues/6002#issuecomment-3353186383 

I am trying to do so by propagating `ServerProperties` from the `RuntimeLocatorModelBuilder`/`ApplicationHolder` to `ComponentModelValidator` using a `Settings` class. The only problem I have is that I don't want to break the API by adding a new constructor, so I need a default Settings class, but that then duplicates the default values (Apparently that also happens in `ApplicationHandler` and `RuntimeLocatorModelBuilder`, I am not sure if that is okay. 

I am not very experienced with contributing to open source, any feedback is welcome!