### PR TITLE
Fix Grizzly on close when error

### DIFF
--- a/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpContainer.java
+++ b/containers/grizzly2-http/src/main/java/org/glassfish/jersey/grizzly2/httpserver/GrizzlyHttpContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -231,25 +231,29 @@ public final class GrizzlyHttpContainer extends HttpHandler implements Container
         public OutputStream writeResponseStatusAndHeaders(final long contentLength,
                                                           final ContainerResponse context)
                 throws ContainerException {
-            try {
-                final javax.ws.rs.core.Response.StatusType statusInfo = context.getStatusInfo();
-                if (statusInfo.getReasonPhrase() == null) {
-                    grizzlyResponse.setStatus(statusInfo.getStatusCode());
-                } else {
-                    grizzlyResponse.setStatus(statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
-                }
-
-                grizzlyResponse.setContentLengthLong(contentLength);
-
-                for (final Map.Entry<String, List<String>> e : context.getStringHeaders().entrySet()) {
-                    for (final String value : e.getValue()) {
-                        grizzlyResponse.addHeader(e.getKey(), value);
+            if (!grizzlyResponse.isCommitted()) {
+                try {
+                    final javax.ws.rs.core.Response.StatusType statusInfo = context.getStatusInfo();
+                    if (statusInfo.getReasonPhrase() == null) {
+                        grizzlyResponse.setStatus(statusInfo.getStatusCode());
+                    } else {
+                        grizzlyResponse.setStatus(statusInfo.getStatusCode(), statusInfo.getReasonPhrase());
                     }
-                }
 
-                return grizzlyResponse.getOutputStream();
-            } finally {
-                logger.debugLog("{0} - writeResponseStatusAndHeaders() called", name);
+                    grizzlyResponse.setContentLengthLong(contentLength);
+
+                    for (final Map.Entry<String, List<String>> e : context.getStringHeaders().entrySet()) {
+                        for (final String value : e.getValue()) {
+                            grizzlyResponse.addHeader(e.getKey(), value);
+                        }
+                    }
+
+                    return grizzlyResponse.getOutputStream();
+                } finally {
+                    logger.debugLog("{0} - writeResponseStatusAndHeaders() called", name);
+                }
+            } else {
+                return null;
             }
         }
 


### PR DESCRIPTION
It is related to https://github.com/eclipse-ee4j/jersey/issues/6012 but it does not fix it in Tomcat.

The issue I found is that when there is an error and `jersey.config.server.response.setStatusOverSendError` is not `true`, it writes in the response, and it later fails within the same request with:

```
SEVERE: Error while closing the output stream in order to commit response.
java.lang.IllegalStateException: Illegal attempt to call getOutputStream() after getWriter() has already been called.
	at org.glassfish.grizzly.http.server.Response.getNIOOutputStream(Response.java:578)
	at org.glassfish.grizzly.http.server.Response.getOutputStream(Response.java:602)
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer$ResponseWriter.writeResponseStatusAndHeaders(GrizzlyHttpContainer.java:250)
	at org.glassfish.jersey.server.ServerRuntime$Responder$1.getOutputStream(ServerRuntime.java:681)
	at org.glassfish.jersey.message.internal.CommittingOutputStream.commitStream(CommittingOutputStream.java:174)
	at org.glassfish.jersey.message.internal.CommittingOutputStream.flushBuffer(CommittingOutputStream.java:279)
	at org.glassfish.jersey.message.internal.CommittingOutputStream.commit(CommittingOutputStream.java:235)
	at org.glassfish.jersey.message.internal.CommittingOutputStream.close(CommittingOutputStream.java:250)
	at org.glassfish.jersey.message.internal.OutboundMessageContext.close(OutboundMessageContext.java:569)
	at org.glassfish.jersey.server.ContainerResponse.close(ContainerResponse.java:406)
	at org.glassfish.jersey.server.ServerRuntime$Responder.writeResponse(ServerRuntime.java:763)
	at org.glassfish.jersey.server.ServerRuntime$Responder.processResponse(ServerRuntime.java:398)
	at org.glassfish.jersey.server.ServerRuntime$Responder.processResponseWithDefaultExceptionMapper(ServerRuntime.java:647)
	at org.glassfish.jersey.server.ServerRuntime$Responder.process(ServerRuntime.java:475)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:266)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:253)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:696)
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:367)
	at org.glassfish.grizzly.http.server.HttpHandler$1.run(HttpHandler.java:190)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:535)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:515)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Internally in Grizzly response, the response was committed. This can be check inside:
`org.glassfish.grizzly.http.server.Response#response`

Later when it is getting closed, `CommittingOutputStream` does not know about this. Its `isCommitted` is `false`, and it fails when it tries to commit again.

It is likely we could have this issue in other web containers too.