### PR TITLE
Upgrading the versions of Netty, Jetty and Spring6

### DIFF
--- a/examples/helloworld-spring-webapp/pom.xml
+++ b/examples/helloworld-spring-webapp/pom.xml
@@ -76,6 +76,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-observation</artifactId>
+                </exclusion>
+            </exclusions>
             <version>${spring6.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2120,7 +2120,6 @@
                 <artifactId>opentracing-util</artifactId>
                 <version>${opentracing.version}</version>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 
@@ -2262,7 +2261,7 @@
         <kryo.version>4.0.3</kryo.version>
         <mockito.version>4.11.0</mockito.version> <!-- CQ 17673 -->
         <mustache.version>0.9.14</mustache.version>
-        <netty.version>4.1.122.Final</netty.version>
+        <netty.version>4.1.128.Final</netty.version>
         <opentracing.version>0.33.0</opentracing.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.framework.version>1.10.0</osgi.framework.version>
@@ -2275,7 +2274,7 @@
         <rxjava2.version>2.2.21</rxjava2.version>
         <simple.version>6.0.1</simple.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <spring6.version>6.0.23</spring6.version>
+        <spring6.version>6.2.11</spring6.version>
         <testng.version>7.11.0</testng.version>
         <testng6.version>6.14.3</testng6.version>
         <thymeleaf.version>3.1.2.RELEASE</thymeleaf.version>
@@ -2322,8 +2321,8 @@
         <jaxrs.api.spec.version>3.0</jaxrs.api.spec.version>
         <jaxrs.api.impl.version>3.0.0</jaxrs.api.impl.version>
         <jetty.osgi.version>org.eclipse.jetty.*;version="[11,15)"</jetty.osgi.version>
-        <jetty.version>11.0.25</jetty.version>
-        <jetty9.version>9.4.57.v20241219</jetty9.version>
+        <jetty.version>11.0.26</jetty.version>
+        <jetty9.version>9.4.58.v20250814</jetty9.version>
         <jetty.plugin.version>11.0.25</jetty.plugin.version>
         <jsonb.api.version>2.0.0</jsonb.api.version>
         <jsonp.ri.version>1.0.5</jsonp.ri.version>


### PR DESCRIPTION
**Why**:
To remediate the following vulnerabilities in 3.0 branch:

**Netty**

[CVE-2025-55163](https://nvd.nist.gov/vuln/detail/CVE-2025-55163)
[CVE-2025-58056](https://nvd.nist.gov/vuln/detail/CVE-2025-58056)
[CVE-2025-58057](https://nvd.nist.gov/vuln/detail/CVE-2025-58057)

**Jetty**

[CVE-2025-5115](https://nvd.nist.gov/vuln/detail/CVE-2025-5115)

**Spring 6**

[CVE-2024-38820](https://nvd.nist.gov/vuln/detail/CVE-2024-38820)
[CVE-2025-22233](https://nvd.nist.gov/vuln/detail/CVE-2025-22233)
[CVE-2025-41234](https://nvd.nist.gov/vuln/detail/CVE-2025-41234)
[CVE-2025-41249](https://nvd.nist.gov/vuln/detail/CVE-2025-41249)

**What**:
Upgraded the dependency versions

Netty - 4.1.122.Final -> 4.1.128.Final
Jetty - 11.0.25 -> 11.0.26
Jetty 9 - 9.4.57.v20241219 -> 9.4.58.v20250814
Spring 6 - 6.0.23 -> 6.2.11