### PR TITLE
Fixed OSGI import version for Grizzly

### DIFF
--- a/containers/grizzly2-http/pom.xml
+++ b/containers/grizzly2-http/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -131,7 +131,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            org.glassfish.grizzly.*;version="[3.0,5.0)",
+                            org.glassfish.grizzly.*;version="3",
                             ${jakarta.rest.osgi.version},
                             *
                         </Import-Package>

--- a/containers/grizzly2-servlet/pom.xml
+++ b/containers/grizzly2-servlet/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -71,7 +71,7 @@
                     <instructions>
                         <Import-Package>
                             jakarta.servlet.*;version="[6.0,7.0)",
-                            org.glassfish.grizzly.*;version="[3.0,5.0)",
+                            org.glassfish.grizzly.*;version="3",
                             ${jakarta.rest.osgi.version},
                             *
                         </Import-Package>


### PR DESCRIPTION
- We use 4.0.2 for build
- The range was limiting major upgrades of other projects while breaking changes in Grizzly still did not affect Jersey. Now we set just the minimal Grizzly version.
- I am not sure if Grizzly 3 is really compatible, but I am not brave enough to change it now.
- This PR blocks release of GlassFish 8.0.0, see https://github.com/eclipse-ee4j/glassfish/pull/25859

Note: I have noticed some issues with test stability (already without this change), I will try to improve it in standalone PR(s).
