### PR TITLE
Updated Jaeger to 1.8.1, fixed readme and one NPE

### DIFF
--- a/examples/open-tracing/README.MD
+++ b/examples/open-tracing/README.MD
@@ -1,3 +1,4 @@
+[//]: # " Copyright 2026 Contributors to the Eclipse Foundation. "
 [//]: # " Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved. "
 [//]: # " "
 [//]: # " This program and the accompanying materials are made available under the "
@@ -20,7 +21,7 @@ Running the Example
 Example can be launched as is, but does not perform any interesting action out of the box.
 To be able to visualise the traces, it is recommended to start Jaeger (and th UI) locally, e.g. in Docker:
 
->     docker run -d -p 5775:5775/udp -p 16686:16686 jaegertracing/all-in-one:travis-1278
+>     docker run -d -p 5775:5775/udp -p 16686:16686 jaegertracing/all-in-one:1.76.0
 
 Check the UI on [localhost:16686](http://localhost:16686), there should be no traces visible.
 
@@ -34,51 +35,45 @@ Try to access resources using the URIs listed bellow and look into Jager UI what
 The first example should be visible in the Jaeger UI right after the example application is started. Others can be created by
 doing rest calls to the exposed resource.
 
-1. On start, the example application sends one request demonstrating more complex tracing
-- jersey client (w/ registered OpenTracingFeature) creates the "jersey-client-GET" span
-- the span is propagated to server (via http headers), jersey server (w/ registered OpenTracinfFeature) automatically creates a
- child span of the client span
-- in the resource method, child span of the server span is manually created and propagated into managed client calls
-- the managed clients are also tracing-enabled, so each one creates its own child span, that is propagated to the server, and
-so on
+0. On start, the example application sends one request demonstrating more complex tracing
+    - jersey client (w/ registered OpenTracingFeature) creates the "jersey-client-GET" span
+    - the span is propagated to server (via http headers), jersey server (w/ registered OpenTracinfFeature) automatically creates a child span of the client span
+    - in the resource method, child span of the server span is manually created and propagated into managed client calls
+    - the managed clients are also tracing-enabled, so each one creates its own child span, that is propagated to the server, and so on
 
-2. No explicit (user-defined) spans.
-- one automatically created "root" span, that measures the processing on the Jersey side and one "resource-level" span to be
-used for logging events on the application level
-- the "root" contains several tags with request and response metadata, such as request headers, status code, etc
-- also, several technical Jersey-level events have been logged
-- to see this simple case, call
->     curl localhost:8080/opentracing/resource/defaultTrace
+0. No explicit (user-defined) spans.
+    - one automatically created "root" span, that measures the processing on the Jersey side and one "resource-level" span to be used for logging events on the application level
+    - the "root" contains several tags with request and response metadata, such as request headers, status code, etc
+    - also, several technical Jersey-level events have been logged
+    - to see this simple case, call
+        `curl localhost:8080/opentracing/resource/defaultTrace`
 
-3. Explicit logging into resource-level span
-- same as above, but the "resource-level" span was resolved within the application logic, an event was logged and a tag was added
->     curl localhost:8080/opentracing/resource/appLevelLogging
+0. Explicit logging into resource-level span
+    - same as above, but the "resource-level" span was resolved within the application logic, an event was logged and a tag was added
+        `curl localhost:8080/opentracing/resource/appLevelLogging`
+    - similar call with POST:
+        `curl -X POST -d "Jersey Rocks" localhost:8080/opentracing/resource/appLevelPost`
 
-- similar call with POST:
->     curl -X POST -d "Jersey Rocks" localhost:8080/opentracing/resource/appLevelPost
+0. Explicit child span creation
+    - same as above, but instead of "resource-level" span, a child span was created and used for logging and adding tags
+    - note, that such a span needs to be finished manually, otherwise it won't propagate (the tracing info will be lost)
+        `curl localhost:8080/opentracing/resource/childSpan`
 
+0. Client calls from the resource
+    - more complex case, the resource method invokes two client calls using managed client
+    - one request via managed client is triggered within the "provided", resource-level span
+    - child span is created and another request via managed client is triggered within the child span
+    - the span context needs to be propagated manually using the OpenTracingFeature.SPAN_CONTEXT_PROPERTY
+    - in both cases, the span context is propagated using http headers to the server and back to the client
+    - the child span (created in the resource) needs to be explicitly finished in the resource (or elsewhere, but needs to be finished)
+        `curl localhost:8080/opentracing/resource/traceWithManagedClient`
 
-4. Explicit child span creation
-- same as above, but instead of "resource-level" span, a child span was created and used for logging and adding tags
-- note, that such a span needs to be finished manually, otherwise it won't propagate (the tracing info will be lost)
->     curl localhost:8080/opentracing/resource/childSpan
+0. Asynchronous processing
+    - either basic case, but using asynchronous request processing
+    - there should be no practical difference visible in the tracing info
+        `curl localhost:8080/opentracing/resource/async`
 
-
-4. Client calls from the resource
-- more complex case, the resource method invokes two client calls using managed client
-- one request via managed client is triggered within the "provided", resource-level span
-- child span is created and another request via manged client is triggered within the child span
-- the span context needs to be propagated manually using the OpenTracingFeature.SPAN_CONTEXT_PROPERTY
-- in both cases, the span context is propagated using http headers to the server and back to the client
-- the child span (created in the resource) needs to be explicitly finished in the resource (or elsewhere, but needs to be finished)
->     curl localhost:8080/opentracing/resource/traceWithManagedClient
-
-5. Asynchronous processing
-- either basic case, but using asynchronous request processing
-- there should be no practical difference visible in the tracing info
->     curl localhost:8080/opentracing/resource/async
-
-6. Failing resource
-- demonstrates exception thrown in the resource method
-- Jaeger shows failed spans with the exclamation mark symbol and the exception is logged in the request span
->     curl localhost:8080/opentracing/resource/error
+0. Failing resource
+    - demonstrates exception thrown in the resource method
+    - Jaeger shows failed spans with the exclamation mark symbol and the exception is logged in the request span
+        `curl localhost:8080/opentracing/resource/error`

--- a/examples/open-tracing/pom.xml
+++ b/examples/open-tracing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2017, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -43,44 +43,31 @@
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-util</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.uber.jaeger</groupId>
+            <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-core</artifactId>
-            <version>${com.uber.jaeger.version}</version>
+            <version>${jaeger.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.opentracing</groupId>
-                    <artifactId>opentracing-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.opentracing</groupId>
-                    <artifactId>opentracing-util</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.google.code.gson</groupId>
                     <artifactId>gson</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.test-framework</groupId>

--- a/incubator/open-tracing/src/main/java/org/glassfish/jersey/opentracing/OpenTracingApplicationEventListener.java
+++ b/incubator/open-tracing/src/main/java/org/glassfish/jersey/opentracing/OpenTracingApplicationEventListener.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -107,7 +108,7 @@ class OpenTracingApplicationEventListener implements ApplicationEventListener {
 
     class OpenTracingRequestEventListener implements RequestEventListener {
         private Span requestSpan;
-        private Span resourceSpan = null;
+        private Span resourceSpan;
 
         OpenTracingRequestEventListener(final Span requestSpan) {
             this.requestSpan = requestSpan;
@@ -171,7 +172,9 @@ class OpenTracingApplicationEventListener implements ApplicationEventListener {
                     // processing; resourceSpan will be finished and the span in the context will be switched back to the
                     // resource span before any further tracing can occur.
                     event.getContainerRequest().setProperty(OpenTracingFeature.SPAN_CONTEXT_PROPERTY, requestSpan);
-                    resourceSpan.finish();
+                    if (resourceSpan != null) {
+                        resourceSpan.finish();
+                    }
                     logVerbose(LocalizationMessages.OPENTRACING_LOG_RESPONSE_FILTERING_STARTED());
                     break;
 
@@ -224,6 +227,11 @@ class OpenTracingApplicationEventListener implements ApplicationEventListener {
                         }
                         requestSpan.finish();
                     }
+                    break;
+                case START:
+                    // This is already handled in onRequest
+                    break;
+                default:
                     break;
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -2197,11 +2197,8 @@
         <groovy.version>5.0.0-alpha-12</groovy.version>
         <gson.version>2.13.1</gson.version>
 
-        <!--versions, extracted here due to maven-enforcer-plugin -->
-        <!--        <commons.codec.version>1.15</commons.codec.version>-->
-        <com.uber.jaeger.version>0.27.0</com.uber.jaeger.version>
+        <jaeger.version>1.8.1</jaeger.version>
         <org.codehaus.gmavenplus.version>4.2.0</org.codehaus.gmavenplus.version>
-        <!-- end of versions extracted here due to maven-enforcer-plugin -->
 
         <!-- micrometer -->
         <micrometer.version>1.15.1</micrometer.version>


### PR DESCRIPTION
### Story behind this
Some old dependency crashed my build on jenkins in https://github.com/eclipse-ee4j/jersey/pull/6055 , so I checked what it is and tried to update it. It was not without some pain, but I was curious, if it still can work, so I fixed it.

### Time for burial
However the technology behind it is dead, and I will create another issue with details, but still it could leave this repository updated (and without nullpointers). :-)


Log from quick testing based on the readme.md:
```
[INFO] --- exec:3.5.1:java (default-cli) @ open-tracing ---
"Hello World" Jersey OpenTracing Example App
[org.glassfish.jersey.examples.opentracing.App.main()] WARN io.jaegertracing.internal.senders.SenderResolver - No sender factories available. Using NoopSender, meaning that data will not be sent anywhere!
[org.glassfish.jersey.examples.opentracing.App.main()] INFO io.jaegertracing.Configuration - Initialized tracer=JaegerTracer(version=Java-1.8.1, serviceName=OpenTracingTemporaryTest, reporter=CompositeReporter(reporters=[RemoteReporter(sender=NoopSender(), closeEnqueueTimeout=1000), LoggingReporter(logger=org.slf4j.simple.SimpleLogger@2ae6ab23)]), sampler=ConstSampler(decision=true, tags={sampler.type=const, sampler.param=true}), tags={hostname=dmatej-tux, jaeger.version=Java-1.8.1, ip=192.168.13.105}, zipkinSharedRpcSpan=false, expandExceptionLogs=false, useTraceId128Bit=false)
Jan 16, 2026 9:39:59 PM org.glassfish.jersey.server.wadl.WadlFeature configure
WARNING: JAXBContext implementation could not be found. WADL feature is disabled.
Jan 16, 2026 9:39:59 PM org.glassfish.grizzly.http.server.NetworkListener start
INFO: Started listener bound to [localhost:8080]
Jan 16, 2026 9:39:59 PM org.glassfish.grizzly.http.server.HttpServer start
INFO: [HttpServer] Started.
Application started.
Try out http://localhost:8080/opentracing/application.wadl
Stop the application using CTRL+C
Jan 16, 2026 9:39:59 PM org.glassfish.jersey.server.wadl.WadlFeature configure
WARNING: JAXBContext implementation could not be found. WADL feature is disabled.
[grizzly-http-server-1] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:0aec23abcb02ec4a:50833f2a2999387d:1 - jersey-resource
[grizzly-http-server-1] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:50833f2a2999387d:42505b42a15b75cf:1 - jersey-server
[grizzly-http-server-0] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:42505b42a15b75cf:0df87c254c13cf2d:1 - jersey-client-POST
[grizzly-http-server-2] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:8ae37e949be02744:0e0709facc323536:1 - jersey-resource
[grizzly-http-server-2] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:0e0709facc323536:8e1dc6bbde793399:1 - jersey-server
[grizzly-http-server-0] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:8e1dc6bbde793399:0da3ae770e26ad03:1 - jersey-client-POST
[grizzly-http-server-0] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:0da3ae770e26ad03:0df87c254c13cf2d:1 - jersey-resource-child-span
[grizzly-http-server-0] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:0df87c254c13cf2d:8c2050e1740f9b37:1 - jersey-resource
[grizzly-http-server-0] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:8c2050e1740f9b37:833fc49d11d57380:1 - jersey-server
[org.glassfish.jersey.examples.opentracing.App.main()] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 833fc49d11d57380:833fc49d11d57380:0:1 - jersey-client-GET
[grizzly-http-server-3] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 97815ab8a9dfafc6:97815ab8a9dfafc6:0:1 - jersey-server
[grizzly-http-server-4] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 48ab351ad40f8929:6ea3d10eaa172b97:48ab351ad40f8929:1 - jersey-resource
[grizzly-http-server-4] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 48ab351ad40f8929:48ab351ad40f8929:0:1 - jersey-server
[grizzly-http-server-5] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: b33e67c3cc8d6da2:3db3791ca088ac8b:b33e67c3cc8d6da2:1 - jersey-resource
Jan 16, 2026 9:44:46 PM org.glassfish.jersey.server.ServerRuntime$Responder process
WARNING: An exception mapping did not successfully produce and processed a response. Logging the exception propagated to the default exception mapper.
java.lang.RuntimeException: Failing just for fun.
        at org.glassfish.jersey.examples.opentracing.TracedResource.failTrace(TracedResource.java:198)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:565)
        at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:189)
        at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$TypeOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:219)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:93)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:470)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:394)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:80)
        at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:274)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
        at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:266)
        at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:253)
        at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:703)
        at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:374)
        at org.glassfish.grizzly.http.server.HttpHandler$1.run(HttpHandler.java:190)
        at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:535)
        at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:515)
        at java.base/java.lang.Thread.run(Thread.java:1474)

[grizzly-http-server-5] WARN io.jaegertracing.internal.JaegerSpan - Span has already been finished; will not be reported again.
[grizzly-http-server-5] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: b33e67c3cc8d6da2:b33e67c3cc8d6da2:0:1 - jersey-server
[grizzly-http-server-6] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 98d9258ba96ea4d8:98d9258ba96ea4d8:0:1 - jersey-server
```

Screenoshot:
<img width="1548" height="782" alt="image" src="https://github.com/user-attachments/assets/08b344ea-c85f-4812-a62b-3e58c5be1e0a" />
