### PR TITLE
Maven central snapshots - BOM  plus few minor fixes

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -38,6 +38,32 @@
     </properties>
 
     <description>Jersey Bill of Materials (BOM)</description>
+
+    <!-- TODO: Can be removed after it would be removed from parent too -->
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <name>Disabled Sonatype Nexus</name>
+            <url>http://localhost</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <name>Disabled Sonatype Nexus</name>
+            <url>http://localhost</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </distributionManagement>
 
     <dependencyManagement>
         <dependencies>
@@ -452,6 +478,45 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>central-release</id>
+            <properties>
+                <!-- Do not autopublish by default -->
+                <release.autopublish>false</release.autopublish>
+                <!-- By default block until everything is really published -->
+                <release.waitUntil>published</release.waitUntil>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>injected-nexus-deploy</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.10.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <autoPublish>${release.autopublish}</autoPublish>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
+                            <deploymentName>Eclipse Jersey ${project.version}</deploymentName>
+                            <publishingServerId>central</publishingServerId>
+                            <waitUntil>${release.waitUntil}</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>project-info</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     </issueManagement>
 
     <ciManagement>
-        <system>Hudson</system>
-        <url>http://hudson.glassfish.org/job/Jersey-trunk-multiplatform/</url>
+        <system>Jenkins</system>
+        <url>https://ci.eclipse.org/jersey</url>
     </ciManagement>
 
     <repositories>

--- a/test-framework/maven/container-runner-maven-plugin/pom.xml
+++ b/test-framework/maven/container-runner-maven-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2015, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -295,6 +295,7 @@
     </build>
 
     <pluginRepositories>
+        <!-- This is because the groovy-compiler is several versions behind on Maven Central -->
         <pluginRepository>
             <id>groovy-plugins-release</id>
             <url>https://groovy.jfrog.io/artifactory/plugins-release</url>

--- a/tests/integration/helidon3-client/pom.xml
+++ b/tests/integration/helidon3-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -77,12 +77,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.surefire</groupId>
-                <artifactId>surefire</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
In #6055 I added configuration for deployment to Maven Central Snapshots, but I missed the BOM's independency.
Fixes #6054 

Except that:
* helidon3-client pom declared surefire plugin in a way causing maven warnings. Also the plugin declaration was redundant, so I just removed it.
* There was a link to old Hudson in the parent pom - fixed to Eclipse Jenkins CI. 
* I have noticed that build downloads from several additional repositories except Central/Eclipse Central Mirror. I added comment why we download groovy plugin from JFrog.