### PR TITLE
Upgaded Netty to 4.1.130.Final to remediate CVE-2025-59419 and CVE-2025-67735

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2313,7 +2313,7 @@
         <kryo.version>4.0.3</kryo.version>
         <mockito.version>4.11.0</mockito.version> <!-- CQ 17673 -->
         <mustache.version>0.9.14</mustache.version>
-        <netty.version>4.1.126.Final</netty.version>
+        <netty.version>4.1.130.Final</netty.version>
         <opentracing.version>0.33.0</opentracing.version>
         <osgi.version>6.0.0</osgi.version>
         <osgi.framework.version>1.10.0</osgi.framework.version>


### PR DESCRIPTION
To remove the CVEs as outlined below:

Netty

CVE-2025-59419
CVE-2025-67735

What

Upgrade the dependency versions

Netty - 4.1.126.Final -> 4.1.130.Final

Evidence
[report.html](https://github.com/user-attachments/files/24766598/report.html)
