### PR TITLE
Exclude jersey-constants from the release test

### DIFF
--- a/tests/release-test/src/test/java/org/glassfish/jersey/test/artifacts/ManifestTest.java
+++ b/tests/release-test/src/test/java/org/glassfish/jersey/test/artifacts/ManifestTest.java
@@ -37,6 +37,7 @@ public class ManifestTest {
             "servlet-portability", /* obsolete */
             "helidon-connector", /* Helidon does not contain OSGi headers */
             "grizzly-connector", /* Limited maintenance */
+            "jersey-constants"   /* Constants do not contain OSGi headers */
     };
 
     @Test


### PR DESCRIPTION
From 2.x branch