### PR TITLE
InputStream.nullInputStream() and Reader.nullWriter() are more efficient than new ByteInputStream(new byte[0]) and new Reader(...(new byte[0]))

### DIFF
--- a/connectors/apache5-connector/src/main/java/org/glassfish/jersey/apache5/connector/Apache5Connector.java
+++ b/connectors/apache5-connector/src/main/java/org/glassfish/jersey/apache5/connector/Apache5Connector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -749,7 +749,7 @@ class Apache5Connector implements Connector {
         final InputStream inputStream;
 
         if (response.getEntity() == null) {
-            inputStream = new ByteArrayInputStream(new byte[0]);
+            inputStream = InputStream.nullInputStream();
         } else {
             final InputStream i = new CancellableInputStream(response.getEntity().getContent(), isCancelled);
             if (i.markSupported()) {

--- a/connectors/jnh-connector/src/test/java/org/glassfish/jersey/jnh/connector/test/FirstByteCachingStreamTest.java
+++ b/connectors/jnh-connector/src/test/java/org/glassfish/jersey/jnh/connector/test/FirstByteCachingStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,8 +39,8 @@ class FirstByteCachingStreamTest {
 
     @Test
     void testNoByte() throws Exception {
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(new byte[0]);
-        InputStream testIs = createFirstByteCachingStream(byteArrayInputStream);
+        InputStream inputStream = InputStream.nullInputStream();
+        InputStream testIs = createFirstByteCachingStream(inputStream);
         Assertions.assertEquals(0, testIs.available());
     }
 

--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -168,7 +168,7 @@ public class HttpUrlConnector implements Connector {
                         return uc.getInputStream();
                     } else {
                         InputStream ein = uc.getErrorStream();
-                        return (ein != null) ? ein : new ByteArrayInputStream(new byte[0]);
+                        return (ein != null) ? ein : InputStream.nullInputStream();
                     }
                 }
             });

--- a/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderProvider.java
+++ b/core-common/src/main/java/org/glassfish/jersey/message/internal/ReaderProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,8 +62,7 @@ public final class ReaderProvider extends AbstractMessageReaderWriterProvider<Re
 
         final EntityInputStream entityStream = EntityInputStream.create(inputStream);
         if (entityStream.isEmpty()) {
-            return new BufferedReader(new InputStreamReader(
-                    new ByteArrayInputStream(new byte[0]), MessageUtils.getCharset(mediaType)));
+            return Reader.nullReader();
         }
 
         return new BufferedReader(new InputStreamReader(entityStream, ReaderWriter.getCharset(mediaType)));

--- a/core-server/src/test/java/org/glassfish/jersey/server/RequestContextBuilder.java
+++ b/core-server/src/test/java/org/glassfish/jersey/server/RequestContextBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.jersey.server;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
@@ -79,7 +80,6 @@ public class RequestContextBuilder {
         @Override
         public void setWorkers(final MessageBodyWorkers workers) {
             super.setWorkers(workers);
-            final byte[] entityBytes;
             if (workers != null) {
                 if (entity != null) {
                     final MultivaluedMap<String, Object> myMap = new MultivaluedHashMap<String, Object>(getHeaders());
@@ -101,11 +101,10 @@ public class RequestContextBuilder {
                             }
                         }
                     }
-                    entityBytes = baos.toByteArray();
+                    setEntityStream(new ByteArrayInputStream(baos.toByteArray()));
                 } else {
-                    entityBytes = new byte[0];
+                    setEntityStream(InputStream.nullInputStream());
                 }
-                setEntityStream(new ByteArrayInputStream(entityBytes));
             }
         }
     }


### PR DESCRIPTION
The target of this PR is to improve efficiency: It prevents useless creation of zero-sized buffers, and by doing so, reduces GC stress later  on.