### PR TITLE
resolve null @Context in Spring-proxied Jersey resources

### DIFF
--- a/ext/spring6/src/main/java/org/glassfish/jersey/server/spring/SpringComponentProvider.java
+++ b/ext/spring6/src/main/java/org/glassfish/jersey/server/spring/SpringComponentProvider.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/ext/spring6/src/main/java/org/glassfish/jersey/server/spring/SpringComponentProvider.java
+++ b/ext/spring6/src/main/java/org/glassfish/jersey/server/spring/SpringComponentProvider.java
@@ -161,9 +161,20 @@ public class SpringComponentProvider implements ComponentProvider {
             Object bean = ctx.getBean(beanName);
             if (bean instanceof Advised) {
                 try {
-                    // Unwrap the bean and inject the values inside of it
-                    Object localBean = ((Advised) bean).getTargetSource().getTarget();
-                    injectionManager.inject(localBean);
+                    Object target = bean;
+                    // Recursively unwrap the bean until we find the real POJO and then inject the values inside of it
+                    while (target instanceof Advised) {
+                        try {
+                            Object nextTarget = ((Advised) target).getTargetSource().getTarget();
+                            if (nextTarget == null || nextTarget == target) {
+                                break;
+                            }
+                            target = nextTarget;
+                        } catch (Exception e) {
+                            break;
+                        }
+                    }
+                    injectionManager.inject(target);
                 } catch (Exception e) {
                     // Ignore and let the injection happen as it normally would.
                     injectionManager.inject(bean);


### PR DESCRIPTION
When using `@RolesAllowed` or other Spring AOP features, Spring wraps resources in CGLIB proxies. Jersey's `InjectionManager` was previously injecting into the outermost proxy, but CGLIB does not delegate field access to the target instance.

This change recursively unwraps the Spring proxy chain to find the ultimate target POJO and performs HK2 injection directly on that instance, ensuring `@Context` fields (like `HttpServletRequest`) are available during method execution.

This should fix issues from #3398 and #3465.