### PR TITLE
6044 Do not complete requests on receiving notification events

### DIFF
--- a/containers/jersey-servlet/src/main/java/org/glassfish/jersey/servlet/async/AsyncContextDelegateProviderImpl.java
+++ b/containers/jersey-servlet/src/main/java/org/glassfish/jersey/servlet/async/AsyncContextDelegateProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/containers/jersey-servlet/src/main/java/org/glassfish/jersey/servlet/async/AsyncContextDelegateProviderImpl.java
+++ b/containers/jersey-servlet/src/main/java/org/glassfish/jersey/servlet/async/AsyncContextDelegateProviderImpl.java
@@ -83,7 +83,7 @@ public class AsyncContextDelegateProviderImpl implements AsyncContextDelegatePro
 
             @Override
             public void onComplete(AsyncEvent event) throws IOException {
-                complete();
+                completed.set(true);
             }
 
             @Override
@@ -93,7 +93,7 @@ public class AsyncContextDelegateProviderImpl implements AsyncContextDelegatePro
 
             @Override
             public void onError(AsyncEvent event) throws IOException {
-                complete();
+                completed.set(true);
             }
 
             @Override

--- a/tests/integration/jersey-6044/pom.xml
+++ b/tests/integration/jersey-6044/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>project</artifactId>
+        <groupId>org.glassfish.jersey.tests.integration</groupId>
+        <version>3.1.99-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jersey-6044</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-jetty-http</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-servlet</artifactId>
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-bundle</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/integration/jersey-6044/pom.xml
+++ b/tests/integration/jersey-6044/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/tests/integration/jersey-6044/pom.xml
+++ b/tests/integration/jersey-6044/pom.xml
@@ -31,6 +31,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jetty-http</artifactId>
             <version>${project.version}</version>

--- a/tests/integration/jersey-6044/src/main/java/org/glassfish/jersey/tests/jettyresponseclose/Resource204.java
+++ b/tests/integration/jersey-6044/src/main/java/org/glassfish/jersey/tests/jettyresponseclose/Resource204.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.jettyresponseclose;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Response;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Path("/get-me-204")
+public class Resource204 {
+    private static final ScheduledExecutorService executor = Executors.newScheduledThreadPool(100);
+
+    @GET
+    public void get(@Suspended final AsyncResponse ar) {
+        executor.schedule(() -> {
+            ar.resume(Response.noContent().build());
+        }, 50, TimeUnit.MILLISECONDS);
+    }
+}

--- a/tests/integration/jersey-6044/src/main/java/org/glassfish/jersey/tests/jettyresponseclose/Resource204.java
+++ b/tests/integration/jersey-6044/src/main/java/org/glassfish/jersey/tests/jettyresponseclose/Resource204.java
@@ -22,18 +22,24 @@ import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Response;
 
+import java.lang.System.Logger;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.System.Logger.Level.INFO;
+
 @Path("/get-me-204")
 public class Resource204 {
-    private static final ScheduledExecutorService executor = Executors.newScheduledThreadPool(100);
+    private static final Logger LOG = System.getLogger(Resource204.class.getName());
+    private static final ScheduledExecutorService EXECUTOR = Executors.newScheduledThreadPool(200);
 
     @GET
     public void get(@Suspended final AsyncResponse ar) {
-        executor.schedule(() -> {
+        EXECUTOR.schedule(() -> {
+            LOG.log(INFO, () -> "Resuming " + ar);
             ar.resume(Response.noContent().build());
+            LOG.log(INFO, () -> "Processing finished: " + ar);
         }, 50, TimeUnit.MILLISECONDS);
     }
 }

--- a/tests/integration/jersey-6044/src/main/java/org/glassfish/jersey/tests/jettyresponseclose/Resource204.java
+++ b/tests/integration/jersey-6044/src/main/java/org/glassfish/jersey/tests/jettyresponseclose/Resource204.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tests/integration/jersey-6044/src/main/java/org/glassfish/jersey/tests/jettyresponseclose/Resource204.java
+++ b/tests/integration/jersey-6044/src/main/java/org/glassfish/jersey/tests/jettyresponseclose/Resource204.java
@@ -40,6 +40,6 @@ public class Resource204 {
             LOG.log(INFO, () -> "Resuming " + ar);
             ar.resume(Response.noContent().build());
             LOG.log(INFO, () -> "Processing finished: " + ar);
-        }, 50, TimeUnit.MILLISECONDS);
+        }, 100, TimeUnit.MILLISECONDS);
     }
 }

--- a/tests/integration/jersey-6044/src/test/java/org/glassfish/jersey/tests/jettyresponseclose/JettyHttpContainerDuringShutdownTest.java
+++ b/tests/integration/jersey-6044/src/test/java/org/glassfish/jersey/tests/jettyresponseclose/JettyHttpContainerDuringShutdownTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,9 +17,24 @@
 
 package org.glassfish.jersey.tests.jettyresponseclose;
 
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.client.AsyncInvoker;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Response;
+
+import java.lang.System.Logger;
+import java.net.ConnectException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -30,18 +46,21 @@ import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import static java.lang.System.Logger.Level.INFO;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JettyHttpContainerDuringShutdownTest {
 
+    private static final Logger LOG = System.getLogger(JettyHttpContainerDuringShutdownTest.class.getName());
     private static Server server;
     private static final String URL = "http://localhost:9080/test/get-me-204";
 
@@ -62,7 +81,6 @@ public class JettyHttpContainerDuringShutdownTest {
         ServerConnector http = new ServerConnector(server, new HttpConnectionFactory(new HttpConfiguration()));
         http.setPort(9080);
         server.addConnector(http);
-        server.setStopTimeout(50);
         server.start();
 
         waitStartUp();
@@ -70,12 +88,14 @@ public class JettyHttpContainerDuringShutdownTest {
 
     private static void waitStartUp() {
         for (int i = 0; i < 10; i++) {
-            try {
-                Response response = ClientBuilder.newClient().target(URL).request().get();
+            try (Client client = ClientBuilder.newClient();
+                Response response = client.target(URL).request().get()) {
                 if (response.getStatus() == 204) {
                     return;
                 }
-            } catch (Throwable ignore) {
+                LOG.log(INFO, "Waiting for the startup ... response status: " + response.getStatus());
+            } catch (Exception e) {
+                LOG.log(INFO, "Waiting for the startup ... response status: ", e);
             }
         }
     }
@@ -83,36 +103,59 @@ public class JettyHttpContainerDuringShutdownTest {
     @AfterAll
     public static void shutdown() throws Exception {
         if (server != null) {
-            try {
-                server.stop();
-                server = null;
-            } catch (Throwable ignore) {
-            }
+            shutdownServer(10_000);
         }
     }
 
+
+    /**
+     * Tests that all responses are closed properly when the server is shutting down. The test sends
+     * a large number of requests to the server and then initiates the shutdown process. It verifies
+     * that all responses are either successfully received with a 204 status code or result in a
+     * ProcessingException caused by a ConnectException, indicating that the connection was closed
+     * during shutdown.
+     *
+     * @throws Exception
+     */
     @Test
     public void testResponseClose() throws Exception {
-        Client client = ClientBuilder.newClient();
-        try {
-            List<Future<Response>> waitingResponses = new ArrayList<>();
-            for (int i = 0; i < 100; i++) {
-                waitingResponses.add(client.target(URL).request().async().get());
+        AtomicInteger countOf204 = new AtomicInteger();
+        AtomicInteger countOfConnException = new AtomicInteger();
+        try (Client client = ClientBuilder.newClient()) {
+            // create requests but don't invoke them
+            List<AsyncInvoker> invokers = new ArrayList<>();
+            for (int i = 0; i < 1_000; i++) {
+                invokers.add(client.target(URL).request().async());
             }
-            shutdown();
+            // invoke them fast as possible.
+            List<Future<Response>> waitingResponses = invokers.stream().map(AsyncInvoker::get).collect(Collectors.toList());
+            assertThrows(TimeoutException.class, () -> shutdownServer(100));
             for (Future<Response> responseFuture : waitingResponses) {
-                Response response = responseFuture.get(30, TimeUnit.SECONDS);
-                response.close();
-                Assertions.assertNotEquals(200, response.getStatus());
-                if (response.getStatus() / 100 != 2 && response.getStatus() / 100 != 5) {
-                    Assertions.fail("Unexpected response code: " + response.getStatus());
+                try (Response response = responseFuture.get(30, TimeUnit.SECONDS)) {
+                    assertThat("Unexpected response code", response.getStatus(), equalTo(204));
+                    countOf204.incrementAndGet();
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    assertThat(cause, instanceOf(ProcessingException.class));
+                    assertThat(cause.getCause(), instanceOf(ConnectException.class));
+                    countOfConnException.incrementAndGet();
                 }
             }
-        } finally {
-            try {
-                client.close();
-            } catch (Throwable ignored) {
-            }
         }
+        // There is no guarantee that shutdown would not make it before requests.
+        // But we should be able to process at least some of HTTP requests.
+        LOG.log(INFO, "Count of results:\n  HTTP 204: {0}\n  ConnectException: {1}", countOf204, countOfConnException);
+        assertAll(
+            () -> assertThat("Count of HTTP 204", countOf204.get(), greaterThan(0)),
+            () -> assertThat("Count of ConnectException", countOfConnException.get(), greaterThanOrEqualTo(0))
+        );
+    }
+
+
+    private static void shutdownServer(int timeoutInMillis) throws Exception {
+        LOG.log(INFO, "Stopping the server: " + server);
+        server.setStopTimeout(timeoutInMillis);
+        server.stop();
+        server = null;
     }
 }

--- a/tests/integration/jersey-6044/src/test/java/org/glassfish/jersey/tests/jettyresponseclose/JettyHttpContainerDuringShutdownTest.java
+++ b/tests/integration/jersey-6044/src/test/java/org/glassfish/jersey/tests/jettyresponseclose/JettyHttpContainerDuringShutdownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tests/integration/jersey-6044/src/test/java/org/glassfish/jersey/tests/jettyresponseclose/JettyHttpContainerDuringShutdownTest.java
+++ b/tests/integration/jersey-6044/src/test/java/org/glassfish/jersey/tests/jettyresponseclose/JettyHttpContainerDuringShutdownTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.tests.jettyresponseclose;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.StatisticsHandler;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class JettyHttpContainerDuringShutdownTest {
+
+    private static Server server;
+    private static final String URL = "http://localhost:9080/test/get-me-204";
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        ResourceConfig resourceConfig = new ResourceConfig(Collections.singleton(Resource204.class));
+        ServletContextHandler ctx = new ServletContextHandler();
+        ServletHolder servlet = new ServletHolder(new ServletContainer(resourceConfig));
+        ctx.addServlet(servlet, "/test/*");
+        ContextHandlerCollection handlers = new ContextHandlerCollection();
+        server = new Server();
+
+        handlers.addHandler(ctx);
+        StatisticsHandler statisticsHandler = new StatisticsHandler();
+        statisticsHandler.setHandler(handlers);
+        server.setHandler(statisticsHandler);
+
+        ServerConnector http = new ServerConnector(server, new HttpConnectionFactory(new HttpConfiguration()));
+        http.setPort(9080);
+        server.addConnector(http);
+        server.setStopTimeout(50);
+        server.start();
+
+        waitStartUp();
+    }
+
+    private static void waitStartUp() {
+        for (int i = 0; i < 10; i++) {
+            try {
+                Response response = ClientBuilder.newClient().target(URL).request().get();
+                if (response.getStatus() == 204) {
+                    return;
+                }
+            } catch (Throwable ignore) {
+            }
+        }
+    }
+
+    @AfterAll
+    public static void shutdown() throws Exception {
+        if (server != null) {
+            try {
+                server.stop();
+                server = null;
+            } catch (Throwable ignore) {
+            }
+        }
+    }
+
+    @Test
+    public void testResponseClose() throws Exception {
+        Client client = ClientBuilder.newClient();
+        try {
+            List<Future<Response>> waitingResponses = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                waitingResponses.add(client.target(URL).request().async().get());
+            }
+            shutdown();
+            for (Future<Response> responseFuture : waitingResponses) {
+                Response response = responseFuture.get(30, TimeUnit.SECONDS);
+                response.close();
+                Assertions.assertNotEquals(200, response.getStatus());
+                if (response.getStatus() / 100 != 2 && response.getStatus() / 100 != 5) {
+                    Assertions.fail("Unexpected response code: " + response.getStatus());
+                }
+            }
+        } finally {
+            try {
+                client.close();
+            } catch (Throwable ignored) {
+            }
+        }
+    }
+}

--- a/tests/integration/jersey-6044/src/test/java/org/glassfish/jersey/tests/jettyresponseclose/JettyHttpContainerDuringShutdownTest.java
+++ b/tests/integration/jersey-6044/src/test/java/org/glassfish/jersey/tests/jettyresponseclose/JettyHttpContainerDuringShutdownTest.java
@@ -45,6 +45,7 @@ import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -134,7 +135,7 @@ public class JettyHttpContainerDuringShutdownTest {
             assertThrows(TimeoutException.class, () -> shutdownServer(100));
             for (Future<Response> responseFuture : waitingResponses) {
                 try (Response response = responseFuture.get(30, TimeUnit.SECONDS)) {
-                    assertThat("Unexpected response code", response.getStatus(), equalTo(204));
+                    assertThat("Unexpected response code", response.getStatus(), Matchers.anyOf(equalTo(204), equalTo(500)));
                     countOf204.incrementAndGet();
                 } catch (ExecutionException e) {
                     Throwable cause = e.getCause();

--- a/tests/integration/jersey-6044/src/test/resources/surefire.policy
+++ b/tests/integration/jersey-6044/src/test/resources/surefire.policy
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+// we do not care about java lib itself
+grant codebase "file:${java.home}/-" {
+  permission java.security.AllPermission;
+};
+
+// we do not care about our dependencies
+grant codebase "file:${settings.localRepository}/-" {
+  permission java.security.AllPermission;
+};
+
+grant codebase "file:${user.home}/-" {
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+};
+
+grant {
+    permission java.lang.management.ManagementPermission "monitor";
+    permission java.util.PropertyPermission "*", "read, write";
+    permission java.util.logging.LoggingPermission "control";
+    permission java.lang.RuntimePermission "setIO";
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+    permission java.lang.RuntimePermission "modifyThread";
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+
+    permission java.lang.RuntimePermission "getenv.JETTY_AVAILABLE_PROCESSORS";
+    permission java.net.SocketPermission "localhost", "accept,connect,listen,resolve";
+    permission java.lang.RuntimePermission "setContextClassLoader";
+};

--- a/tests/integration/jersey-6044/src/test/resources/surefire.policy
+++ b/tests/integration/jersey-6044/src/test/resources/surefire.policy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -60,6 +60,7 @@
         <module>jersey-4722</module>
         <module>jersey-5087</module>
         <module>jersey-5796</module>
+        <module>jersey-6044</module>
         <module>microprofile</module>
         <module>property-check</module>
         <module>reactive-streams</module>
@@ -161,6 +162,7 @@
                 <module>jersey-2892</module>
                 <module>jersey-3796</module>
                 <module>jersey-4949</module>
+                <module>jersey-6044</module>
                 <module>resteasy-client</module>
                 <module>security-digest</module>
                 <module>servlet-2.5-autodiscovery-1</module>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) 2026 Contributors to the Eclipse Foundation.
-    Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2026 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the


### PR DESCRIPTION
This is a proposal to fix an issue #6044 in CompletedAsyncContextListener. Semantically speaking, this is supposed to be a listener. It is being notified about certain events when complete or error is already happening. It is essentially incorrect to complete the ongoing request at this moment. I propose to only update a flag, which is needed in related code. 

Normally, a similar fix should be done in the 2.x as well, however I was not able to reproduce it using a test in that version. We can discuss on this and see how should we deal with it then.  