### PR TITLE
Fix memory leak (port to 3.1)

### DIFF
--- a/core-server/src/main/java/org/glassfish/jersey/server/ApplicationHandler.java
+++ b/core-server/src/main/java/org/glassfish/jersey/server/ApplicationHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
@@ -362,8 +363,24 @@ public final class ApplicationHandler implements ContainerLifecycleListener {
 
             injectionManager.completeRegistration();
 
-            bootstrapConfigurators.forEach(configurator -> configurator.postInit(injectionManager, bootstrapBag));
+            ComponentProviderConfigurator componentProviderConfigurator = null;
+            for (BootstrapConfigurator configurator : bootstrapConfigurators) {
+                if (configurator instanceof ComponentProviderConfigurator) {
+                    componentProviderConfigurator = (ComponentProviderConfigurator) configurator;
+                } else {
+                    configurator.postInit(injectionManager, bootstrapBag);
+                }
+            }
+
             resourceModelConfigurator.postInit(injectionManager, bootstrapBag);
+
+            /*
+                postInit on ComponentProviderConfigurator must be called last to clean up thread local,
+                which is also possibly set by other configurators
+            */
+            if (componentProviderConfigurator != null) {
+                componentProviderConfigurator.postInit(injectionManager, bootstrapBag);
+            }
 
             Iterable<ApplicationEventListener> appEventListeners =
                     Providers.getAllProviders(injectionManager, ApplicationEventListener.class, new RankedComparator<>());


### PR DESCRIPTION
Backport of https://github.com/eclipse-ee4j/jersey/pull/6075 from 4.x

* Fix memory leak

beanManager was set to threadLocal from a configurator that was post-init  after the ComponentProvider configurator which is supposed to free the thread local. The beanManager  thread local was never removed afterwards. I switched the order of calling post-init so that configurators go in reversed order compared to calling init

* Fix memory leak - fix failing tests

Revert the change to run postInit on all configurators in reversed order. Instead run postInit only on the specific Component configurator last, while initialize runs in the original order. This cleans up thread locals safely, without changing the order of other configurators, which was breking other functionality.