### PR TITLE
porting fix for class analyzer

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/ClientConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 Payara Foundation and/or its affiliates.
  *
@@ -425,6 +426,7 @@ public class ClientConfig implements Configurable<ClientConfig>, ExtendedConfig 
             final ClientMessageBodyFactory.MessageBodyWorkersConfigurator messageBodyWorkersConfigurator =
                     new ClientMessageBodyFactory.MessageBodyWorkersConfigurator();
 
+            ClientComponentConfigurator clientComponentConfigurator = new ClientComponentConfigurator();
             List<BootstrapConfigurator> bootstrapConfigurators = Arrays.asList(
                     new RequestScope.RequestScopeConfigurator(),
                     new ParamConverterConfigurator(),
@@ -435,7 +437,7 @@ public class ClientConfig implements Configurable<ClientConfig>, ExtendedConfig 
                     new ExceptionMapperFactory.ExceptionMappersConfigurator(),
                     new JaxrsProviders.ProvidersConfigurator(),
                     new AutoDiscoverableConfigurator(RuntimeType.CLIENT),
-                    new ClientComponentConfigurator(),
+                    clientComponentConfigurator,
                     new FeatureConfigurator(RuntimeType.CLIENT));
             bootstrapConfigurators.forEach(configurator -> configurator.init(injectionManager, bootstrapBag));
 
@@ -465,12 +467,20 @@ public class ClientConfig implements Configurable<ClientConfig>, ExtendedConfig 
 
             injectionManager.completeRegistration();
 
-            bootstrapConfigurators.forEach(configurator -> configurator.postInit(injectionManager, bootstrapBag));
+            //bootstrapConfigurators.forEach(configurator -> configurator.postInit(injectionManager, bootstrapBag));
+            bootstrapConfigurators.forEach(configurator -> {
+                if (!configurator.equals(clientComponentConfigurator)) {
+                    configurator.postInit(injectionManager, bootstrapBag);
+                }
+            });
 
             final ClientConfig configuration = new ClientConfig(runtimeCfgState);
             final Connector connector = connectorProvider.getConnector(client, configuration);
             final ClientRuntime crt = new ClientRuntime(configuration, connector, injectionManager, bootstrapBag);
 
+            // We call postInit here to clean up thread locals,
+            // while other configurators need to be postInit earlier because they set up dependencies for ClientRuntime
+            clientComponentConfigurator.postInit(injectionManager, bootstrapBag);
             client.registerShutdownHook(crt);
             messageBodyWorkersConfigurator.setClientRuntime(crt);
 

--- a/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
+++ b/ext/cdi/jersey-cdi1x/src/main/java/org/glassfish/jersey/ext/cdi1x/internal/CdiComponentProvider.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2022 Payara Foundation and/or its affiliates. All rights reserved.
  *
@@ -144,6 +145,10 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
 
     private boolean initialized = false;
 
+    // Shared by multiple clients, which can be initialized in parallel,
+    // therefore storing to a thread local and removing after initialization done in the done() method
+    private ThreadLocal<InjectionManager> effectiveInjectionManager = new ThreadLocal<>();
+
     public CdiComponentProvider() {
         customHk2TypesProvider = CdiUtil.lookupService(Hk2CustomBoundTypesProvider.class);
         injectionManagerStore = CdiUtil.createHk2InjectionManagerStore();
@@ -253,6 +258,14 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
 
     @Override
     public void done() {
+
+        if (beanManager != null) {
+            final CdiComponentProvider extension = beanManager.getExtension(CdiComponentProvider.class);
+            if (extension != null) {
+                extension.effectiveInjectionManager.remove();
+            }
+        }
+
         if (requestScopedComponents.size() > 0) {
             InstanceBinding<ForeignRequestScopeBridge> descriptor = Bindings
                     .service((ForeignRequestScopeBridge) () -> requestScopedComponents)
@@ -656,7 +669,6 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
     /* package */ abstract class InjectionManagerInjectedCdiTarget implements InjectionManagerInjectedTarget {
 
         private final InjectionTarget delegate;
-        private volatile InjectionManager effectiveInjectionManager;
 
         public InjectionManagerInjectedCdiTarget(InjectionTarget delegate) {
             this.delegate = delegate;
@@ -669,7 +681,7 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
         public void inject(final Object t, final CreationalContext cc) {
             InjectionManager injectingManager = getEffectiveInjectionManager();
             if (injectingManager == null || /* reload */ injectingManager.isShutdown()) {
-                injectingManager = effectiveInjectionManager;
+                injectingManager = effectiveInjectionManager.get();
                 threadInjectionManagers.set(injectingManager);
             }
 
@@ -704,7 +716,16 @@ public class CdiComponentProvider implements ComponentProvider, Extension {
 
         @Override
         public void setInjectionManager(final InjectionManager injectionManager) {
-            this.effectiveInjectionManager = injectionManager;
+            // The injectionManager is always the same within a single invocation.
+            // We set it only once, which is a bit faster than calling set with the same value
+            final InjectionManager manager = effectiveInjectionManager.get();
+            if (manager == null) {
+                effectiveInjectionManager.set(injectionManager);
+            } else if (!manager.equals(injectionManager)) {
+                LOGGER.log(Level.SEVERE, "Leaking injection manager found in the current thread."
+                        + " Very likely because it wasn't removed in a previous invocation and"
+                        + " leaked into this invocation.");
+            }
         }
     }
 

--- a/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/GsonCustomTest.java
+++ b/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/GsonCustomTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/GsonCustomTest.java
+++ b/tests/e2e-server/src/test/java/org/glassfish/jersey/tests/e2e/server/GsonCustomTest.java
@@ -17,8 +17,7 @@
 package org.glassfish.jersey.tests.e2e.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Date;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -36,17 +35,22 @@ import org.junit.jupiter.api.Test;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-public class GsonCustomTest extends JerseyTest {
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
-    private static final Date date = new Date(0);
+public class GsonCustomTest extends JerseyTest {
 
     @Path("/test")
     public static class Resource {
 
         @GET
         @Consumes("application/json")
-        public Date get() {
-            return date;
+        public String get() {
+            Instant epochInstant = Instant.EPOCH;
+            ZoneId utcZone = ZoneId.of("UTC");
+            LocalDateTime localDateTime = LocalDateTime.ofInstant(epochInstant, utcZone);
+            return localDateTime.toString();
         }
     }
 
@@ -60,7 +64,7 @@ public class GsonCustomTest extends JerseyTest {
         Response response = target("/test").request().get();
         assertEquals(200, response.getStatus());
         String obj = response.readEntity(String.class);
-        assertEquals("\"1970\"", obj);
+        assertTrue(obj.contains("1970"));
     }
 
     @Provider


### PR DESCRIPTION
This is a PR to port the fix for ClassAnalyzer issue. Here the original PR: https://github.com/eclipse-ee4j/jersey/pull/6049

I replicated this using glassfish 7.1.0 that is using the jersey version 3.1.11. Here the logs after reproducing the error:

```
[2026-06-25T19:42:11.043412-06:00] [GF 7.1.0] [WARNING] [] [org.glassfish.jersey.internal.Errors] [tid: _ThreadID=135 _ThreadName=http-listener-1(4)] [levelValue: 900] [[
  The following warnings have been detected: WARNING: HK2 failure has been detected in a code that does not run in an active Jersey Error scope.
WARNING: Unknown HK2 failure detected:
MultiException stack 1 of 1
java.lang.IllegalStateException: Could not find an implementation of ClassAnalyzer with name CdiInjecteeSkippingClassAnalyzer
	at org.jvnet.hk2.internal.ServiceLocatorImpl.getAnalyzer(ServiceLocatorImpl.java:2500)
	at org.jvnet.hk2.internal.Utilities.getClassAnalyzer(Utilities.java:145)
	at org.jvnet.hk2.internal.Utilities.justInject(Utilities.java:971)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.inject(ServiceLocatorImpl.java:1026)
	at org.glassfish.jersey.inject.hk2.AbstractHk2InjectionManager.inject(AbstractHk2InjectionManager.java:217)
	at org.glassfish.jersey.inject.hk2.ImmediateHk2InjectionManager.inject(ImmediateHk2InjectionManager.java:30)
	at org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider$InjectionManagerInjectedCdiTarget.inject(CdiComponentProvider.java:679)
	at org.jboss.weld.bean.ManagedBean.create(ManagedBean.java:165)
```

 I based this PR from the branch 3.1.12-BRANCH, I hope this is correct