### PR TITLE
Fix Jetty container context path handling

### DIFF
--- a/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
+++ b/containers/jetty-http/src/main/java/org/glassfish/jersey/jetty/JettyHttpContainer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -174,7 +175,7 @@ public final class JettyHttpContainer extends Handler.Abstract implements Contai
 
     private URI getRequestUri(final Request request, final URI baseUri) throws URISyntaxException {
         final String serverAddress = getServerAddress(baseUri);
-        String uri = request.getHttpURI().getPath();
+        String uri = Request.getPathInContext(request);
 
         final String queryString = request.getHttpURI().getQuery();
         if (queryString != null) {

--- a/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ContextPathTest.java
+++ b/containers/jetty-http/src/test/java/org/glassfish/jersey/jetty/ContextPathTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability under the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.jetty;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.glassfish.jersey.server.ContainerFactory;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ContextPathTest {
+
+    @Test
+    public void testContainerMountedAtRootContextPath() throws Exception {
+        testContainer("/", "/resource?value=query", "/\n/resource\nquery");
+    }
+
+    @Test
+    public void testContainerMountedAtNonRootContextPath() throws Exception {
+        testContainer("/context", "/context/resource?value=query",
+                "/context/\n/context/resource\nquery");
+    }
+
+    private void testContainer(String contextPath, String requestTarget, String expectedContent) throws Exception {
+        final Server server = new Server();
+        final LocalConnector connector = new LocalConnector(server);
+        server.addConnector(connector);
+        final JettyHttpContainer container = ContainerFactory.createContainer(
+                JettyHttpContainer.class, new ResourceConfig(ContextPathResource.class));
+        server.setHandler(new ContextHandler(container, contextPath));
+        server.start();
+
+        try {
+            final HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(
+                    "GET " + requestTarget + " HTTP/1.1\r\n"
+                            + "Host: localhost\r\n"
+                            + "Connection: close\r\n\r\n"));
+
+            assertEquals(200, response.getStatus());
+            assertEquals(expectedContent, response.getContent());
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Path("resource")
+    public static class ContextPathResource {
+
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String get(@Context UriInfo uriInfo, @QueryParam("value") String value) {
+            return uriInfo.getBaseUri().getPath()
+                    + "\n" + uriInfo.getRequestUri().getPath()
+                    + "\n" + value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- use Jetty's context-relative request path when constructing the Jersey request URI
- add coverage for `JettyHttpContainer` mounted at both root and non-root context paths

## Root cause

`JettyHttpContainer` used the full request path while also deriving its base URI from the Jetty context path. A request for `/context/resource` was therefore constructed as `/context/context/resource` and failed resource matching.

Using `Request.getPathInContext(request)` preserves the context path in the base URI while appending only the part of the request path that is relative to that context.

## Impact

Jersey resources mounted under a non-root Jetty `ContextHandler` now route correctly. Root-context routing remains unchanged, `UriInfo` exposes the expected base and request URIs, and query parameters are preserved.

## Testing

- `mvnd -pl containers/jetty-http -am test -DskipTests=false`
- verified that the regression test passes at `/` but fails with `404` at `/context` without the fix

Fixes #3338
