### PR TITLE
fix(client): respect sun.net.http.allowRestrictedHeaders after config refactor

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnectorConfiguration.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/internal/HttpUrlConnectorConfiguration.java
@@ -221,11 +221,14 @@ public abstract class HttpUrlConnectorConfiguration<C extends HttpUrlConnectorCo
             // check if sun.net.http.allowRestrictedHeaders system property has been set and log the result
             // the property is being cached in the HttpURLConnection, so this is only informative - there might
             // already be some connection(s), that existed before the property was set/changed.
-            isRestrictedHeaderPropertySet.set(Boolean.valueOf(AccessController.doPrivileged(
+            // Must set on the returned clientConfiguration (not on this intermediate instance):
+            // copyFromClient() already created a copy via init()+setNonEmpty(this), and this value
+            // is what HttpUrlConnector stores and later propagates via fromRequest().
+            clientConfiguration.isRestrictedHeaderPropertySet.set(Boolean.valueOf(AccessController.doPrivileged(
                     PropertiesHelper.getSystemProperty(ALLOW_RESTRICTED_HEADERS_SYSTEM_PROPERTY, "false")
             )));
 
-            LOGGER.config(isRestrictedHeaderPropertySet.get()
+            LOGGER.config(clientConfiguration.isRestrictedHeaderPropertySet.get()
                     ? LocalizationMessages.RESTRICTED_HEADER_PROPERTY_SETTING_TRUE(ALLOW_RESTRICTED_HEADERS_SYSTEM_PROPERTY)
                     : LocalizationMessages.RESTRICTED_HEADER_PROPERTY_SETTING_FALSE(ALLOW_RESTRICTED_HEADERS_SYSTEM_PROPERTY)
             );

--- a/core-client/src/test/java/org/glassfish/jersey/client/internal/HttpUrlConnectorRestrictedHeadersTest.java
+++ b/core-client/src/test/java/org/glassfish/jersey/client/internal/HttpUrlConnectorRestrictedHeadersTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.client.internal;
+
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.Configuration;
+
+/**
+ * Regression tests for {@code sun.net.http.allowRestrictedHeaders} handling after the
+ * HttpUrlConnector configuration refactor (issue #6085).
+ * <p>
+ * {@link HttpUrlConnectorConfiguration.ReadWrite#fromClient} must apply the system property
+ * to the configuration instance it returns (the one stored by {@link HttpUrlConnector}),
+ * not to the intermediate instance used to build that copy.
+ */
+public class HttpUrlConnectorRestrictedHeadersTest {
+
+    private static final String PROPERTY =
+            HttpUrlConnectorConfiguration.ALLOW_RESTRICTED_HEADERS_SYSTEM_PROPERTY;
+
+    private String previousProperty;
+
+    @AfterEach
+    public void restoreSystemProperty() {
+        if (previousProperty == null) {
+            System.clearProperty(PROPERTY);
+        } else {
+            System.setProperty(PROPERTY, previousProperty);
+        }
+    }
+
+    private void captureProperty() {
+        previousProperty = System.getProperty(PROPERTY);
+    }
+
+    private static HttpUrlConnectorConfiguration.ReadWrite fromClient(Configuration configuration) {
+        // Match HttpUrlConnector: config.rw().fromClient(configuration)
+        return new HttpUrlConnectorConfiguration.ReadWrite().fromClient(configuration);
+    }
+
+    @Test
+    public void fromClientRecordsAllowRestrictedHeadersTrueOnReturnedConfig() {
+        captureProperty();
+        System.setProperty(PROPERTY, "true");
+
+        Client client = JerseyClientBuilder.createClient();
+        try {
+            HttpUrlConnectorConfiguration.ReadWrite clientConfig = fromClient(client.getConfiguration());
+
+            Assertions.assertTrue(clientConfig.isRestrictedHeaderPropertySet.get(),
+                    "fromClient must record allowRestrictedHeaders=true on the returned configuration");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void fromClientRecordsAllowRestrictedHeadersFalseOnReturnedConfig() {
+        captureProperty();
+        System.setProperty(PROPERTY, "false");
+
+        Client client = JerseyClientBuilder.createClient();
+        try {
+            HttpUrlConnectorConfiguration.ReadWrite clientConfig = fromClient(client.getConfiguration());
+
+            Assertions.assertFalse(clientConfig.isRestrictedHeaderPropertySet.get(),
+                    "fromClient must record allowRestrictedHeaders=false on the returned configuration");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void fromClientCopyRetainsValueViaSetNonEmpty() {
+        captureProperty();
+        System.setProperty(PROPERTY, "true");
+
+        Client client = JerseyClientBuilder.createClient();
+        try {
+            HttpUrlConnectorConfiguration.ReadWrite clientConfig = fromClient(client.getConfiguration());
+
+            // fromRequest path starts with copy(), which init()s to false then setNonEmpty(clientConfig)
+            HttpUrlConnectorConfiguration.ReadWrite copy = clientConfig.copy();
+            Assertions.assertTrue(copy.isRestrictedHeaderPropertySet.get(),
+                    "client configuration value must survive copy() used by fromRequest()");
+        } finally {
+            client.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a regression introduced by the `HttpUrlConnector` configuration refactor (2.48+): `sun.net.http.allowRestrictedHeaders=true` was ignored for restricted headers such as `Host` and `Origin`.

### Root cause

`HttpUrlConnectorConfiguration.ReadWrite#fromClient()` set `isRestrictedHeaderPropertySet` on the **intermediate** `this` instance, then returned a **copy** (`clientConfiguration`) created earlier via `copyFromClient()` → `init()` (defaults the flag to `false`) + `setNonEmpty(this)` (still empty at that point).

`HttpUrlConnector` stores that returned copy and later uses `fromRequest()` / `copy()`, so the system property value never reached request-time checks. Users always saw:

```
Attempt to send restricted header(s) while the [sun.net.http.allowRestrictedHeaders] system property not set. Header(s) will possibly be ignored
```

even when the property was set (e.g. OCI SDK setting `Host`).

### Fix

Apply and log the system property on the **returned** `clientConfiguration`, matching the pre-2.48 behavior where the constructor field was assigned from the property.

## Testing

- `HttpUrlConnectorRestrictedHeadersTest` (3 tests):
  - `fromClient` records `true` / `false` on the **returned** config
  - value survives `copy()` (the path used by `fromRequest`)
- Verified the two true-path tests **fail** on unfixed code and **pass** with this change
- JDK 17 (JBR 17.0.14), `mvn -pl core-client -am test -Dtest=HttpUrlConnectorRestrictedHeadersTest`

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Fixes #6085