### PR TITLE
Terminate SseEventSource gracefully on HTTP 204 during (re)connect

### DIFF
--- a/core-client/src/main/java/org/glassfish/jersey/client/JerseyInvocation.java
+++ b/core-client/src/main/java/org/glassfish/jersey/client/JerseyInvocation.java
@@ -941,46 +941,7 @@ public class JerseyInvocation implements jakarta.ws.rs.client.Invocation {
             // leaking connections (see JERSEY-2157).
             response.bufferEntity();
 
-            final WebApplicationException webAppException;
-            final Response.Status status = Response.Status.fromStatusCode(statusCode);
-
-            if (status == null) {
-                final Response.Status.Family statusFamily = finalResponse.getStatusInfo().getFamily();
-                webAppException = createExceptionForFamily(finalResponse, statusFamily);
-            } else {
-                switch (status) {
-                    case BAD_REQUEST:
-                        webAppException = new BadRequestException(finalResponse);
-                        break;
-                    case UNAUTHORIZED:
-                        webAppException = new NotAuthorizedException(finalResponse);
-                        break;
-                    case FORBIDDEN:
-                        webAppException = new ForbiddenException(finalResponse);
-                        break;
-                    case NOT_FOUND:
-                        webAppException = new NotFoundException(finalResponse);
-                        break;
-                    case METHOD_NOT_ALLOWED:
-                        webAppException = new NotAllowedException(finalResponse);
-                        break;
-                    case NOT_ACCEPTABLE:
-                        webAppException = new NotAcceptableException(finalResponse);
-                        break;
-                    case UNSUPPORTED_MEDIA_TYPE:
-                        webAppException = new NotSupportedException(finalResponse);
-                        break;
-                    case INTERNAL_SERVER_ERROR:
-                        webAppException = new InternalServerErrorException(finalResponse);
-                        break;
-                    case SERVICE_UNAVAILABLE:
-                        webAppException = new ServiceUnavailableException(finalResponse);
-                        break;
-                    default:
-                        final Response.Status.Family statusFamily = finalResponse.getStatusInfo().getFamily();
-                        webAppException = createExceptionForFamily(finalResponse, statusFamily);
-                }
-            }
+            final WebApplicationException webAppException = convertToWebApplicationException(finalResponse);
 
             return new ResponseProcessingException(finalResponse, webAppException);
         } catch (final Throwable t) {
@@ -989,7 +950,63 @@ public class JerseyInvocation implements jakarta.ws.rs.client.Invocation {
         }
     }
 
-    private WebApplicationException createExceptionForFamily(final Response response, final Response.Status.Family statusFamily) {
+    /**
+     * Convert the given response into the {@link WebApplicationException} subtype matching its status code,
+     * in the same way the sync and async invocation entry points do for non-successful responses.
+     * <p>
+     * Note that the response entity is not buffered by this method. Callers that do not consume the entity
+     * are responsible for buffering or closing the response to prevent leaking connections.
+     * </p>
+     *
+     * @param response the response to convert.
+     * @return the {@link WebApplicationException} subtype matching the response status code.
+     */
+    public static WebApplicationException convertToWebApplicationException(final Response response) {
+        final WebApplicationException webAppException;
+        final Response.Status status = Response.Status.fromStatusCode(response.getStatus());
+
+        if (status == null) {
+            final Response.Status.Family statusFamily = response.getStatusInfo().getFamily();
+            webAppException = createExceptionForFamily(response, statusFamily);
+        } else {
+            switch (status) {
+                case BAD_REQUEST:
+                    webAppException = new BadRequestException(response);
+                    break;
+                case UNAUTHORIZED:
+                    webAppException = new NotAuthorizedException(response);
+                    break;
+                case FORBIDDEN:
+                    webAppException = new ForbiddenException(response);
+                    break;
+                case NOT_FOUND:
+                    webAppException = new NotFoundException(response);
+                    break;
+                case METHOD_NOT_ALLOWED:
+                    webAppException = new NotAllowedException(response);
+                    break;
+                case NOT_ACCEPTABLE:
+                    webAppException = new NotAcceptableException(response);
+                    break;
+                case UNSUPPORTED_MEDIA_TYPE:
+                    webAppException = new NotSupportedException(response);
+                    break;
+                case INTERNAL_SERVER_ERROR:
+                    webAppException = new InternalServerErrorException(response);
+                    break;
+                case SERVICE_UNAVAILABLE:
+                    webAppException = new ServiceUnavailableException(response);
+                    break;
+                default:
+                    final Response.Status.Family statusFamily = response.getStatusInfo().getFamily();
+                    webAppException = createExceptionForFamily(response, statusFamily);
+            }
+        }
+        return webAppException;
+    }
+
+    private static WebApplicationException createExceptionForFamily(final Response response,
+            final Response.Status.Family statusFamily) {
         final WebApplicationException webAppException;
         switch (statusFamily) {
             case REDIRECTION:

--- a/media/sse/src/main/java/org/glassfish/jersey/media/sse/internal/EventProcessor.java
+++ b/media/sse/src/main/java/org/glassfish/jersey/media/sse/internal/EventProcessor.java
@@ -29,11 +29,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jakarta.ws.rs.ServiceUnavailableException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.sse.SseEvent;
 
 import org.glassfish.jersey.client.ClientExecutor;
+import org.glassfish.jersey.client.JerseyInvocation;
 import org.glassfish.jersey.internal.util.ExtendedLogger;
 import org.glassfish.jersey.media.sse.EventInput;
 import org.glassfish.jersey.media.sse.EventListener;
@@ -166,7 +169,20 @@ public class EventProcessor implements Runnable, EventListener {
                 final Invocation.Builder request = prepareHandshakeRequest();
                 if (state.get() == State.OPEN) { // attempt to connect only if even source is open
                     LOGGER.debugLog("Connecting...");
-                    eventInput = request.get(EventInput.class);
+                    final Response response = request.get();
+                    if (response.getStatus() == Response.Status.NO_CONTENT.getStatusCode()) {
+                        // HTTP 204 No Content: the server signalled that no further events will be sent.
+                        // Terminate gracefully instead of reconnecting, in alignment with the WHATWG
+                        // EventSource processing model, where a 204 response stops the reconnection loop.
+                        response.close();
+                        LOGGER.debugLog("Received HTTP 204 - closing the event source.");
+                        shutdownHandler.shutdown();
+                        return;
+                    }
+                    if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+                        throw translateNonSuccessfulResponse(response);
+                    }
+                    eventInput = response.readEntity(EventInput.class);
                     LOGGER.debugLog("Connected!");
                 }
             } finally {
@@ -222,6 +238,24 @@ public class EventProcessor implements Runnable, EventListener {
             }
             LOGGER.debugLog("Listener task finished.");
         }
+    }
+
+    /**
+     * Translate a non-successful handshake response into the same {@link WebApplicationException} subtype
+     * that {@link JerseyInvocation} would have produced when the response entity was requested directly,
+     * so that the error handling behavior stays unchanged.
+     *
+     * @param response a response with a non-{@link Response.Status.Family#SUCCESSFUL} status code.
+     * @return the exception to throw for the given response.
+     */
+    private static WebApplicationException translateNonSuccessfulResponse(final Response response) {
+        try {
+            // Buffer and close entity input stream (if any) to prevent leaking connections (see JERSEY-2157).
+            response.bufferEntity();
+        } catch (final Exception ignored) {
+            // exception during buffering ignored - the original response status is what matters here
+        }
+        return JerseyInvocation.convertToWebApplicationException(response);
     }
 
     /**

--- a/media/sse/src/test/java/org/glassfish/jersey/media/sse/SseEventSourceNoContentTerminationTest.java
+++ b/media/sse/src/test/java/org/glassfish/jersey/media/sse/SseEventSourceNoContentTerminationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.jersey.media.sse;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.sse.InboundSseEvent;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+import jakarta.ws.rs.sse.SseEventSource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tests that an HTTP 204 (No Content) response terminates the {@link SseEventSource} gracefully -
+ * the completion callback is invoked, no error is reported and no further reconnect attempts are
+ * made - in alignment with the WHATWG EventSource processing model.
+ */
+public class SseEventSourceNoContentTerminationTest extends JerseyTest {
+
+    private static final AtomicInteger CONNECT_COUNT = new AtomicInteger();
+
+    @Path("sse")
+    public static class NoContentTerminationTestSseEndpoint {
+
+        @Path("204")
+        @GET
+        @Produces(SseFeature.SERVER_SENT_EVENTS)
+        public void immediateNoContent(@Context SseEventSink output, @Context Sse sse) {
+            CONNECT_COUNT.incrementAndGet();
+            throw new WebApplicationException(Response.noContent().build());
+        }
+
+        @Path("204-reconnect")
+        @GET
+        @Produces(SseFeature.SERVER_SENT_EVENTS)
+        public void noContentOnReconnect(@HeaderParam(HttpHeaders.LAST_EVENT_ID_HEADER) String lastEventId,
+                                         @Context SseEventSink output,
+                                         @Context Sse sse) throws IOException {
+            CONNECT_COUNT.incrementAndGet();
+            if (lastEventId != null) {
+                // the client reconnected after the stream completed - signal that no further events
+                // will ever be sent by responding with HTTP 204
+                throw new WebApplicationException(Response.noContent().build());
+            }
+            try (SseEventSink sink = output) {
+                for (int i = 0; i < 3; i++) {
+                    sink.send(sse.newEventBuilder().id(String.valueOf(i)).data(String.valueOf(i)).build());
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(NoContentTerminationTestSseEndpoint.class);
+    }
+
+    @Test
+    public void testImmediateNoContentTerminatesWithoutError() throws InterruptedException {
+        CONNECT_COUNT.set(0);
+        WebTarget sseTarget = target("sse/204");
+        AtomicReference<Throwable> throwable = new AtomicReference<>();
+        CountDownLatch completeLatch = new CountDownLatch(1);
+
+        SseEventSource eventSource = SseEventSource.target(sseTarget).build();
+        eventSource.register(event -> { }, throwable::set, completeLatch::countDown);
+        eventSource.open();
+
+        MatcherAssert.assertThat(completeLatch.await(10_000, TimeUnit.MILLISECONDS), Matchers.is(true));
+        MatcherAssert.assertThat(throwable.get(), Matchers.nullValue());
+        MatcherAssert.assertThat(eventSource.isOpen(), Matchers.is(false));
+        MatcherAssert.assertThat(CONNECT_COUNT.get(), Matchers.is(1));
+    }
+
+    @Test
+    public void testNoContentOnReconnectTerminatesWithoutError() throws InterruptedException {
+        CONNECT_COUNT.set(0);
+        WebTarget sseTarget = target("sse/204-reconnect");
+        AtomicReference<Throwable> throwable = new AtomicReference<>();
+        List<String> events = new CopyOnWriteArrayList<>();
+        CountDownLatch completeLatch = new CountDownLatch(1);
+
+        SseEventSource eventSource = SseEventSource.target(sseTarget)
+                .reconnectingEvery(100, TimeUnit.MILLISECONDS)
+                .build();
+        eventSource.register(event -> events.add(event.readData()), throwable::set, completeLatch::countDown);
+        eventSource.open();
+
+        MatcherAssert.assertThat(completeLatch.await(10_000, TimeUnit.MILLISECONDS), Matchers.is(true));
+        MatcherAssert.assertThat(throwable.get(), Matchers.nullValue());
+        MatcherAssert.assertThat(events, Matchers.contains("0", "1", "2"));
+        MatcherAssert.assertThat(eventSource.isOpen(), Matchers.is(false));
+
+        // the event source must not attempt any further reconnects after the 204 response
+        Thread.sleep(500);
+        MatcherAssert.assertThat(CONNECT_COUNT.get(), Matchers.is(2));
+    }
+}


### PR DESCRIPTION
- EventProcessor now inspects the handshake response status: a 204 shuts the event source down gracefully using onComplete callback instead of scheduling further reconnects.
- All other non-successful statuses are translated into the same WebApplicationException subtypes.
- The translation logic is extracted from JerseyInvocation into a reusable static method instead of being duplicated.
- Addes corresponding tests, that shows that new expecged behavior.
 
- Fixes #6119